### PR TITLE
Attempt to "switch on" an endpoint in the "Endpoints Configuration" fails

### DIFF
--- a/src/ServicePulse.Host/app/js/app.http.js
+++ b/src/ServicePulse.Host/app/js/app.http.js
@@ -9,10 +9,8 @@
 
         $httpProvider.defaults.headers.patch = {
             'Accept': 'application/json, text/javascript',
-            'Content-Type': 'application/json-patch+json'
+            'Content-Type': 'application/json'
         }
-
-   
     };
 
     httpProvider.$inject = [


### PR DESCRIPTION
## Symptoms
When trying to switch on the monitoring of an endpoint in the "Endpoints Configuration", the UI updates as if it all succeeds, but if the page is refreshed the monitoring setting resets back to off.

## Who's affected
All users of ServiceControl that are currently running v1.11.

## Description of issue
It seems when angular sends a PATCH request the `Content-Type` is set to `application/json-patch+json`, this content-type is not recognised by Nancy, hence Nancy is not able to correctly bind to the model and default the flag to `false`.

