### PR TITLE
Making cosmetic changes to pending retry screen

### DIFF
--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -163,6 +163,10 @@
             notifier.notify("MessageRedirectRemoved", message);
         }, "MessageRedirectRemoved");
 
+        listener.subscribe($scope, function(message) {
+            notifier.notify("MessageFailed", message);
+        }, "MessageFailed");
+
         listener.subscribe($scope, function (message) {
             notifier.notify("MessageFailureResolvedManually", message);
         }, "MessageFailureResolvedManually");

--- a/src/ServicePulse.Host/app/js/services/factory.shareddata.js
+++ b/src/ServicePulse.Host/app/js/services/factory.shareddata.js
@@ -34,7 +34,7 @@
 
         var environment = {
             sc_version: undefined,
-            minimum_supported_sc_version: "1.16.0",
+            minimum_supported_sc_version: "1.23.0",
             is_compatible_with_sc: true,
             sp_version: spVersion
         };

--- a/src/ServicePulse.Host/app/js/views/pending_retries/controller.js
+++ b/src/ServicePulse.Host/app/js/views/pending_retries/controller.js
@@ -50,6 +50,11 @@
             refreshRedirects();
         }, 'RedirectsUpdated');
 
+
+        notifier.subscribe($scope, function (event, messagefailed) {
+            removeResolvedMessage(messagefailed.failed_message_id);
+        }, "MessageFailed");
+
         notifier.subscribe($scope, function (event, messagefailureResolvedManually) {
             removeResolvedMessage(messagefailureResolvedManually.failed_message_id);
         }, "MessageFailureResolvedManually");

--- a/src/ServicePulse.Host/app/js/views/pending_retries/view.html
+++ b/src/ServicePulse.Host/app/js/views/pending_retries/view.html
@@ -31,15 +31,15 @@
                                 </div>
                             </div>
                             <div class="action-btns">
-                                <button type="button" class="btn btn-default" confirm-title="Are you sure you want to retry the selected messages?" confirm-message="Ensure that the selected messages were not processed previously as this will create a duplicate message." confirm-second-paragraph="NOTE: If the selection includes messages to be processed via unaudited queues, those messages will need to be marked as resolved once the retry is manually verified." confirm-click="vm.retrySelected()" ng-disabled="vm.selectedIds.length == 0"><i class="fa fa-refresh"></i> <span>Retry</span> ({{vm.selectedIds.length | number}})</button>
-                                <button type="button" class="btn btn-default" confirm-title="Are you sure you want to mark as resolved the selected messages?" confirm-message="If you mark these messages as resolved they will not be available for Retry. Messages should only be marked as resolved only if they belong to unaudited queues." confirm-click="vm.markAsResolvedSelected()" ng-disabled="vm.selectedIds.length == 0"><i class="fa fa-check-square-o"></i> <span>Mark as resolved</span> ({{vm.selectedIds.length | number}})</button>
+                                <button type="button" class="btn btn-default" confirm-title="Are you sure you want to retry the selected messages?" confirm-message="Ensure that the selected messages were not processed previously as this will create a duplicate message." confirm-second-paragraph="NOTE: If the selection includes messages to be processed via unaudited endpoints, those messages will need to be marked as resolved once the retry is manually verified." confirm-click="vm.retrySelected()" ng-disabled="vm.selectedIds.length == 0"><i class="fa fa-refresh"></i> <span>Retry</span> ({{vm.selectedIds.length | number}})</button>
+                                <button type="button" class="btn btn-default" confirm-title="Are you sure you want to mark as resolved the selected messages?" confirm-message="If you mark these messages as resolved they will not be available for Retry. Messages should only be marked as resolved only if they belong to unaudited endpoints." confirm-click="vm.markAsResolvedSelected()" ng-disabled="vm.selectedIds.length == 0"><i class="fa fa-check-square-o"></i> <span>Mark as resolved</span> ({{vm.selectedIds.length | number}})</button>
                                 <button type="button" class="btn btn-default" ng-disabled="vm.filteredTotal === '0'" confirm-title="{{vm.retryAllConfirmationTitle()}}" confirm-message="{{vm.retryAllConfirmationMessage()}}" confirm-click="vm.retryAll()" confirm-ok-only="{{vm.isQueueFilterEmpty()}}"><i class="fa fa-refresh"></i> <span>Retry all</span> ({{vm.filteredTotal | number}})</button>
                                 <button type="button" class="btn btn-default" ng-disabled="vm.filteredTotal === '0'" confirm-message="Are you sure you want to mark as resolved all {{vm.filteredTotal}} retried messages out of {{vm.total}}? If you do they will not be available for Retry. {{vm.filteredTotal < vm.total ? 'If you want to mark as resolved all clear the filtering.' : ''}}" confirm-click="vm.markAsResolvedAll()"><i class="fa fa-check-square-o"></i> <span>Mark all as resolved</span> ({{vm.filteredTotal | number}})</button>
                             </div>
                         </div>
                         <div class="col-md-4 col-xs-12 toolbar-menus no-side-padding">
                             
