### PR TITLE
 Failed messages to display UNKNOWN when data is missing instead of blank or min date

### DIFF
--- a/src/ServicePulse.Host/app/js/directives/moment.js
+++ b/src/ServicePulse.Host/app/js/directives/moment.js
@@ -5,15 +5,18 @@ angular.module('directives.moment', [])
         return {
             restrict: 'E',
             link: function(scope, element, attrs) {
+                var minDate = "0001-01-01T00:00:00";
                 var timeoutId = null;
                 var m;
                 
                 attrs.$observe('date', function (value) {
-                    if (value) {
+                    if (value && attrs.date !== minDate) {
                         m = moment(attrs.date);
                         element.attr('title', m.format('LLLL'));
                         updateText();
                         updateLoop();
+                    } else {
+                        element.text('TimeSent value unknown');
                     }
                 });
 

--- a/src/ServicePulse.Host/app/js/failed_messages/failedMessages.tpl.html
+++ b/src/ServicePulse.Host/app/js/failed_messages/failedMessages.tpl.html
@@ -108,7 +108,7 @@
                                         <a eat-click tooltip="This only works if ServiceInsight is installed." class="btn btn-small btn-link" ng-click="debugInServiceInsight($index)"><i class="icon-service-insight"></i> Open in ServiceInsight</a>
                                     </div>
                                     <div class=" row-fluid">
-                                        <div class="span10 rowText" title="Message Type: {{row.message_type}}">{{row.message_type | limitTo: 90}}<span ng-show="row.message_type.length > 90">...</span></div>
+                                        <div class="span10 rowText" title="Message Type: {{row.message_type}}">{{row.message_type || 'Message Type Unknown - missing metadata EnclosedMessageTypes' | limitTo: 90}}<span ng-show="row.message_type.length > 90">...</span></div>
                                         <div class="span2 text-right"><sp-moment date="{{row.time_sent}}" /></div>
                                     </div>
                                     <div class="row-fluid">


### PR DESCRIPTION
When an NServiceBus endpoint receives messages from external systems such as BizTalk, TIBCO, etc. directly, the message itself will not contain regular NServiceBus headers. Without them ServiceControl cannot provide all usual information. For example, it won’t be able to determine when message was sent or what is its type.

To ensure that you are able to monitor your endpoints and have valuable metadata from ServiceControl, it becomes important as to how you integrate these messages. If for some reason failed messages will miss some metadata ServicePulse will handle it better by providing more meaningful defaults and descriptions.
Here is an example:
![image](https://cloud.githubusercontent.com/assets/122651/9053750/c8d47c3a-3abc-11e5-9b46-35b6f4d83bc0.png)