### PR TITLE
Display the version of service control available for upgrade

### DIFF
--- a/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.js
@@ -21,6 +21,7 @@
                         if (semverService.isUpgradeAvailable($scope.scversion, result.SC[0]['tag'])) {
                             $scope.newscversion = true;
                             $scope.newscversionlink = result.SC[0]['release'];
+                            $scope.newscversionnumber = result.SC[0]['tag'];
                         }
                     }
                 });

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.tpl.html
@@ -31,7 +31,7 @@
 
 
             <span ng-show="newscversion">
-                ServiceControl v{{scversion}} (<i ng-show="newspversion" class="fa fa-external-link fake-link"></i> <a href="{{newscversionlink}}" target="_blank">update available</a>)
+                ServiceControl v{{scversion}} (<i ng-show="newscversion" class="fa fa-external-link fake-link"></i> <a href="{{newscversionlink}}" target="_blank">(Upgrade to v{{newscversionnumber}})</a>)
             </span>
     </div>
 


### PR DESCRIPTION
Connects to https://github.com/Particular/ServicePulse/issues/342

Shows the text "Upgrade to V1.19.0" (or the corresponding version number) when an update to Service Control is available. This matches with the format used in the Service Control Management facility.

Also fixes a bug where the link would not display if Service Pulse was up to date but Service Control was not.

Ping @Particular/servicepulse-maintainers 