-                            <div class="filter-period-menu">
+                            <div class="filter-period-menu dropdown">
                                 <label class="control-label"><i class="fa fa-calendar" aria-hidden="true"></i> Period:</label>
                                 <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     {{vm.timeGroup.buttonText}}
@@ -61,7 +61,7 @@
                                 </ul>
                             </div>
 
-                            <div class="sort-menu">
+                            <div class="sort-menu dropdown">
                                 <label class="control-label"><i class="fa fa-sort" aria-hidden="true"></i> Sort:</label>
                                 <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     <i class="fa fa-long-arrow-down" aria-hidden="true" ng-show="vm.sortDirection === 'asc'"></i>
@@ -126,7 +126,7 @@
                                             <div class="msg-status" ng-hide="vm.noStatusPresent(message)">
                                                 <span>
                                                     <span ng-if="message.submittedForRetrial" tooltip="Message was submitted for retrying" class="label sidebar-label label-info">To retry</span>
-                                                    <i ng-if="message.submittedForRetrial" class="fa fa-info-circle" uib-tooltip="Messages set to retry need to be marked as resolved manually once the retry is manually verified. This is because they belong to unaudited queues."></i>
+                                                    <i ng-if="message.submittedForRetrial" class="fa fa-info-circle" uib-tooltip="Messages set to retry need to be marked as resolved manually once the retry is manually verified. This is because they belong to unaudited endpoints."></i>
                                                     <span ng-if="message.retried" tooltip="Message is being retried" class="label sidebar-label label-info">Retried</span>
                                                     <span ng-if="message.resolved" tooltip="Message is being marked as resolved" class="label sidebar-label label-info">Resolved</span>
                                                     <span ng-if="message.number_of_processing_attempts > 1" tooltip="This message has already failed {{message.number_of_processing_attempts}} times" class="label sidebar-label label-important">{{message.number_of_processing_attempts}} Retry Failures</span>

--- a/src/ServicePulse.Host/app/js/views/redirect/edit/controller.js
+++ b/src/ServicePulse.Host/app/js/views/redirect/edit/controller.js
@@ -74,7 +74,7 @@
                     $uibModalInstance.close();
                 }, function(response) {
                     if ((response.status === '409' || response.status === 409) && response.statusText === 'Duplicate') {
-                        toastService.showError('Failed to create a redirect, can not create more than one redirect for queue: ' + $scope.from_physical_address);
+                        toastService.showError('Failed to create a redirect, can not create more than one redirect for queue: ' + $scope.selected.physical_address);
                     } else if ((response.status === '409' || response.status === 409) && response.statusText === 'Dependents') {
                         toastService.showError('Failed to create a redirect, can not create a redirect to a queue that already has a redirect or is a target of a redirect.');
                     } else {

--- a/src/ServicePulse.Host/app/js/views/redirect/service.js
+++ b/src/ServicePulse.Host/app/js/views/redirect/service.js
@@ -1,7 +1,7 @@
 ﻿; (function (window, angular, undefined) {
     'use strict';
     
-    function service($http, $timeout, $q, $rootScope, $interval, scConfig, uri, notifications, notifyService) {
+    function service($http, $timeout, $q, $rootScope, $interval, $moment, scConfig, uri, notifications, notifyService) {
         var notifier = notifyService();
 
         var redirects = {
@@ -13,6 +13,9 @@
             var url = uri.join(scConfig.service_control_url, 'redirects');
             return $http.get(url).then(function (response) {
                 redirects.data = response.data;
+                redirects.data.forEach(function(item) {
+                    item.last_modified = moment.utc(item.last_modified).local().format('YYYY-MM-DDTHH:mm:ss');
+                });
                 redirects.total = response.headers('Total-Count');
                 notifier.notify('RedirectsUpdated', { total: redirects.total, data: redirects.data });
                 notifier.notify('RedirectMessageCountUpdated', redirects.total);
@@ -20,7 +23,7 @@
         }
 
         notifier.subscribe($rootScope, function (event, response) {
-            response.LastModified = '';
+            response.last_modified = $moment().format('YYYY-MM-DDTHH:mm:ss');
             redirects.data.push(response);
             redirects.total++;
             notifier.notify('RedirectsUpdated', { total: redirects.total, data: redirects.data });
@@ -108,7 +111,7 @@
         };
     }
 
-    service.$inject = ['$http', '$timeout', '$q', '$rootScope', '$interval', 'scConfig', 'uri', 'notifications', 'notifyService'];
+    service.$inject = ['$http', '$timeout', '$q', '$rootScope', '$interval', '$moment', 'scConfig', 'uri', 'notifications', 'notifyService'];
 
     angular.module('sc')
         .service('redirectService', service);


### PR DESCRIPTION
Bumping the min supported SC version to 1.23.0
Fixing issue with date time zone issues in redirect screen
Replacing text unaudited queue for unaudited endpoint
Hooking to a signalr event to remove message from pending retry screen if displayed
Fixing duplicate error message on create redirect to display queue name
cc: @Particular/servicepulse-maintainers 