### PR TITLE
Fix the issue with version when extracting to host in IIS

### DIFF
--- a/src/ServicePulse.Host/Hosting/HostArguments.cs
+++ b/src/ServicePulse.Host/Hosting/HostArguments.cs
@@ -57,7 +57,7 @@ namespace ServicePulse.Host.Hosting
                     @"Extract files to be installed in a Web Server."
                     , s =>
                     {
-                        commands = new List<Type> { typeof(ExtractAndUpdateConstantsCommand), typeof(ExtractCommand) };
+                        commands = new List<Type> { typeof(ExtractCommand), typeof(ExtractAndUpdateConstantsCommand) };
                         executionMode = ExecutionMode.Extract;
                     }
                 },


### PR DESCRIPTION
## Who's affected

* Every ServicePulse user that hosts ServicePulse in IIS or any other web server.

## Symptoms

When extracting files according to documentation the version number always show 1.2.0 which is incorrect.

## Original bug report

[Incorrect version shown when using ServicePulse in IIS](https://github.com/Particular/ServicePulse/issues/371)

cc: @Particular/servicepulse-maintainers please review