### PR TITLE
Add X-UA-Compatible for Servicepulse

### DIFF
--- a/src/ServicePulse.Host/Nancy/SpecialEmbeddedFileResponse.cs
+++ b/src/ServicePulse.Host/Nancy/SpecialEmbeddedFileResponse.cs
@@ -24,6 +24,7 @@
             }
 
             this.WithHeader("ETag", GenerateETag(content));
+            this.WithHeader("X-UA-Compatible", "IE=edge,chrome=1");
             Contents = GetFileContent(content);
         }
 

--- a/src/ServicePulse.Host/Nancy/SpecialEmbeddedFileResponse.cs
+++ b/src/ServicePulse.Host/Nancy/SpecialEmbeddedFileResponse.cs
@@ -24,7 +24,7 @@
             }
 
             this.WithHeader("ETag", GenerateETag(content));
-            this.WithHeader("X-UA-Compatible", "IE=edge,chrome=1");
+            this.WithHeader("X-UA-Compatible", "IE=edge");
             Contents = GetFileContent(content);
         }
 

--- a/src/ServicePulse.Host/Nancy/SpecialEmbeddedFileResponse.cs
+++ b/src/ServicePulse.Host/Nancy/SpecialEmbeddedFileResponse.cs
@@ -24,7 +24,6 @@
             }
 
             this.WithHeader("ETag", GenerateETag(content));
-            this.WithHeader("X-UA-Compatible", "IE=edge");
             Contents = GetFileContent(content);
         }
 

--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -1,6 +1,7 @@
 ﻿<!doctype html>
 <html lang="en" ng-app="sc">
 <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"> 
     <style>
         /* This helps the ng-show/ng-hide animations start at the right place. */
         /* Since Angular has this but needs to load, this gives us the class early. */


### PR DESCRIPTION
Servicepulse fails to work on Internet Explorer 11 in intranet environments where IE is configured by group policy to display intranet sites in compatiblity mode. This fix adds an http header to servicepulse to fix this issue for affected browsers.