### PR TITLE
If ServiceControl Api Uri is configured with or without a trailing slash the application will now behave properly

### DIFF
--- a/src/ServicePulse.Host/ServicePulse.Host.csproj
+++ b/src/ServicePulse.Host/ServicePulse.Host.csproj
@@ -253,6 +253,7 @@
     <None Include="app\css\font-awesome\fonts\fontawesome-webfont.woff" />
     <None Include="app\css\font-awesome\fonts\fontawesome-webfont.woff2" />
     <None Include="app\css\font-awesome\fonts\FontAwesome.otf" />
+    <Content Include="app\js\services\services.uri.js" />
     <None Include="app\lib\bootstrap-3.3.5\css\bootstrap-theme.css.map" />
     <None Include="app\lib\bootstrap-3.3.5\css\bootstrap.css.map" />
     <None Include="app\lib\bootstrap-3.3.5\fonts\glyphicons-halflings-regular.eot" />

--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -90,6 +90,7 @@
     <script src="js/services/services.semver.js"></script>
     <script src="js/services/services.service-control.js"></script>
     <script src="js/services/services.stream.js"></script>
+    <script src="js/services/services.uri.js"></script>
 
     <!-- Directives -->
     <script src="js/directives/ngClip.js"></script>

--- a/src/ServicePulse.Host/app/js/app.constants.js
+++ b/src/ServicePulse.Host/app/js/app.constants.js
@@ -3,7 +3,7 @@
     angular.module('sc')
         .constant('version', '1.2.0')
         .constant('scConfig', {
-            service_control_url: 'http://localhost:33333/api',
+            service_control_url: 'http://localhost:33333/api/',
             service_pulse_url: 'http://platformupdate.particular.net/servicepulse.txt'
         });
 

--- a/src/ServicePulse.Host/app/js/failed_messages/failedMessages.service.js
+++ b/src/ServicePulse.Host/app/js/failed_messages/failedMessages.service.js
@@ -74,11 +74,13 @@
 
         var service = {
             getData: getData,
-            retryGroup: function(id, success, error) {
-                return postPromise(scConfig.service_control_url + '/recoverability/groups/' + id + '/errors/retry', success, error);
+            retryGroup: function (id, success, error) {
+                var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups', id, 'errors', 'retry');
+                return postPromise(url, success, error);
             },
             archiveGroup: function(id, success, error) {
-                return postPromise(scConfig.service_control_url + '/recoverability/groups/' + id + '/errors/archive', success, error);
+                var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups', id, 'errors', 'archive');
+                return postPromise(url, success, error);
             },
             wait: wait
         };

--- a/src/ServicePulse.Host/app/js/services/services.module.js
+++ b/src/ServicePulse.Host/app/js/services/services.module.js
@@ -7,7 +7,8 @@
         'services.platformUpdateService',
         'services.semverService',
         'services.notifications',
-        'services.exceptionHandler'
+        'services.exceptionHandler',
+        'services.uri'
     ]);
 
 

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -2,16 +2,18 @@
     'use strict';
 
 
