### PR TITLE
Refactor streamService to not rely on events. Remove apply call with $jquery.

### DIFF
--- a/src/ServicePulse.Host/app/js/app.js
+++ b/src/ServicePulse.Host/app/js/app.js
@@ -23,7 +23,6 @@
             $rootScope.$log = $log;
         }]);
 
-    angular.module('sc')
-    .value('$jquery', $);
+    angular.module('sc').value('$jquery', $);
 
-} (window, window.angular, window.jQuery));
+}(window, window.angular, window.jQuery));

--- a/src/ServicePulse.Host/app/js/app.js
+++ b/src/ServicePulse.Host/app/js/app.js
@@ -1,4 +1,4 @@
-; (function (window, angular, undefined) {
+; (function (window, angular, $, undefined) {
     'use strict';
 
     angular.module('sc', [
@@ -23,4 +23,7 @@
             $rootScope.$log = $log;
         }]);
 
-} (window, window.angular));
+    angular.module('sc')
+    .value('$jquery', $);
+
+} (window, window.angular, window.jQuery));

--- a/src/ServicePulse.Host/app/js/custom_checks/customChecks.controller.js
+++ b/src/ServicePulse.Host/app/js/custom_checks/customChecks.controller.js
@@ -22,19 +22,19 @@
             serviceControlService.muteCustomChecks(row);
         };
 
-        var cleanupMethods = [];
+        var subscriptionDisposalMethods = [];
 