-    function Service($http, scConfig, notifications) {
+    function Service($http, scConfig, notifications, uri) {
 
         function getVersion() {
-            return $http.get(scConfig.service_control_url).then(function (response) {
+            var url = uri.join(scConfig.service_control_url);
+            return $http.get(url).then(function (response) {
                 return response.headers('X-Particular-Version');
             });
         };
         
         function checkLicense() {
-            return $http.get(scConfig.service_control_url + '/').then(function (response) {
+            var url = uri.join(scConfig.service_control_url);
+            return $http.get(url).then(function (response) {
                 if (response.data.license_status != "valid") {
                     return false;
                 }
@@ -20,13 +22,15 @@
         };
 
         function getEventLogItems() {
-            return $http.get(scConfig.service_control_url + '/eventlogitems').then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'eventlogitems');
+            return $http.get(url).then(function (response) {
                 return response.data;
             });
         };
 
         function getFailedMessages(sortBy, page) {
-            return $http.get(scConfig.service_control_url + '/errors?status=unresolved&page=' + page + '&sort=' + sortBy).then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'errors?status=unresolved&page=' + page + '&sort=' + sortBy);
+            return $http.get(url).then(function (response) {
                 return {
                     data: response.data,
                     total: response.headers('Total-Count')
@@ -35,7 +39,8 @@
         };
 
         function getExceptionGroups() {
-            return $http.get(scConfig.service_control_url + '/recoverability/groups').then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'recoverability','groups');
+            return $http.get(url).then(function (response) {
                 return {
                     data: response.data
                 };
@@ -43,7 +48,8 @@
         };
 
         function getFailedMessagesForExceptionGroup(groupId, sortBy, page) {
-            return $http.get(scConfig.service_control_url + '/recoverability/groups/' + groupId + '/errors?page=' + page + '&sort=' + sortBy).then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'recoverability','groups',groupId,'errors?page=' + page + '&sort=' + sortBy);
+            return $http.get(url).then(function (response) {
                 return {
                     data: response.data,
                     total: response.headers('Total-Count')
@@ -52,7 +58,8 @@
         };
 
         function getMessageBody(messageId) {
-            return $http.get(scConfig.service_control_url + '/messages/' + messageId + "/body").then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'messages',messageId,'body' );
+            return $http.get(url).then(function (response) {
                 return {
                     data: response.data
                 };
@@ -60,7 +67,8 @@
         };
 
         function getMessageHeaders(messageId) {
-            return $http.get(scConfig.service_control_url + '/messages/search/' + messageId).then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'messages','search',messageId );
+            return $http.get(url).then(function (response) {
                 return {
                     data: response.data
                 };
@@ -68,19 +76,22 @@
         };
 
         function getTotalFailedMessages() {
-            return $http.head(scConfig.service_control_url + '/errors?status=unresolved').then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'errors?status=unresolved' );
+            return $http.get(url).then(function (response) {
                 return response.headers('Total-Count');
             });
         };
 
         function getTotalFailingCustomChecks() {
-            return $http.head(scConfig.service_control_url + '/customchecks?status=fail').then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'customchecks?status=unresolved' );
+            return $http.get(url).then(function (response) {
                 return response.headers('Total-Count');
             });
         };
 
         function getFailingCustomChecks(page) {
-            return $http.get(scConfig.service_control_url + '/customchecks?status=fail&page=' + page).then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'customchecks?status=fail&page=' + page );
+            return $http.get(url).then(function (response) {
                 return {
                     data: response.data,
                     total: response.headers('Total-Count')
@@ -89,23 +100,27 @@
         };
 
         function getFailedMessageStats() {
-            return $http.get(scConfig.service_control_url + '/errors/summary').then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'errors','summary' );
+            return $http.get(url).then(function (response) {
                 return response.data;
             });
         };
         
         function muteCustomChecks(customCheck) {
-            $http.delete(scConfig.service_control_url + '/customchecks/' + customCheck.id)
-                .success(function () {
-                    notifications.pushForCurrentRoute('"{{item.custom_check_id}}" custom check muted', 'info', { item: customCheck });
-                })
-                .error(function () {
-                    notifications.pushForCurrentRoute('Failed to mute "{{item.custom_check_id}}" custom check', 'danger', { item: customCheck });
-                });
+            var url = uri.join(scConfig.service_control_url, 'customchecks', customCheck.id);
+
+            $http.delete(url)
+            .success(function () {
+                notifications.pushForCurrentRoute('"{{item.custom_check_id}}" custom check muted', 'info', { item: customCheck });
+            })
+            .error(function () {
+                notifications.pushForCurrentRoute('Failed to mute "{{item.custom_check_id}}" custom check', 'danger', { item: customCheck });
+            });
         };
 
         function retryAllFailedMessages() {
-            $http.post(scConfig.service_control_url + '/errors/retry/all')
+            var url = uri.join(scConfig.service_control_url, 'errors', 'retry', 'all');
+            $http.post(url)
                 .success(function () {
                    // notifications.pushForCurrentRoute('Retrying all messages...', 'info');
                 })
@@ -115,7 +130,8 @@
         };
 
         function retryFailedMessages(selectedMessages) {
-            $http.post(scConfig.service_control_url + '/errors/retry', selectedMessages)
+            var url = uri.join(scConfig.service_control_url, 'errors', 'retry', selectedMessages);
+            $http.post(url)
                 .success(function () {
                    // notifications.pushForCurrentRoute('Retrying {{num}} messages...', 'info', { num: selectedMessages.length });
                 })
@@ -125,10 +141,12 @@
         };
 
         function archiveFailedMessages(selectedMessages) {
+            var url = uri.join(scConfig.service_control_url, 'errors', 'archive');
+
             $http({
-                url: scConfig.service_control_url + '/errors/archive',
+                url: url,
                 data: selectedMessages,
-                method: "PATCH",
+                method: 'PATCH'
             })
                 .success(function () {
                    // notifications.pushForCurrentRoute('Archiving {{num}} messages...', 'info', { num: selectedMessages.length });
@@ -139,7 +157,8 @@
         };
 
         function archiveExceptionGroup(id, successText) {
-            $http.post(scConfig.service_control_url + '/recoverability/groups/' + id + '/errors/archive')
+            var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups', id, 'errors', 'archive');
+            $http.post(url)
                 .success(function () {
                    // notifications.pushForCurrentRoute(successText, 'info');
                 })
@@ -149,7 +168,9 @@
         };
 
         function retryExceptionGroup(id, successText) {
-            $http.post(scConfig.service_control_url + '/recoverability/groups/' + id + '/errors/retry')
+           
+            var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups', id, 'errors', 'retry');
+            $http.post(url)
                 .success(function () {
                  //   notifications.pushForCurrentRoute(successText, 'info');
                 })
@@ -159,14 +180,16 @@
         };
 
         function getHeartbeatStats() {
-            return $http.get(scConfig.service_control_url + '/heartbeats/stats').then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'heartbeats', 'stats');
+            return $http.get(url).then(function (response) {
                 return response.data;
             });
         };
 
 
         function removeEndpoint(endpoint) {
-            $http.delete(scConfig.service_control_url + '/heartbeats/' + endpoint.id)
+            var url = uri.join(scConfig.service_control_url, 'heartbeats', endpoint.id);
+            $http.delete(url)
                 .success(function () {
                   //  notifications.pushForCurrentRoute('{{item.originating_endpoint.name}}@{{item.originating_endpoint.machine}} endpoint removed', 'info', { item: endpoint });
                 })
@@ -176,8 +199,10 @@
         };
 
         function updateEndpoint(id, data) {
+            var url = uri.join(scConfig.service_control_url, 'endpoints', id);
+
             return $http({
-                url: scConfig.service_control_url + '/endpoints/' + id,
+                url: url,
                 data: data,
                 method: "PATCH",
             })
@@ -190,7 +215,8 @@
         };
 
         function getEndpoints() {
-            return $http.get(scConfig.service_control_url + '/endpoints').then(function (response) {
+            var url = uri.join(scConfig.service_control_url, 'endpoints');
+            return $http.get(url).then(function (response) {
                 return response.data;
             });
         };
@@ -201,7 +227,8 @@
                 .then(function (endpoints) {
                     var results = [];
                     endpoints.forEach(function (item) {
-                        $http.get(scConfig.service_control_url + '/endpoints/' + item.name + '/sla').then(function (response) {
+                        var url = uri.join(scConfig.service_control_url, 'endpoints', item.name, 'sla');
+                        $http.get(url).then(function (response) {
                             angular.extend(item, { sla: response.data.current });
                             results.push(item);
                         });
@@ -243,7 +270,7 @@
 
     }
 
-    Service.$inject = ['$http', 'scConfig', 'notifications'];
+    Service.$inject = ['$http', 'scConfig', 'notifications', 'uri'];
 
 
     angular.module('services.serviceControlService', [])

--- a/src/ServicePulse.Host/app/js/services/services.stream.js
+++ b/src/ServicePulse.Host/app/js/services/services.stream.js
@@ -1,11 +1,13 @@
 ; (function (window, angular, undefined) {
     'use strict';
 
-    function Service(notifications, $log, $rootScope, scConfig, $jquery) {
+    function Service(notifications, $log, $rootScope, scConfig, $jquery, uri) {
 
         var subscriberRegistry = {}, registryKey = 1;
 
-        var connection = $jquery.connection(scConfig.service_control_url + '/messagestream');
+        var url = uri.join(scConfig.service_control_url, 'messagestream');
+
+        var connection = $jquery.connection(url);
 
         connection.received(function (data) {
             for (var i in data.types) {
@@ -80,7 +82,7 @@
         };
     };
 
-    Service.$inject = ['notifications', '$log', '$rootScope', 'scConfig', '$jquery'];
+    Service.$inject = ['notifications', '$log', '$rootScope', 'scConfig', '$jquery', 'uri'];
 
     angular
         .module('services.streamService', [])

--- a/src/ServicePulse.Host/app/js/services/services.uri.js
+++ b/src/ServicePulse.Host/app/js/services/services.uri.js
@@ -1,0 +1,19 @@
+﻿; (function (window, angular, $, undefined) {
+    'use strict';
+
+    angular.module('services.uri', [])
+        .service('uri', function () {
+
+            this.join = function( /* path segments */) {
+                // Split the inputs into a list of path commands.
+                var parts = [];
+                for (var i = 0; i < arguments.length; i++) {
+                    parts = parts.concat(arguments[i].replace(/\/$/, ''));
+                }
+
+                // Turn back into a single string path.
+                return parts.join('/');
+            };
+        });
+
+} (window, window.angular, window.jQuery));


### PR DESCRIPTION
relates to https://github.com/Particular/ServicePulse/issues/200

If there is a trailing slash on the end of the ServiceControl api uri in the config file ServicePulse would compensate for it inappropriately. Now if the config has a trailing slash or not ServicePulse will be able to handle it.