-        cleanupMethods.push(streamService.subscribe('CustomChecksUpdated', function () {
+        subscriptionDisposalMethods.push(streamService.subscribe('CustomChecksUpdated', function () {
             reloadData();
         }));
 
-        cleanupMethods.push(streamService.subscribe('CustomCheckDeleted', function () {
+        subscriptionDisposalMethods.push(streamService.subscribe('CustomCheckDeleted', function () {
             reloadData();
         }));
 
         $scope.$on('$destroy', function () {
-            for (var i = 0; i < cleanupMethods.length; i++) {
-                cleanupMethods[i]();
+            for (var i = 0; i < subscriptionDisposalMethods.length; i++) {
+                subscriptionDisposalMethods[i]();
             }
         });
 

--- a/src/ServicePulse.Host/app/js/custom_checks/customChecks.controller.js
+++ b/src/ServicePulse.Host/app/js/custom_checks/customChecks.controller.js
@@ -22,19 +22,21 @@
             serviceControlService.muteCustomChecks(row);
         };
 
-        streamService.subscribe($scope, 'CustomChecksUpdated', function () {
-            reloadData();
-        });
+        var cleanupMethods = [];
 
-        streamService.subscribe($scope, 'CustomCheckDeleted', function () {
+        cleanupMethods.push(streamService.subscribe('CustomChecksUpdated', function () {
             reloadData();
-        });
+        }));
+
+        cleanupMethods.push(streamService.subscribe('CustomCheckDeleted', function () {
+            reloadData();
+        }));
 
         $scope.$on('$destroy', function () {
-            streamService.unsubscribe($scope, 'CustomChecksUpdated');
-            streamService.unsubscribe($scope, 'CustomCheckDeleted');
+            for (var i = 0; i < cleanupMethods.length; i++) {
+                cleanupMethods[i]();
+            }
         });
-
 
         function reloadData() {
             $scope.loadingData = true;

--- a/src/ServicePulse.Host/app/js/dashboard/dashboard.controller.js
+++ b/src/ServicePulse.Host/app/js/dashboard/dashboard.controller.js
@@ -31,21 +31,21 @@
 			customChecksUpdated.resetToNow();
 		});
 
-        var cleanupMethods = [];
+        var subscriptionDisposalMethods = [];
 
-		cleanupMethods.push(streamService.subscribe('CustomChecksUpdated', function (message) {
+		subscriptionDisposalMethods.push(streamService.subscribe('CustomChecksUpdated', function (message) {
 			customChecksUpdated.runIfLatest(message, function () {
 				$scope.model.number_of_failed_checks = message.failed;
 			});
 		}));
 
-		cleanupMethods.push(streamService.subscribe('MessageFailuresUpdated', function (message) {
+		subscriptionDisposalMethods.push(streamService.subscribe('MessageFailuresUpdated', function (message) {
 			failedMessageUpdated.runIfLatest(message, function () {
 				$scope.model.number_of_failed_messages = message.total;
 			});
 		}));
 
-		cleanupMethods.push(streamService.subscribe('HeartbeatsUpdated', function (message) {
+		subscriptionDisposalMethods.push(streamService.subscribe('HeartbeatsUpdated', function (message) {
 			heartbeatsUpdated.runIfLatest(message, function () {
 				$scope.model.failing_endpoints = message.failing;
 				$scope.model.active_endpoints = message.active;
@@ -53,8 +53,8 @@
 		}));
 
 		$scope.$on('$destroy', function () {
-            for (var i = 0; i < cleanupMethods.length; i++) {
-                cleanupMethods[i]();
+            for (var i = 0; i < subscriptionDisposalMethods.length; i++) {
+                subscriptionDisposalMethods[i]();
             }
 		});
 

--- a/src/ServicePulse.Host/app/js/dashboard/dashboard.controller.js
+++ b/src/ServicePulse.Host/app/js/dashboard/dashboard.controller.js
@@ -31,29 +31,31 @@
 			customChecksUpdated.resetToNow();
 		});
 
-		streamService.subscribe($scope, 'CustomChecksUpdated', function (message) {
+        var cleanupMethods = [];
+
+		cleanupMethods.push(streamService.subscribe('CustomChecksUpdated', function (message) {
 			customChecksUpdated.runIfLatest(message, function () {
 				$scope.model.number_of_failed_checks = message.failed;
 			});
-		});
+		}));
 
-		streamService.subscribe($scope, 'MessageFailuresUpdated', function (message) {
+		cleanupMethods.push(streamService.subscribe('MessageFailuresUpdated', function (message) {
 			failedMessageUpdated.runIfLatest(message, function () {
 				$scope.model.number_of_failed_messages = message.total;
 			});
-		});
+		}));
 
-		streamService.subscribe($scope, 'HeartbeatsUpdated', function (message) {
+		cleanupMethods.push(streamService.subscribe('HeartbeatsUpdated', function (message) {
 			heartbeatsUpdated.runIfLatest(message, function () {
 				$scope.model.failing_endpoints = message.failing;
 				$scope.model.active_endpoints = message.active;
 			});
-		});
+		}));
 
 		$scope.$on('$destroy', function () {
-			streamService.unsubscribe($scope, 'HeartbeatsUpdated');
-			streamService.unsubscribe($scope, 'CustomChecksUpdated');
-			streamService.unsubscribe($scope, 'MessageFailuresUpdated');
+            for (var i = 0; i < cleanupMethods.length; i++) {
+                cleanupMethods[i]();
+            }
 		});
 
 		function OutOfOrderPurger() {

--- a/src/ServicePulse.Host/app/js/event_log_items/eventLogItems.js
+++ b/src/ServicePulse.Host/app/js/event_log_items/eventLogItems.js
@@ -13,12 +13,12 @@
                 $scope.loadingData = false;
             });
 
-            var cleanupMethod = streamService.subscribe('EventLogItemAdded', function (message) {
+            var subscriptionDisposalMethod = streamService.subscribe('EventLogItemAdded', function (message) {
                 processMessage(message);
             });
 
             $scope.$on('$destroy', function () {
-                cleanupMethod();
+                subscriptionDisposalMethod();
             });
 
             function processMessage(message) {

--- a/src/ServicePulse.Host/app/js/event_log_items/eventLogItems.js
+++ b/src/ServicePulse.Host/app/js/event_log_items/eventLogItems.js
@@ -13,12 +13,12 @@
                 $scope.loadingData = false;
             });
 
-            streamService.subscribe($scope, 'EventLogItemAdded', function (message) {
+            var cleanupMethod = streamService.subscribe('EventLogItemAdded', function (message) {
                 processMessage(message);
             });
 
             $scope.$on('$destroy', function () {
-                streamService.unsubscribe($scope, 'EventLogItemAdded');
+                cleanupMethod();
             });
 
             function processMessage(message) {

--- a/src/ServicePulse.Host/app/js/failed_messages/failedMessages.controller.js
+++ b/src/ServicePulse.Host/app/js/failed_messages/failedMessages.controller.js
@@ -319,9 +319,9 @@
 
         };
 
-        var cleanupMethods = [];
+        var subscriptionDisposalMethods = [];
 
-        cleanupMethods.push(streamService.subscribe('MessageFailed', function(event) {
+        subscriptionDisposalMethods.push(streamService.subscribe('MessageFailed', function(event) {
             var failedMessageId = event.failed_message_id;
             $scope.allFailedMessagesGroup.count++;
 
@@ -336,7 +336,7 @@
             updateCountForFailedMessageNotification($scope.model.newMessages, ++$scope.model.newMessages);
         }));
 
-        cleanupMethods.push(streamService.subscribe('MessageFailureResolved', function(event) {
+        subscriptionDisposalMethods.push(streamService.subscribe('MessageFailureResolved', function(event) {
 
             var failedMessageId = event.failed_message_id;
             $scope.allFailedMessagesGroup.count--;
@@ -353,13 +353,13 @@
 
         }));
 
-        cleanupMethods.push(streamService.subscribe('FailedMessageGroupArchived', function(event) {
+        subscriptionDisposalMethods.push(streamService.subscribe('FailedMessageGroupArchived', function(event) {
             notifications.pushForCurrentRoute('Messages from group \'' + event.group_name + '\' were successfully archived.', 'info');
         }));
 
         $scope.$on('$destroy', function () {
-            for (var i = 0; i < cleanupMethods.length; i++) {
-                cleanupMethods[i]();
+            for (var i = 0; i < subscriptionDisposalMethods.length; i++) {
+                subscriptionDisposalMethods[i]();
             }
         });
 

--- a/src/ServicePulse.Host/app/js/failed_messages/failedMessages.controller.js
+++ b/src/ServicePulse.Host/app/js/failed_messages/failedMessages.controller.js
@@ -226,6 +226,7 @@
                 break;
             }
         };
+
         $scope.testSuccess = function(group) {
 
           //  <!--<button type="button" class="btn btn-default btn-sm" tooltip="Test" ng-click="testSuccess(excGroup)"><i class="fa fa-smile-o"></i></button>-->
@@ -242,8 +243,6 @@
                 .finally(function() {
 
                 });
-
-
         };
 
 
@@ -320,7 +319,9 @@
 
         };
 
-        streamService.subscribe($scope, 'MessageFailed', function(event) {
+        var cleanupMethods = [];
+
+        cleanupMethods.push(streamService.subscribe('MessageFailed', function(event) {
             var failedMessageId = event.failed_message_id;
             $scope.allFailedMessagesGroup.count++;
 
@@ -333,9 +334,9 @@
             }
 
             updateCountForFailedMessageNotification($scope.model.newMessages, ++$scope.model.newMessages);
-        });
+        }));
 
-        streamService.subscribe($scope, 'MessageFailureResolved', function(event) {
+        cleanupMethods.push(streamService.subscribe('MessageFailureResolved', function(event) {
 
             var failedMessageId = event.failed_message_id;
             $scope.allFailedMessagesGroup.count--;
@@ -350,16 +351,16 @@
 
             $scope.model.newMessages--;
 
-        });
+        }));
 
-        streamService.subscribe($scope, 'FailedMessageGroupArchived', function(event) {
+        cleanupMethods.push(streamService.subscribe('FailedMessageGroupArchived', function(event) {
             notifications.pushForCurrentRoute('Messages from group \'' + event.group_name + '\' were successfully archived.', 'info');
-        });
+        }));
 
-        $scope.$on('$destroy', function() {
-            streamService.unsubscribe($scope, 'MessageFailed');
-            streamService.unsubscribe($scope, 'MessageFailureResolved');
-            streamService.unsubscribe($scope, 'FailedMessageGroupArchived');
+        $scope.$on('$destroy', function () {
+            for (var i = 0; i < cleanupMethods.length; i++) {
+                cleanupMethods[i]();
+            }
         });
 
         $scope.init();


### PR DESCRIPTION
The $apply call was necessary because we were using a global reference to jQuery instead of injecting and giving angular context. 

I opted to use an internal dictionary per messageType for the subscribers. The subscribe method returns an unsubscribe method, removing the need for $scope references.