### PR TITLE
Track failure group retry request progress

### DIFF
--- a/gitversionconfig.yaml
+++ b/gitversionconfig.yaml
@@ -1,1 +1,2 @@
 assembly-versioning-scheme: MajorMinorPatch
+next-version: 1.7.0

--- a/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
@@ -271,7 +271,6 @@
 
                         controller.updateExceptionGroups();
                         root.$apply(function () {
-                            //deferred.resolve({data: []});
                             deferred.resolve({ data: [{ id: 3, workflow_state: null }] });
                         });
                         expect(controller.exceptionGroups[0].id).toEqual(3);
@@ -285,7 +284,6 @@
 
                         controller.updateExceptionGroups();
                         root.$apply(function () {
-                            //deferred.resolve({data: []});
                             deferred.resolve({ data: [{ id: 3, workflow_state: null, retry_status: 'pending' }] });
                         });
                         expect(controller.exceptionGroups[0].id).toEqual(3);

--- a/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
@@ -32,7 +32,7 @@
                     {
                         $scope: root,
                         $timeout: null,
-                        $interval: null,
+                        $interval: function(){},
                         $location: null,
                         sharedDataService: { getstats: function() { return { number_of_pending_retries: 0 }; } },
                         notifyService: notifyService,
@@ -93,7 +93,7 @@
                     {
                         $scope: root,
                         $timeout: null,
-                        $interval: null,
+                        $interval: function () { },
                         $location: null,
                         sharedDataService: { getstats: function () { return { number_of_pending_retries: 0 }; } },
                         notifyService: notifyService,
@@ -198,7 +198,7 @@
                     {
                         $scope: root,
                         $timeout: null,
-                        $interval: null,
+                        $interval: function () { },
                         $location: null,
                         sharedDataService: { getstats: function () { return { number_of_pending_retries: 0 }; } },
                         notifyService: notifyService,
@@ -256,7 +256,7 @@
                     {
                         $scope: root,
                         $timeout: null,
-                        $interval: null,
+                        $interval: function () { },
                         $location: null,
                         sharedDataService: { getstats: function () { return { number_of_pending_retries: 0 }; } },
                         notifyService: notifyService,

--- a/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
@@ -15,12 +15,16 @@
                 beforeEach(inject(function ($rootScope, notifyService, $q) {
                     root = $rootScope;
                     this.notifyService = notifyService;
-                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function() {} };
+                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function () { }, getExceptionGroupClassifiers: function() {} };
                     var deferred = $q.defer();
                     spyOn(serviceControlService, 'getExceptionGroups').and.callFake(function () {
                         return deferred.promise;
                     });
                     spyOn(serviceControlService, 'getHistoricGroups').and.callFake(function () {
+                        return deferred.promise;
+                    });
+
+                    spyOn(serviceControlService, 'getExceptionGroupClassifiers').and.callFake(function () {
                         return deferred.promise;
                     });
 
@@ -72,12 +76,16 @@
                 beforeEach(inject(function ($rootScope, notifyService, $q) {
                     root = $rootScope;
                     this.notifyService = notifyService;
-                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function() {} };
+                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function () { }, getExceptionGroupClassifiers: function () { } };
                     var deferred = $q.defer();
                     spyOn(serviceControlService, 'getExceptionGroups').and.callFake(function () {
                         return deferred.promise;
                     });
                     spyOn(serviceControlService, 'getHistoricGroups').and.callFake(function () {
+                        return deferred.promise;
+                    });
+
+                    spyOn(serviceControlService, 'getExceptionGroupClassifiers').and.callFake(function () {
                         return deferred.promise;
                     });
 
@@ -173,12 +181,16 @@
                 beforeEach(inject(function ($rootScope, notifyService, $q) {
                     root = $rootScope;
                     this.notifyService = notifyService;
-                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function() {} };
+                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function () { }, getExceptionGroupClassifiers: function () { } };
                     var deferred = $q.defer();
                     spyOn(serviceControlService, 'getExceptionGroups').and.callFake(function () {
                         return deferred.promise;
                     });
                     spyOn(serviceControlService, 'getHistoricGroups').and.callFake(function () {
+                        return deferred.promise;
+                    });
+
+                    spyOn(serviceControlService, 'getExceptionGroupClassifiers').and.callFake(function () {
                         return deferred.promise;
                     });
 

--- a/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
@@ -15,9 +15,12 @@
                 beforeEach(inject(function ($rootScope, notifyService, $q) {
                     root = $rootScope;
                     this.notifyService = notifyService;
-                    serviceControlService = { getExceptionGroups: function () { } };
+                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function() {} };
                     var deferred = $q.defer();
                     spyOn(serviceControlService, 'getExceptionGroups').and.callFake(function () {
+                        return deferred.promise;
+                    });
+                    spyOn(serviceControlService, 'getHistoricGroups').and.callFake(function () {
                         return deferred.promise;
                     });
 
@@ -61,9 +64,12 @@
                 beforeEach(inject(function ($rootScope, notifyService, $q) {
                     root = $rootScope;
                     this.notifyService = notifyService;
-                    serviceControlService = { getExceptionGroups: function () { } };
+                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function() {} };
                     var deferred = $q.defer();
                     spyOn(serviceControlService, 'getExceptionGroups').and.callFake(function () {
+                        return deferred.promise;
+                    });
+                    spyOn(serviceControlService, 'getHistoricGroups').and.callFake(function () {
                         return deferred.promise;
                     });
 
@@ -125,9 +131,12 @@
                 beforeEach(inject(function ($rootScope, notifyService, $q) {
                     root = $rootScope;
                     this.notifyService = notifyService;
-                    serviceControlService = { getExceptionGroups: function () { } };
+                    serviceControlService = { getExceptionGroups: function () { }, getHistoricGroups: function() {} };
                     var deferred = $q.defer();
                     spyOn(serviceControlService, 'getExceptionGroups').and.callFake(function () {
+                        return deferred.promise;
+                    });
+                    spyOn(serviceControlService, 'getHistoricGroups').and.callFake(function () {
                         return deferred.promise;
                     });
 
@@ -156,7 +165,7 @@
 
                         this.notifyService().notify("RetryOperationCompleted", { request_id: 1});
 
-                        expect(controller.exceptionGroups[0].workflow_state.status).toEqual('done');
+                        expect(controller.exceptionGroups[0].workflow_state.status).toEqual('completed');
                         expect(controller.exceptionGroups[1].workflow_state).toEqual(null);
                         expect(controller.exceptionGroups[2].workflow_state).toEqual(null);
                     });

--- a/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/views/failed_groups/controller.spec.js
@@ -47,7 +47,15 @@
                             { id: 3, workflow_state: null }
                         ];
 
-                        this.notifyService().notify("RetryOperationWaiting", { request_id: 1, progression: 0.3 });
+                        this.notifyService()
+                            .notify("RetryOperationWaiting",
+                            {
+                                request_id: 1,
+                                progress: {
+                                    percentage: 0.3,
+                                    messages_remaining: 2
+                                }
+                            });
 
                         expect(controller.exceptionGroups[0].workflow_state.status).toEqual('waiting');
                         expect(controller.exceptionGroups[0].workflow_state.total).toEqual(30);
@@ -96,13 +104,42 @@
                             { id: 3, workflow_state: null }
                         ];
 
-                        this.notifyService().notify("RetryOperationForwarding", { request_id: 1, progression: 0.6 });
+                        this.notifyService().notify("RetryOperationForwarding", {
+                            request_id: 1, progress: {
+                                percentage: 0.6,
+                                messages_remaining: 2
+                            }
+                        });
 
                         expect(controller.exceptionGroups[0].workflow_state.status).toEqual('forwarding');
                         expect(controller.exceptionGroups[0].workflow_state.total).toEqual(60);
                         expect(controller.exceptionGroups[1].workflow_state).toEqual(null);
                         expect(controller.exceptionGroups[2].workflow_state).toEqual(null);
                     });
+
+                it('when an event RetryOperationForwarded is pubslished group get its state updated',
+                    function () {
+
+                        spyOn(root, '$broadcast');
+
+                        controller.exceptionGroups = [
+                            { id: 1, workflow_state: { state: "in_progress", total: 10 } }, { id: 2, workflow_state: null },
+                            { id: 3, workflow_state: null }
+                        ];
+
+                        this.notifyService().notify("RetryOperationForwarded", {
+                            request_id: 1, progress: {
+                                percentage: 0.7,
+                                messages_remaining: 2
+                            }
+                        });
+
+                        expect(controller.exceptionGroups[0].workflow_state.status).toEqual('forwarding');
+                        expect(controller.exceptionGroups[0].workflow_state.total).toEqual(70);
+                        expect(controller.exceptionGroups[1].workflow_state).toEqual(null);
+                        expect(controller.exceptionGroups[2].workflow_state).toEqual(null);
+                    });
+
 
                 it('when an event RetryOperationPreparing is pubslished group get its state updated',
                     function () {
@@ -114,7 +151,12 @@
                             { id: 3, workflow_state: null }
                         ];
 
-                        this.notifyService().notify("RetryOperationPreparing", { request_id: 1, progression: 0.5 });
+                        this.notifyService().notify("RetryOperationPreparing", {
+                            request_id: 1, progress: {
+                                percentage: 0.5,
+                                messages_remaining: 2
+                            }
+                        });
 
                         expect(controller.exceptionGroups[0].workflow_state.status).toEqual('preparing');
                         expect(controller.exceptionGroups[0].workflow_state.total).toEqual(50);
@@ -163,7 +205,12 @@
                             { id: 3, workflow_state: null }
                         ];
 
-                        this.notifyService().notify("RetryOperationCompleted", { request_id: 1});
+                        this.notifyService().notify("RetryOperationCompleted", {
+                            request_id: 1, progress: {
+                                percentage: 1,
+                                messages_remaining: 0
+                            }
+                        });
 
                         expect(controller.exceptionGroups[0].workflow_state.status).toEqual('completed');
                         expect(controller.exceptionGroups[1].workflow_state).toEqual(null);

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -869,8 +869,8 @@ nav {
     width: 100% !important;
 }
 
-.filter-period-menu, .sort-menu {
-    float:right;
+.filter-period-menu, .sort-menu, .msg-group-menu {
+    float: right;
 }
 
 .filter-input, .action-btns, .filter-period-menu, .sort-menu {
@@ -885,6 +885,11 @@ nav {
 
 .filter-period-menu {
     margin: 0 30px 0 6px;
+}
+
+.msg-group-menu {
+    margin: 21px 0px 0 6px;
+    padding-right: 15px;
 }
 
 .sort-menu {

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -997,7 +997,7 @@ ul.retry-request-progress li > div {
 }
 
 li.left-to-do, li.completed {
-    color: #777f7f;
+    color: #B0B5B5;
 }
 
 li.left-to-do {
@@ -1005,7 +1005,7 @@ li.left-to-do {
 }
 
 li.active div {
-    color: #000 !important;
+    color: #fff !important;
     font-weight: bold;
 }
 
@@ -1015,7 +1015,7 @@ li.active div.bulk-retry-progress-status:before {
 }
 
 div.retry-completed.bulk-retry-progress-status {
-    color: #000;
+    color: #fff;
     font-weight: bold;
 }
 
@@ -1025,7 +1025,7 @@ li.completed div.bulk-retry-progress-status:before, div.retry-completed.bulk-ret
 }
 
 div.col-xs-3.col-sm-3.retry-op-queued {
-    color: #777f7f !important;
+    color: #B0B5B5 !important;
 }
 
 div.progress-bar.progress-bar-striped.active {
@@ -1034,6 +1034,7 @@ div.progress-bar.progress-bar-striped.active {
 
 .progress.bulk-retry-progress {
     margin-bottom: 0;
+    background-color: #333333;
 }
 
 .retry-completed, ul.retry-request-progress button {
@@ -1042,6 +1043,24 @@ div.progress-bar.progress-bar-striped.active {
 
 ul.retry-request-progress button {
     background-color: #00a3c4;
+}
+
+.panel-retry {
+    background-color: #1A1A1A;
+    border: none;
+    color: #fff
+}
+
+.panel-retry p.lead {
+    color: #fff;
+}
+
+.navbar-inverse {
+    background-color: #1A1A1A;
+}
+
+.panel-retry span.metadata, .panel-retry sp-moment {
+    color: #B0B5B5 !important;
 }
 
 /* RESPONSIVE TWEAKS */ 

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -761,7 +761,7 @@ p.endpoint-metadata {
 
 .fa-stack-2x { font-size: 24px; }
 
-.events .box { padding-bottom: 0; }
+.events .box { padding-bottom: 0; cursor: pointer; }
 
 .events p.lead { padding-bottom: 10px; }
 

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -156,7 +156,7 @@ footer a:hover { font-weight: normal; }
 
 .warning i { color: #aa6708; }
 
-.danger { color: #ce4844; }
+.danger { color: #ce4844 !important; font-weight: bold !important; }
 
 .box-info { border-left-color: #1b809e; }
 
@@ -412,6 +412,10 @@ h3 {
     cursor: pointer;
 }
 
+.check-hover {
+
+}
+
 h5 {
     color: #777f7f;
     display: inline-block !important;
@@ -429,7 +433,7 @@ h6 {
 }
 
 h6 a {
-    color: #a8b3b1;
+    color: #929e9e;
 }
 
 h6 a:hover {
@@ -456,7 +460,7 @@ h6 a:hover {
 .tabs h5.active a { color: #181919; }
 
 .tabs a {
-    color: #a8b3b1;
+    color: #929e9e;
     cursor: pointer;
 }
 
@@ -975,10 +979,6 @@ p.lead hard-wrap.ng-binding {
     text-decoration: none;
 }
 
-.no-link-underline:hover {
-    color: #23527c;
-    text-decoration: none;
-}
 
 @media only screen and (min-width: 993px) {
     .filter-period-menu {
@@ -1018,7 +1018,6 @@ p.lead hard-wrap.ng-binding {
     margin-right: 0;
     }
 }
-
 
 @media only screen and (max-width: 480px) {
     .sidebar-label { margin: 3px 0 14px; }

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -761,7 +761,15 @@ p.endpoint-metadata {
 
 .fa-stack-2x { font-size: 24px; }
 
-.events .box { padding-bottom: 0; cursor: pointer; }
+.events .box {
+    padding-bottom: 0;
+}
+
+.events .box:hover { 
+    cursor: pointer; 
+    background-color: #edf6f7;
+    border: 1px solid #00a3c4;
+}
 
 .events p.lead { padding-bottom: 10px; }
 
@@ -982,32 +990,58 @@ p.lead hard-wrap.ng-binding {
     padding-left: 0;
 }
 
-ul.retry-request-progress li {
-    color: #eee !important;
+
+
+ul.retry-request-progress li > div {
+    margin-bottom: 6px;
 }
 
-.bulk-retry-progress-status {
-    color: #eee;
+li.left-to-do, li.completed {
+    color: #777f7f;
 }
 
-.retry-completed {
+li.left-to-do {
+    padding-left: 15px;
+}
+
+li.active div {
     color: #000 !important;
-}
-
-ul.retry-request-progress li.active {
     font-weight: bold;
 }
 
-.bulk-retry-progress-status {
+li.active div.bulk-retry-progress-status:before {
+    font: normal normal normal 14px/1 FontAwesome;
+    content: "\f061 \00a0";
+}
 
+div.retry-completed.bulk-retry-progress-status {
+    color: #000;
+    font-weight: bold;
+}
+
+li.completed div.bulk-retry-progress-status:before, div.retry-completed.bulk-retry-progress-status:before {
+    font: normal normal normal 14px/1 FontAwesome;
+    content: "\f00c \00a0";
+}
+
+div.col-xs-3.col-sm-3.retry-op-queued {
+    color: #777f7f !important;
+}
+
+div.progress-bar.progress-bar-striped.active {
+    color: #fff !important;
 }
 
 .progress.bulk-retry-progress {
-
+    margin-bottom: 0;
 }
 
-.retry-completed {
+.retry-completed, ul.retry-request-progress button {
     display: inline-block;
+}
+
+ul.retry-request-progress button {
+    background-color: #00a3c4;
 }
 
 /* RESPONSIVE TWEAKS */ 
@@ -1020,7 +1054,7 @@ ul.retry-request-progress li.active {
 
 @media only screen and (max-width: 992px) {
     .filter-period-menu, .sort-menu {
-    float: left !important;
+        float: left !important;
     }
     .sort-menu {
         margin-top: 0;
@@ -1034,6 +1068,11 @@ ul.retry-request-progress li.active {
 @media only screen and (max-width: 768px) {
     .filter-toolbar .input-group {
         margin-bottom: 6px;
+    }
+    .msg-group-menu {
+        float: left !important;
+        margin-top: 0;
+        margin-left: 15px;
     }
     div.sp-pull-right {
         display: inline-block;

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -953,15 +953,12 @@ p.lead hard-wrap.ng-binding {
 
 .progress-bar {
     background-color: #777f7f;
+    display: inline-block;
 }
 
 .no-side-padding {
     padding-right: 0 !important;
     padding-left: 0 !important;
-}
-
-.bulk-retry-progress-status {
-    color: #000 !important;
 }
 
 ..box-no-interaction {
@@ -980,6 +977,40 @@ p.lead hard-wrap.ng-binding {
     text-decoration: none;
 }
 
+.panel-body ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+ul.retry-request-progress li {
+    color: #eee !important;
+}
+
+.bulk-retry-progress-status {
+    color: #eee;
+}
+
+.retry-completed {
+    color: #000 !important;
+}
+
+ul.retry-request-progress li.active {
+    font-weight: bold;
+}
+
+.bulk-retry-progress-status {
+
+}
+
+.progress.bulk-retry-progress {
+
+}
+
+.retry-completed {
+    display: inline-block;
+}
+
+/* RESPONSIVE TWEAKS */ 
 
 @media only screen and (min-width: 993px) {
     .filter-period-menu {
@@ -1047,12 +1078,4 @@ p.lead hard-wrap.ng-binding {
     div.btn-toolbar, div.form-inliner {
         margin-bottom: 0px;
     }
-}
-
-ul li {
-    background-color: red;
-}
-
-ul li.active {
-    background-color: green;
 }

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -7,7 +7,11 @@
 a {
     color: #00a3c4;
     font-weight: bold;
+    outline: none;
+    border: none;
 }
+
+a:focus, button:focus {outline:0 !important;}
 
 a:hover {
     color: #00a3c4;
@@ -965,8 +969,8 @@ p.lead hard-wrap.ng-binding {
 }
 
 .no-side-padding {
-    padding-right: 0 !important;
-    padding-left: 0 !important;
+    padding-right: 0;
+    padding-left: 0;
 }
 
 ..box-no-interaction {
@@ -1084,6 +1088,14 @@ div.danger.sc-restart-warning > strong {
     letter-spacing: 0.2px;
 }
 
+.op-metadata {
+    border-top: 1px solid #414242;
+    padding-top: 15px;
+}
+
+
+
+
 /* RESPONSIVE TWEAKS */ 
 
 @media only screen and (min-width: 993px) {
@@ -1128,6 +1140,10 @@ div.danger.sc-restart-warning > strong {
     .input-group-btn button.btn.btn-default {
     margin-right: 0;
     }
+    .no-mobile-side-padding {
+     padding-right: 0;
+     padding-left: 0;
+    }
 }
 
 @media only screen and (max-width: 480px) {
@@ -1150,7 +1166,9 @@ div.danger.sc-restart-warning > strong {
         float: none;
         margin-top: 4px;    
     }
-
+    .progress.bulk-retry-progress {
+        margin-top: 6px;
+    }
 }
 
 @media only screen and (max-width: 320px) {

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -931,6 +931,10 @@ p.lead hard-wrap.ng-binding {
     padding-bottom: 0;
 }
 
+.progress-bar {
+    background-color: #777f7f;
+}
+
 .no-side-padding {
         padding-right: 0;
         padding-left: 0;

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -432,10 +432,6 @@ h6 {
     color: #181919;
 }
 
-h6 a {
-    color: #929e9e;
-}
-
 h6 a:hover {
     cursor: pointer;
 }

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -751,8 +751,14 @@ p.endpoint-metadata {
 .events p.lead { padding-bottom: 10px; }
 
 .fake-link {
-    color: #00a3c4;
-    text-decoration: none;
+    color: #00a3c4 !important;
+    text-decoration: none !important;
+}
+
+
+.fake-link:hover {
+    color: #00a3c4 !important;
+    text-decoration: none !important;
 }
 
 .version-info-container { width: 100% !important; }
@@ -770,6 +776,10 @@ p.endpoint-metadata {
 .version-separator {
     color: #BCC6C2;
     margin: 0 15px;
+}
+
+.list-section {
+    margin-top: 20px;
 }
 
 
@@ -903,6 +913,22 @@ span.ui-select-match-text.pull-left {
 
 p.lead hard-wrap.ng-binding {
     color: #777f7f;
+}
+
+.collapsible-section {
+    margin-top: 20px;
+}
+.disclose-link {
+    margin-top: 20px;
+}
+
+.extra-box-padding {
+    padding-left: 20px !important;
+    padding-right: 20px !important;
+}
+
+.panel-body {
+    padding-bottom: 0;
 }
 
 .no-side-padding {

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -175,8 +175,6 @@ footer a:hover { font-weight: normal; }
     padding: 0;
 }
 
-.box-body { }
-
 /* fixed bus with repeat list transition lag */
 
 .ng-animate { transition: none; }
@@ -356,7 +354,7 @@ section.events > div > div > div > div { padding-bottom: 8px !important; }
 .lead {
     -ms-word-wrap: break-word;
     color: #181919 !important;
-    font-size: 16px !important;
+    font-size: 14px !important;
     font-weight: bold;
     margin-bottom: 3px;
     word-wrap: break-word;
@@ -408,7 +406,7 @@ h3 {
     font-weight: bold;
 }
 
-.box:hover, .summary-item:hover {
+.summary-item:hover {
     background-color: #edf6f7;
     border-color: #00a3c4 !important;
     cursor: pointer;
@@ -422,6 +420,20 @@ h5 {
     margin: 0 0 14px;
     margin-right: 30px;
     text-transform: uppercase;
+}
+
+h6 {
+    font-size: 18px;
+    font-weight: bold;
+    color: #181919;
+}
+
+h6 a {
+    color: #a8b3b1;
+}
+
+h6 a:hover {
+    cursor: pointer;
 }
 
 .tabs {
@@ -485,11 +497,14 @@ h1 {
     margin: 0 0 32px;
 }
 
-p.metadata { margin-bottom: 6px; }
+p.metadata { 
+    margin-bottom: 6px;
+}
 
 span.metadata {
     display: inline-block;
     padding: 0px 20px 2px 0;
+    color: #777f7f;
 }
 
 .metadata:first-child { padding-left: 0; }
@@ -927,8 +942,8 @@ p.lead hard-wrap.ng-binding {
     padding-right: 20px !important;
 }
 
-.panel-body {
-    padding-bottom: 0;
+.progress {
+    margin-bottom: 10px;
 }
 
 .progress-bar {
@@ -936,8 +951,33 @@ p.lead hard-wrap.ng-binding {
 }
 
 .no-side-padding {
-        padding-right: 0;
-        padding-left: 0;
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+}
+
+.bulk-retry-progress-status {
+    color: #000 !important;
+}
+
+..box-no-interaction {
+    background-color: #fff;
+    border-color: #eee !important;
+}
+
+.box-no-interaction:hover {
+    background-color: #fff !important;
+    border-color: #eee !important;
+    cursor: default;
+}
+
+.no-link-underline {
+    color: #00a3c4;
+    text-decoration: none;
+}
+
+.no-link-underline:hover {
+    color: #23527c;
+    text-decoration: none;
 }
 
 @media only screen and (min-width: 993px) {

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -1048,3 +1048,11 @@ p.lead hard-wrap.ng-binding {
         margin-bottom: 0px;
     }
 }
+
+ul li {
+    background-color: red;
+}
+
+ul li.active {
+    background-color: green;
+}

--- a/src/ServicePulse.Host/app/js/app.constants.js
+++ b/src/ServicePulse.Host/app/js/app.constants.js
@@ -2,6 +2,7 @@
 
     angular.module('sc')
         .constant('version', '1.2.0')
+        .constant('showPendingRetry', false)
         .constant('scConfig', {
             service_control_url: 'http://localhost:33333/api/'
         });

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -220,6 +220,10 @@
         }, "RetryOperationForwarding");
 
         listener.subscribe($scope, function (message) {
+            notifier.notify("RetryOperationForwarded", message);
+        }, "RetryOperationForwarded");
+
+        listener.subscribe($scope, function (message) {
             notifier.notify("RetryOperationCompleted", message);
         }, "RetryOperationCompleted");
     };

--- a/src/ServicePulse.Host/app/js/directives/moment.js
+++ b/src/ServicePulse.Host/app/js/directives/moment.js
@@ -5,6 +5,9 @@
     function Directive($timeout, $moment) {
         return {
             restrict: 'E',
+            scope: {
+                emptyMessage: '@'
+            },
             link: function(scope, element, attrs) {
                 var minDate = '0001-01-01T00:00:00';
                 var timeoutId = null;
@@ -28,7 +31,7 @@
                         updateText();
                         updateLoop();
                     } else {
-                        element.text('unknown');
+                        element.text(scope.emptyMessage || 'unknown');
                     }
                 });
 

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.js
@@ -2,7 +2,7 @@
     'use strict';
 
 
-    function controller($scope, $interval, $location, sharedDataService, notifyService, serviceControlService) {
+    function controller($scope, $interval, $location, sharedDataService, notifyService, serviceControlService, showPendingRetry) {
 
         var notifier = notifyService();
 
@@ -13,7 +13,7 @@
         var stats = sharedDataService.getstats();
         var currentClassification;
         var allFailedMessagesGroup = { 'id': undefined, 'title': 'All Failed Messages', 'count': stats.number_of_failed_messages }
-
+        $scope.showPendingRetry = showPendingRetry;
         $scope.counters = {
             group: stats.number_of_exception_groups,
             message: stats.number_of_failed_messages,
@@ -79,7 +79,7 @@
         }, 'PendingRetriesTotalUpdated');
     }
 
-    controller.$inject = ['$scope', '$interval', '$location', 'sharedDataService', 'notifyService', 'serviceControlService'];
+    controller.$inject = ['$scope', '$interval', '$location', 'sharedDataService', 'notifyService', 'serviceControlService', 'showPendingRetry'];
 
     function directive() {
         return {

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.js
@@ -11,6 +11,7 @@
         };
 
         var stats = sharedDataService.getstats();
+        var currentClassification;
         var allFailedMessagesGroup = { 'id': undefined, 'title': 'All Failed Messages', 'count': stats.number_of_failed_messages }
 
         $scope.counters = {
@@ -24,14 +25,6 @@
             sharedDataService.set(allFailedMessagesGroup);
             $location.path('/failedMessages');
         }
-
-        var exceptionGroupCountUpdatedTimer = $interval(function() {
-            serviceControlService.getTotalExceptionGroups().then(function(response) {
-                if (stats.number_of_exception_groups !== parseInt(response)) {
-                    notifier.notify('ExceptionGroupCountUpdated', response);
-                }
-            });
-        }, 5000);
 
         var archiveMessagesUpdatedTimer = $interval(function() {
             serviceControlService.getTotalArchivedMessages().then(function(response) {
@@ -53,10 +46,6 @@
 
         // Cancel interval on page changes
         $scope.$on('$destroy', function() {
-            if (angular.isDefined(exceptionGroupCountUpdatedTimer)) {
-                $interval.cancel(exceptionGroupCountUpdatedTimer);
-                exceptionGroupCountUpdatedTimer = undefined;
-            }
             if (angular.isDefined(archiveMessagesUpdatedTimer)) {
                 $interval.cancel(archiveMessagesUpdatedTimer);
                 archiveMessagesUpdatedTimer = undefined;

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
@@ -4,7 +4,7 @@
             <h5 ng-class="{ active: isActive('/failedGroups') }"><a href="#/failedGroups">Failed message groups ({{counters.group | number}})</a></h5>
             <h5 ng-class="{ active: isActive('/failedMessages') }"><a ng-click="viewExceptionGroup()">All failed messages ({{counters.message | number}})</a></h5>
             <h5 ng-class="{ active: isActive('/archived') }"><a href="#/archived">Archived messages ({{counters.archived | number}})</a></h5>
-            <h5 ng-class="{ active: isActive('/pendingRetries') }"><a href="#/pendingRetries">Pending retries ({{counters.pendingRetries | number}})</a></h5>
+            <h5 ng-show="{{showPendingRetry}}" ng-class="{ active: isActive('/pendingRetries') }"><a href="#/pendingRetries">Pending retries ({{counters.pendingRetries | number}})</a></h5>
         </div>
     </div>
 </div>

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.js
@@ -14,6 +14,7 @@
                         if (semverService.isUpgradeAvailable($scope.version, result.SP[0]['tag'])) {
                             $scope.newspversion = true;
                             $scope.newspversionlink = result.SP[0]['release'];
+                            $scope.newspversionnumber = result.SP[0]['tag'];
                         }
                     }
 

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.productVersion.tpl.html
@@ -11,7 +11,7 @@
 
 
         <span ng-show="newspversion">
-            ServicePulse v{{version}} (<i ng-show="newspversion" class="fa fa-external-link fake-link"></i> <a href="{{newspversionlink}}" target="_blank">update available</a>)
+            ServicePulse v{{version}} (<i ng-show="newspversion" class="fa fa-level-up fake-link"></i> <a href="{{newspversionlink}}" target="_blank">v{{newspversionnumber}} available</a>)
         </span>
 
     </div>
@@ -31,7 +31,7 @@
 
 
             <span ng-show="newscversion">
-                ServiceControl v{{scversion}} (<i ng-show="newscversion" class="fa fa-external-link fake-link"></i> <a href="{{newscversionlink}}" target="_blank">(Upgrade to v{{newscversionnumber}})</a>)
+                ServiceControl v{{scversion}} (<i ng-show="newscversion" class="fa fa-level-up fake-link"></i> <a href="{{newscversionlink}}" target="_blank">v{{newscversionnumber}} available</a>)
             </span>
     </div>
 

--- a/src/ServicePulse.Host/app/js/services/factory.shareddata.js
+++ b/src/ServicePulse.Host/app/js/services/factory.shareddata.js
@@ -69,10 +69,6 @@
             stats.active_endpoints = stat.active || 0;
         });
 
-        serviceControlService.getTotalExceptionGroups().then(function (response) {
-            notifier.notify('ExceptionGroupCountUpdated', response);
-        });
-
         serviceControlService.getTotalArchivedMessages().then(function (response) {
             notifier.notify('ArchivedMessagesUpdated', response || 0);
         });

--- a/src/ServicePulse.Host/app/js/services/factory.shareddata.js
+++ b/src/ServicePulse.Host/app/js/services/factory.shareddata.js
@@ -34,7 +34,7 @@
 
         var environment = {
             sc_version: undefined,
-            minimum_supported_sc_version: "1.27.0",
+            minimum_supported_sc_version: "1.30.0",
             is_compatible_with_sc: true,
             sp_version: spVersion
         };

--- a/src/ServicePulse.Host/app/js/services/service.toast.js
+++ b/src/ServicePulse.Host/app/js/services/service.toast.js
@@ -14,8 +14,8 @@
             });
         }
 
-        this.showInfo = function (text) {
-            this.showToast(text, 'info', 'Info', false);
+        this.showInfo = function (text, sticky) {
+            this.showToast(text, 'info', 'Info', sticky);
         }
 
         this.showError = function (text) {

--- a/src/ServicePulse.Host/app/js/services/service.toast.js
+++ b/src/ServicePulse.Host/app/js/services/service.toast.js
@@ -14,8 +14,8 @@
             });
         }
 
-        this.showInfo = function (text, sticky) {
-            this.showToast(text, 'info', 'Info', sticky);
+        this.showInfo = function (text, title, sticky) {
+            this.showToast(text, 'info', title || 'Info', sticky);
         }
 
         this.showError = function (text) {

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -42,7 +42,8 @@
             var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups', classifier);
             return $http.get(url).then(function(response) {
                 return {
-                    data: response.data
+                    data: response.data,
+                    status: reponse.status
                 };
             });
         }
@@ -81,13 +82,6 @@
                 return {
                     data: response.data
                 };
-            });
-        }
-
-        function getTotalExceptionGroups() {
-            var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups');
-            return $http.head(url).then(function(response) {
-                return response.headers('Total-Count');
             });
         }
 
@@ -286,7 +280,6 @@
             getFailedMessagesForExceptionGroup: getFailedMessagesForExceptionGroup,
             getMessageBody: getMessageBody,
             getMessageHeaders: getMessageHeaders,
-            getTotalExceptionGroups: getTotalExceptionGroups,
             getTotalFailedMessages: getTotalFailedMessages,
             getTotalArchivedMessages: getTotalArchivedMessages,
             getTotalFailingCustomChecks: getTotalFailingCustomChecks,

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -222,6 +222,16 @@
                 });
         }
 
+        function acknowledgeGroup(id, successText, failureText) {
+            var url = uri.join(scConfig.service_control_url, 'recoverability', 'unacknowledgedgroups', id);
+            return $http.delete(url).then(
+                function () {
+                    //   notifications.pushForCurrentRoute(successText, 'info');
+                }, function () {
+                    notifications.pushForCurrentRoute('Retrying messages failed', 'danger');
+                });
+        }
+
         function retryExceptionGroup(id, successText) {
 
             var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups', id, 'errors', 'retry');
@@ -291,7 +301,8 @@
             archiveExceptionGroup: archiveExceptionGroup,
             retryExceptionGroup: retryExceptionGroup,
             getHeartbeatStats: getHeartbeatStats,
-            loadQueueNames: loadQueueNames
+            loadQueueNames: loadQueueNames,
+            acknowledgeGroup: acknowledgeGroup
         };
 
         return service;

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -60,7 +60,8 @@
             var url = uri.join(scConfig.service_control_url, 'recoverability', 'history');
             return $http.get(url).then(function (response) {
                 return {
-                    data: response.data
+                    data: response.data,
+                    etag: response.headers('etag')
                 };
             });
         }

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -38,12 +38,20 @@
             });
         }
 
+        var previousExceptionGroupEtag;
+
         function getExceptionGroups(classifier) {
             var url = uri.join(scConfig.service_control_url, 'recoverability', 'groups', classifier);
-            return $http.get(url).then(function(response) {
+            return $http.get(url).then(function (response) {
+                var status = 200;
+                if (previousExceptionGroupEtag === response.headers('etag')) {
+                    status = 304;
+                } else {
+                    previousExceptionGroupEtag = response.headers('etag');
+                }
                 return {
                     data: response.data,
-                    status: reponse.status
+                    status: status
                 };
             });
         }

--- a/src/ServicePulse.Host/app/js/views/archive/controller.js
+++ b/src/ServicePulse.Host/app/js/views/archive/controller.js
@@ -178,10 +178,6 @@
                 .finally(function () {
                     vm.selectedIds = [];
                 });
-
-            serviceControlService.getTotalExceptionGroups().then(function (response) {
-                notifier.notify('ExceptionGroupCountUpdated', response);
-            });
         };
 
         vm.archiveExceptionGroup = function (group) {

--- a/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
+++ b/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
@@ -13,7 +13,7 @@
 
     <div class="row">
         <div class="col-sm-12">
-            <h5>system status</h5>
+            <h6>System status</h6>
             <div class="row box system-status">
                 <div class="col-sm-12">
                     <div class="row">

--- a/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="row">
-        <div class="col-sm-12">
-            <h1>Endpoint Overview</h1>
+        <div class="col-sm-12 no-side-padding">
+            <h1>Endpoints Overview</h1>
         </div>
     </div>
 </div>
@@ -17,7 +17,7 @@
     <section ng-show="isActiveEndpoints" name="active_endpoints">
         <no-data ng-show="model.active.length == 0" message="No active endpoints"></no-data>
         <div class="row">
-            <div class="col-sm-12">
+            <div class="col-sm-12 no-side-padding">
                 <div class="row box box-no-click" ng-repeat="endpoint in model.active | orderBy:'name'">
                     <div class="col-sm-12 no-side-padding">
                         <div class="row">
@@ -44,7 +44,7 @@
     <section ng-show="!isActiveEndpoints" name="inactive_endpoints">
         <no-data ng-show="model.inactive.length == 0" message="No inactive endpoints"></no-data>
         <div class="row">
-            <div class="col-sm-12">
+            <div class="col-sm-12 no-side-padding">
                 <div class="row box box-no-click" ng-repeat="endpoint in model.inactive | orderBy:'name'">
                     <div class="col-sm-12 no-side-padding">
                         <div class="row">

--- a/src/ServicePulse.Host/app/js/views/event_log_items/eventLogItems.tpl.html
+++ b/src/ServicePulse.Host/app/js/views/event_log_items/eventLogItems.tpl.html
@@ -2,7 +2,7 @@
     <section class="events" name="eventlog" ng-controller="EventLogItemsCtrl">
         <div class="row">
             <div class="col-sm-12">
-                <h5>Last 10 events</h5>
+                <h6>Last 10 events</h6>
 
                 <div ng-repeat="eventLogItem in model | orderBy: '-raised_at' | limitTo: 10" class="row box">
                     <div class="col-xs-12" ng-click="viewCategory(eventLogItem)">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -119,7 +119,7 @@
                             nObj
                                 .workflow_state =
                                 createWorkflowState(retryStatus,
-                                    getMessageForRetryStatus(retryStatus),
+                                    getMessageForRetryStatus(retryStatus, false, nObj.retry_progress),
                                     nObj.retry_progress);
                             
                             return nObj;
@@ -142,12 +142,15 @@
                 });
         };
 
-        function getMessageForRetryStatus(retryStatus, failed) {
+        function getMessageForRetryStatus(retryStatus, failed, progress) {
             if (retryStatus === 'waiting') {
                 return 'Retry request initiated...';
             }
 
             if (retryStatus === 'preparing') {
+                if (progress && progress === 1) {
+                    return 'Retry request in progress. Step 2/2 - Sending messages to retry...waiting for other sending operation(s) to finish.';
+                }
                 return 'Retry request in progress. Step 1/2 - Preparing messages...';
             }
         
@@ -206,7 +209,7 @@
                     item
                         .workflow_state =
                         createWorkflowState(status,
-                            getMessageForRetryStatus(status, data.failed || false),
+                            getMessageForRetryStatus(status, data.failed || false, data.progress.percentage),
                             data.progress.percentage,
                             data.failed || false);
                     item.retry_remaining_count = data.progress.messages_remaining;

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -210,7 +210,7 @@
                             data.progress.percentage,
                             data.failed || false);
                     item.retry_remaining_count = data.progress.messages_remaining;
-                    item.start_time = data.start_time;
+                    item.retry_start_time = data.start_time;
                 });
         };
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -142,11 +142,11 @@
 
         function getMessageForRetryStatus(retryStatus) {
             if (retryStatus === 'waiting') {
-                return 'Starting operation...';
+                return 'Starting...';
             }
 
             if (retryStatus === 'preparing') {
-                return 'Step 1/2 - Preparing...';
+                return 'Step 1/2 - Preparing messages...';
             }
         
             if (retryStatus === 'forwarding') {
@@ -154,7 +154,7 @@
             }
 
             if (retryStatus === 'completed') {
-                return 'Messages successfully forwarded for retrying';
+                return 'Messages successfully submitted for retrying';
             }
 
             return '';

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -195,30 +195,30 @@
         }, 'FailedMessageGroupArchived');
 
         notifier.subscribe($scope, function (event, data) {
-            vm.exceptionGroups.filter(x => x.id === data.request_id)
-                .forEach(x => {
-                    x.workflow_state = createWorkflowState('waiting', getMessageForRetryStatus('waiting'), data.progression);
+            vm.exceptionGroups.filter(function (item) { return item.id === data.request_id })
+                .forEach(function(item) {
+                    item.workflow_state = createWorkflowState('waiting', getMessageForRetryStatus('waiting'), data.progression);
                 });
         }, 'RetryOperationWaiting');
 
         notifier.subscribe($scope, function (event, data) {
-            vm.exceptionGroups.filter(x => x.id === data.request_id)
-                .forEach(x => {
-                    x.workflow_state = createWorkflowState('preparing', getMessageForRetryStatus('preparing'), data.progression);
+            vm.exceptionGroups.filter(function (item) { return item.id === data.request_id })
+                .forEach(function (item) {
+                    item.workflow_state = createWorkflowState('preparing', getMessageForRetryStatus('preparing'), data.progression);
                 });
         }, 'RetryOperationPreparing');
 
         notifier.subscribe($scope, function (event, data) {
-            vm.exceptionGroups.filter(x => x.id === data.request_id)
-                .forEach(x => {
-                    x.workflow_state = createWorkflowState('forwarding', getMessageForRetryStatus('forwarding'), data.progression);
+            vm.exceptionGroups.filter(function (item) { return item.id === data.request_id })
+                .forEach(function (item) {
+                    item.workflow_state = createWorkflowState('forwarding', getMessageForRetryStatus('forwarding'), data.progression);
                 });
         }, 'RetryOperationForwarding');
 
         notifier.subscribe($scope, function (event, data) {
-            vm.exceptionGroups.filter(x => x.id === data.request_id)
-                .forEach(x => {
-                    x.workflow_state = createWorkflowState('completed', getMessageForRetryStatus('completed'), data.progression);
+            vm.exceptionGroups.filter(function(item) { return item.id === data.request_id })
+                .forEach(function (item) {
+                    item.workflow_state = createWorkflowState('completed', getMessageForRetryStatus('completed'), data.progression);
                 });
         }, 'RetryOperationCompleted');
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -7,15 +7,9 @@
             optionalTotal = optionalTotal * 100;
         }
         return {
-            status: optionalStatus || 'working',
+        status: optionalStatus || 'working',
             message: optionalMessage || 'working',
-            total: optionalTotal || 0,
-            getDisplayMessage: function() {
-                if (this.status === 'waiting') {
-                    return this.message;
-                }
-                return this.message.concat(' - ', this.total, '% done');
-            }
+            total: optionalTotal || 0
         };
     }
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -167,9 +167,9 @@
                     });
 
                     vm.exceptionGroups.forEach(function(group) {
-                        var d = response.data.find(function(item) {
+                        var d = response.data.filter(function(item) {
                             return item.id === group.id;
-                        });
+                        })[0];
 
                         for (var prop in d) {
                             group[prop] = d[prop];

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -70,8 +70,8 @@
             group.workflow_state = createWorkflowState('none');
         }
 
-        vm.canBeRetried = function(group) {
-            return group.workflow_state.status === 'none' || group.workflow_state.status === 'completed';
+        vm.isBeingRetried = function(group) {
+            return group.workflow_state.status !== 'none' && group.workflow_state.status !== 'completed';
         }
 
         vm.selectClassification = function (newClassification) {

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -229,41 +229,17 @@
             return '';
         }
 
-        var localtimeout;
-        var startTimer = function (time) {
-            time = time || 5000;
-            localtimeout = $timeout(function () {
-
-                getHistoricGroups();
-                vm.updateExceptionGroups();
-            }, time);
-        }
+        var groupUpdatedInterval = $interval(function () {
+            getHistoricGroups();
+            vm.updateExceptionGroups();
+        }, 5000);
 
         $scope.$on("$destroy", function (event) {
-            $timeout.cancel(localtimeout);
-        });
-
-        notifier.subscribe($scope, function (event, data) {
-            if (vm.exceptionGroups.length !== parseInt(data)) {
-                autoGetExceptionGroups();
-                getHistoricGroups();
+            if (angular.isDefined(groupUpdatedInterval)) {
+                $interval.cancel(groupUpdatedInterval);
+                groupUpdatedInterval = undefined;
             }
-        }, "ExceptionGroupCountUpdated");
-
-        notifier.subscribe($scope, function (event, data) {
-            $timeout.cancel(localtimeout);
-            startTimer();
-        }, 'MessagesSubmittedForRetry');
-        
-        notifier.subscribe($scope, function (event, data) {
-            $timeout.cancel(localtimeout);
-            startTimer();
-        }, 'MessageFailed');
-
-        notifier.subscribe($scope, function (event, data) {
-            $timeout.cancel(localtimeout);
-            startTimer();
-        }, 'FailedMessageGroupArchived');
+        });
 
         var retryOperationEventHandler = function (data, status) {
             var group = vm.exceptionGroups.filter(function (item) { return item.id === data.request_id });

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -7,9 +7,15 @@
             optionalTotal = optionalTotal * 100;
         }
         return {
-        status: optionalStatus || 'working',
+            status: optionalStatus || 'working',
             message: optionalMessage || 'working',
-            total: optionalTotal || 0
+            total: optionalTotal || 0,
+            getDisplayMessage: function() {
+                if (this.status === 'waiting') {
+                    return this.message;
+                }
+                return this.message.concat(' - ', this.total, '% done');
+            }
         };
     }
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -290,6 +290,7 @@
 
                 if (status === 'completed') {
                     item.need_user_acknowledgement = true;
+                    item.retry_completion_time = data.completion_time;
                 }
             });
         };

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -220,6 +220,7 @@
                 .forEach(function (item) {
                     item.workflow_state = createWorkflowState('completed', getMessageForRetryStatus('completed'), data.progression);
                 });
+            getHistoricGroups();
         }, 'RetryOperationCompleted');
 
         // INIT

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -265,11 +265,8 @@
 
                     item.retry_remaining_count = data.progress.messages_remaining;
                     item.retry_start_time = data.start_time;
+            });
 
-                    if (status === 'completed') {
-                        item.count -= data.progress.messages_forwarded;
-                    }
-                });
             if (status === 'completed' && group.count === 0) {
                 vm.exceptionGroups.remove(vm.exceptionGroups.indexOf(group), 1);
             }

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -218,10 +218,15 @@
                 });
         };
 
+        var historicGroupsEtag;
+
         var getHistoricGroups = function() {
-            vm.historicGroups = [];
             serviceControlService.getHistoricGroups()
-                .then(function(response) {
+                .then(function (response) {
+                    if (historicGroupsEtag === response.etag) {
+                        return true;
+                    }
+                    historicGroupsEtag = response.etag;
                     vm.historicGroups = response.data.historic_operations;
                 });
         };

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -81,6 +81,24 @@
                     });
         };
 
+
+        var statuses = ['waiting', 'preparing', 'queued', 'forwarding'];
+        vm.getClasses = function (stepStatus, currentStatus) {
+            if (currentStatus === 'queued') {
+                currentStatus = 'forwarding';
+            }
+            var indexOfStep = statuses.indexOf(stepStatus);
+            var indexOfCurrent = statuses.indexOf(currentStatus);
+            if (indexOfStep > indexOfCurrent) {
+                return 'left-to-do';
+            }
+            else if (indexOfStep === indexOfCurrent) {
+                return 'active';
+            } else {
+                return 'completed';
+            }
+        }
+
         vm.isBeingRetried = function(group) {
             return group.workflow_state.status !== 'none' && (group.workflow_state.status !== 'completed' || group.need_user_acknowledgement === true) && !vm.isBeingArchived(group);
         };
@@ -135,7 +153,10 @@
 
         vm.updateExceptionGroups = function () {
             return serviceControlService.getExceptionGroups(vm.selectedClassification)
-                .then(function(response) {
+                .then(function (response) {
+                    if (response.status === 304) {
+                        return true;
+                    }
                     var exceptionGroupsToBeRemoved = vm.exceptionGroups.filter(function(item) {
                         return !response.data.some(function(d) {
                             return d.id === item.id;
@@ -179,6 +200,10 @@
             vm.exceptionGroups = [];
             return serviceControlService.getExceptionGroups(vm.selectedClassification)
                 .then(function (response) {
+                    if (response.status === 304) {
+                        return true;
+                    }
+
                     if (response.data.length > 0) {
                         
                         // need a map in some ui state for controlling animations

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -212,8 +212,13 @@
                             getMessageForRetryStatus(status, data.failed || false, data.progress.percentage),
                             data.progress.percentage,
                             data.failed || false);
+
                     item.retry_remaining_count = data.progress.messages_remaining;
                     item.retry_start_time = data.start_time;
+
+                    if (status === 'completed') {
+                        item.count -= data.number_of_messages_processed;
+                    }
                 });
         };
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -242,9 +242,9 @@
             retryOperationEventHandler(data, 'completed');
             getHistoricGroups();
             if (data.failed) {
-                toastService.showInfo("Group " + data.originator + " was retried however and error have occured and not all messages were retried. Retry the remaining messages afterwards.", true);
+                toastService.showInfo("Group " + data.originator + " was retried however and error have occured and not all messages were retried. Retry the remaining messages afterwards.", "Retry operation completed", true);
             } else {
-                toastService.showInfo("Group " + data.originator + " was retried succesfully.", true);
+                toastService.showInfo("Group " + data.originator + " was retried succesfully.", "Retry operation completed", true);
             }
         }, 'RetryOperationCompleted');
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -39,7 +39,7 @@
         }
         
         vm.archiveExceptionGroup = function (group) {
-            group.workflow_state = { status: 'working', message: 'working' };
+            group.workflow_state = { status: 'waiting', message: getMessageForRetryStatus('waiting') };
             failedMessageGroupsService.archiveGroup(group.id, 'Archive Group Request Enqueued', 'Archive Group Request Rejected')
                 .then(function (message) {
                     group.workflow_state = createWorkflowState('success', 'Starting operation...');
@@ -52,7 +52,7 @@
         }
 
         vm.retryExceptionGroup = function (group) {
-            group.workflow_state = { status: 'working', message: 'working' };
+            group.workflow_state = { status: 'waiting', message: getMessageForRetryStatus('waiting') };
 
             failedMessageGroupsService.retryGroup(group.id, 'Retry Group Request Enqueued', 'Retry Group Request Rejected')
                 .then(function () {

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -149,7 +149,7 @@
 
             if (retryStatus === 'preparing') {
                 if (progress && progress === 1) {
-                    return 'Retry request in progress. Step 2/2 - Queued.';
+                    return 'Retry request in progress. Next Step - Queued.';
                 }
                 return 'Retry request in progress. Step 1/2 - Preparing messages...';
             }

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -44,7 +44,7 @@
                     'Group Acknowledged',
                     'Acknowledging Group Failed')
                 .then(function(message) {
-                        group.workflow_state = createWorkflowState('none');
+                        vm.exceptionGroups.splice(vm.exceptionGroups.indexOf(group), 1);
                     });
         }
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -119,8 +119,8 @@
                             nObj
                                 .workflow_state =
                                 createWorkflowState(retryStatus,
-                                    getMessageForRetryStatus(retryStatus, false, nObj.retry_progress),
-                                    nObj.retry_progress);
+                                    getMessageForRetryStatus(retryStatus, nObj.retry_failed, nObj.retry_progress),
+                                    nObj.retry_progress, nObj.retry_failed);
                             
                             return nObj;
                         });

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -173,12 +173,12 @@
         var startTimer = function (time) {
             time = time || 5000;
             localtimeout = $timeout(function () {
-                vm.loadingData = true;
+                //vm.loadingData = true;
 
-                getHistoricGroups();
-                autoGetExceptionGroups().then(function (result) {
-                    vm.loadingData = false;
-                });
+                //getHistoricGroups();
+                //autoGetExceptionGroups().then(function (result) {
+                //    vm.loadingData = false;
+                //});
             }, time);
         }
 
@@ -217,7 +217,7 @@
                     item.retry_start_time = data.start_time;
 
                     if (status === 'completed') {
-                        item.count -= data.number_of_messages_processed;
+                        item.count -= data.progress.messages_forwarded;
                     }
                 });
         };

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -39,6 +39,15 @@
             $location.path('/failedMessages');
         };
 
+        vm.acknowledgeGroup = function (group) {
+            serviceControlService.acknowledgeGroup(group.id,
+                    'Group Acknowledged',
+                    'Acknowledging Group Failed')
+                .then(function(message) {
+                        group.workflow_state = createWorkflowState('none');
+                    });
+        }
+
         vm.archiveExceptionGroup = function(group) {
             group.workflow_state = { status: 'requestingArchive', message: 'Archive request initiated...' };
             failedMessageGroupsService.archiveGroup(group.id,
@@ -73,7 +82,7 @@
         };
 
         vm.isBeingRetried = function(group) {
-            return group.workflow_state.status !== 'none' && group.workflow_state.status !== 'completed' && !vm.isBeingArchived(group);
+            return group.workflow_state.status !== 'none' && (group.workflow_state.status !== 'completed' || group.need_user_acknowledgement === true) && !vm.isBeingArchived(group);
         };
 
         vm.isBeingArchived = function (group) {
@@ -272,11 +281,10 @@
 
                     item.retry_remaining_count = data.progress.messages_remaining;
                     item.retry_start_time = data.start_time;
+                if (status === 'completed') {
+                    item.need_user_acknowledgement = true;
+                }
             });
-
-            if (status === 'completed' && group.count === 0) {
-                vm.exceptionGroups.remove(vm.exceptionGroups.indexOf(group), 1);
-            }
         };
 
         notifier.subscribe($scope, function (event, data) {

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -143,20 +143,20 @@
 
         function getMessageForRetryStatus(retryStatus, failed) {
             if (retryStatus === 'waiting') {
-                return 'Starting...';
+                return 'Retry request initiated...';
             }
 
             if (retryStatus === 'preparing') {
-                return 'Step 1/2 - Preparing messages...';
+                return 'Retry request in progress. Step 1/2 - Preparing messages...';
             }
         
             if (retryStatus === 'forwarding') {
-                return 'Step 2/2 - Sending messages to retry...';
+                return 'Retry request in progress. Step 2/2 - Sending messages to retry...';
             }
 
             if (retryStatus === 'completed') {
                 if (failed) {
-                    return 'ServiceControl had to restart while this operation was in progress. Not all messages were submitted.';
+                    return 'ServiceControl had to restart while this operation was in progress. Not all messages were submitted for retrying.';
                 }
 
                 return 'Messages successfully submitted for retrying';

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -40,12 +40,12 @@
         };
 
         vm.archiveExceptionGroup = function(group) {
-            group.workflow_state = { status: 'archiveRequested', message: 'Archive request initiated...' };
+            group.workflow_state = { status: 'requestingArchive', message: 'Archive request initiated...' };
             failedMessageGroupsService.archiveGroup(group.id,
                     'Archive Group Request Enqueued',
                     'Archive Group Request Rejected')
                 .then(function(message) {
-                        group.workflow_state = createWorkflowState('success', 'Archive completed...');
+                    group.workflow_state = createWorkflowState('archiveRequested', 'Archiving messages...');
                         notifier.notify('ArchiveGroupRequestAccepted', group);
 
                     },
@@ -73,7 +73,11 @@
         };
 
         vm.isBeingRetried = function(group) {
-            return group.workflow_state.status !== 'none' && group.workflow_state.status !== 'completed';
+            return group.workflow_state.status !== 'none' && group.workflow_state.status !== 'completed' && !vm.isBeingArchived(group);
+        };
+
+        vm.isBeingArchived = function (group) {
+            return group.workflow_state.status === 'requestingArchive' || group.workflow_state.status === 'archiveRequested';
         };
 
         vm.selectClassification = function (newClassification) {

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -210,6 +210,7 @@
                             data.progress.percentage,
                             data.failed || false);
                     item.retry_remaining_count = data.progress.messages_remaining;
+                    item.start_time = data.start_time;
                 });
         };
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -22,7 +22,8 @@
         sharedDataService,
         notifyService,
         serviceControlService,
-        failedMessageGroupsService) {
+        failedMessageGroupsService,
+        toastService) {
 
         var vm = this;
         var notifier = notifyService();
@@ -231,6 +232,11 @@
         notifier.subscribe($scope, function (event, data) {
             retryOperationEventHandler(data, 'completed');
             getHistoricGroups();
+            if (data.failed) {
+                toastService.showInfo("Group " + data.originator + " was retried however and error have occured and not all messages were retried. Retry the remaining messages afterwards.", true);
+            } else {
+                toastService.showInfo("Group " + data.originator + " was retried succesfully.", true);
+            }
         }, 'RetryOperationCompleted');
 
         // INIT
@@ -246,7 +252,8 @@
         "sharedDataService",
         "notifyService",
         "serviceControlService",
-        "failedMessageGroupsService"
+        "failedMessageGroupsService",
+        "toastService"
     ];
 
     angular.module("sc")

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -197,7 +197,7 @@
             vm.historicGroups = [];
             serviceControlService.getHistoricGroups()
                 .then(function(response) {
-                    vm.historicGroups = response.data.previous_fully_completed_operations;
+                    vm.historicGroups = response.data.historic_operations;
                 });
         };
 
@@ -281,6 +281,7 @@
 
                     item.retry_remaining_count = data.progress.messages_remaining;
                     item.retry_start_time = data.start_time;
+
                 if (status === 'completed') {
                     item.need_user_acknowledgement = true;
                 }

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -200,7 +200,7 @@
             vm.exceptionGroups = [];
             return serviceControlService.getExceptionGroups(vm.selectedClassification)
                 .then(function (response) {
-                    if (response.status === 304) {
+                    if (response.status === 304 && vm.exceptionGroups.length > 0) {
                         return true;
                     }
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -142,11 +142,11 @@
 
         function getMessageForRetryStatus(retryStatus) {
             if (retryStatus === 'waiting') {
-                return 'Step 1/2 - Preparing...';
+                return 'Starting operation...';
             }
 
             if (retryStatus === 'preparing') {
-                return 'Step 2/2 - Sending messages to retry...';
+                return 'Step 1/2 - Preparing...';
             }
         
             if (retryStatus === 'forwarding') {

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -46,7 +46,8 @@
                         </div>
                     </div>
                 </div>
-                <p ng-show="vm.historicGroups.length < 10">There are only {{vm.historicGroups.length}} completed groups.</p>
+                <p ng-show="vm.historicGroups.length === 1">There is only 1 completed group.</p>
+                <p ng-show="vm.historicGroups.length < 10 && vm.historicGroups.length > 1">There are only {{vm.historicGroups.length}} completed groups.</p>
             </div>
         </div>
 
@@ -92,7 +93,6 @@
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.completion_time}}"></sp-moment></span>
-                                            <span class="metadata" ng-show="group.workflow_state.status !== 'completed'"><i class="fa fa-clock-o"></i> Retry started: <sp-moment empty-message="never" date="{{group.start_time}}"></sp-moment></span>
                                         </p>
                                     </div>
                                 </div>
@@ -120,7 +120,7 @@
                                                     </div>
                                                 </div>
                                                 <div>
-                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.start_time}}"></sp-moment></span>
                                                 </div>
                                                 <div ng-show="{{group.retry_failed}}">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -122,12 +122,33 @@
                                     <div class="col-sm-12">
                                         <div class="panel panel-default">
                                             <div class="panel-body">
-                                                <p class="bulk-retry-progress-status">{{group.workflow_state.message}}</p>
-                                                <div class="progress bulk-retry-progress" ng-hide="group.workflow_state.status === 'waiting' || (group.workflow_state.status === 'preparing' && group.workflow_state.total === 100)">
-                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}%;">
-                                                        {{group.workflow_state.total | number : 0}}%
-                                                    </div>
-                                                </div>
+                                                <ul>
+                                                    <li ng-class="{active: group.workflow_state.status === 'waiting'}">
+                                                        <p class="bulk-retry-progress-status">Retry request initiated...</p>        
+                                                    </li>
+                                                    <li ng-class="{active: group.workflow_state.status === 'preparing'}">
+                                                        <p class="bulk-retry-progress-status">Retry request in progress. Step 1/2 - Preparing messages...</p>
+                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
+                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
+                                                                {{group.workflow_state.total | number : 0}}%
+                                                            </div>
+                                                        </div>
+                                                    </li>
+                                                    <li ng-class="{active: group.workflow_state.status === 'queued'}">
+                                                        <p class="bulk-retry-progress-status">Retry request in progress. Next Step - Queued.</p>
+                                                    </li>
+                                                    <li ng-class="{active: group.workflow_state.status === 'forwarding'}">
+                                                        <p class="bulk-retry-progress-status">Retry request in progress. Step 2/2 - Sending messages to retry...</p>
+                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
+                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
+                                                                {{group.workflow_state.total | number : 0}}%
+                                                            </div>
+                                                        </div>
+                                                    </li>
+                                                    <li ng-class="{active: group.workflow_state.status === 'completed'}">
+                                                        <p class="bulk-retry-progress-status">Messages successfully submitted for retrying</p>
+                                                    </li>
+                                                </ul>
                                                 <div>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -90,8 +90,8 @@
                                             <span class="metadata"><i class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
                                             <span class="metadata"><i class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
-                                            <span class="metadata"><i class="fa fa-refresh"></i> Last retried: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
-                                            <span class="metadata" ng-show="group.workflow_state.status !== 'completed'"><i class="fa fa-clock-o"></i> Retry started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
+                                            <span class="metadata"><i class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata" ng-show="group.workflow_state.status !== 'completed'"><i class="fa fa-clock-o"></i> Retry started: <sp-moment empty-message="never" date="{{group.start_time}}"></sp-moment></span>
                                         </p>
                                     </div>
                                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -19,20 +19,20 @@
                     <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed retry requests</a>
                 </h6>
             </div>
-            <div class="col-sm-12" ng-show="vm.showHistoricRetries">
+            <div class="col-sm-12 no-mobile-side-padding" ng-show="vm.showHistoricRetries">
                 <no-data ng-show="vm.historicGroups.length === 0" title="message group retries" message="No group retry requests have ever been completed"></no-data>
                 <div class="row box extra-box-padding repeat-modify" ng-repeat="group in vm.historicGroups" ng-show="vm.historicGroups.length">
-                    <div class="col-sm-12">
+                    <div class="col-sm-12 no-mobile-side-padding">
                         <div class="row">
-                            <div class="col-sm-12">
+                            <div class="col-sm-12 no-side-padding">
                                 <div class="row box-header">
-                                    <div class="col-sm-12">
+                                    <div class="col-sm-12 no-side-padding">
                                         <p class="lead break"> {{group.originator}}</p>
                                     </div>
                                 </div>
 
                                 <div class="row">
-                                    <div class="col-sm-12">
+                                    <div class="col-sm-12 no-side-padding">
                                         <p class="metadata">
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
@@ -80,114 +80,116 @@
         </div>
         
         
+        <div class="row">
+            <div class="col-sm-12 no-mobile-side-padding">
 
+                <div ng-show="vm.exceptionGroups.length > 0">
 
-            <div class="" ng-show="vm.exceptionGroups.length > 0">
+                    <div class="row box box-no-interaction wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups">
+                        <div class="col-sm-12 no-mobile-side-padding">
+                            <div class="row">
+                                <div class="col-sm-12 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <p class="lead break"> {{group.title}}</p>
+                                            <p class="metadata" ng-show="!vm.isBeingRetried(group)">
+                                                <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>
 
-                <div class="row box box-no-interaction wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups">
-                    <div class="col-sm-12">
-                        <div class="row">
-                            <div class="col-sm-12">
-                                <div class="row box-header">
-                                    <div class="col-sm-12">
-                                        <p class="lead break"> {{group.title}}</p>
-                                        <p class="metadata" ng-show="!vm.isBeingRetried(group)">
-                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>
+                                                <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
 
-                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
+                                                <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
-                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
-
-                                            <span class="metadata"><i aria-hidden="true" class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.last_retry_completion_time}}"></sp-moment></span>
-                                        </p>
-                                    </div>
-                                </div>
-                                <div class="row" ng-show="!vm.isBeingRetried(group)">
-                                    <div class="col-sm-12">
-                                        <button type="button" class="btn btn-link btn-sm hidden-sm-down" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0">
-                                            <i aria-hidden="true" class="fa fa-eye no-link-underline">&nbsp</i>View Messages
-                                        </button>
-                                        <button type="button" class="btn btn-link btn-sm" confirm-click="vm.retryExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to retry this group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry this group of {{group.count}} messages?" confirm-second-paragraph="NOTE: Additional failed messages will be automatically included in the retry operation while it is queued.">
-                                            <i aria-hidden="true" class="fa fa-refresh no-link-underline">&nbsp</i>Request retry
-                                        </button>
-                                        <button type="button" class="btn btn-link btn-sm" confirm-click="vm.archiveExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to archive this group?" confirm-message="If you do, they will not be available for Retry.">
-                                            <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Archive Group
-                                        </button>
-                                    </div>
-                                </div>
-                                <div class="row" ng-show="vm.isBeingRetried(group)">
-                                    <div class="col-sm-12">
-                                        <div class="panel panel-default panel-retry">
-                                            <div class="panel-body">
-                                                <ul class="retry-request-progress">
-                                                    <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('waiting', group.workflow_state.status)">
-                                                        <div class="bulk-retry-progress-status">Initialize retry request...</div>        
-                                                    </li>
-                                                    <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('preparing', group.workflow_state.status)">
-                                                        
-                                                        <div class="row">
-                                                            <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
-                                                                <div class="bulk-retry-progress-status">Prepare messages...</div>
-                                                            </div>
-
-                                                            <div class="col-xs-12 col-sm-6">
-                                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
-                                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
-                                                                        {{group.workflow_state.total | number : 0}}%
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </li>
-                                                    <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('forwarding', group.workflow_state.status)">
-
-                                                        <div class="row">
-                                                            <div class="col-xs-9 col-sm-4 col-md-3 no-side-padding">
-                                                                <div class="bulk-retry-progress-status">Send messages to retry...</div>
-                                                            </div>
-                                                            <div class="col-xs-3 col-sm-3 retry-op-queued" ng-show="group.workflow_state.status === 'queued'">
-                                                                (Queued)
-                                                            </div>
-                                                            <div class="col-xs-12 col-sm-6">
-
-                                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
-                                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
-                                                                        {{group.workflow_state.total | number : 0}}%
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-</li>
-                                                    <li ng-show="group.workflow_state.status === 'completed'">
-                                                        <div class="retry-completed bulk-retry-progress-status">Retry request completed</div>
-                                                        <button type="button" class="btn btn-default btn-primary btn-xs" ng-show="group.need_user_acknowledgement == true" ng-click="vm.acknowledgeGroup(group)">
-                                                            Dismiss
-                                                        </button>
-                                                        <div class="danger sc-restart-warning" ng-show="{{group.workflow_state.failed}}">
-                                                            <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> <strong>WARNING: </strong>Not all messages will be retried because ServiceControl had to restart. You need to request retrying the remaining messages.
-                                                        </div>
-                                                        
-                                                    </li>
-                                                </ul>
-
-                                                <div>
-                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to send: {{(group.retry_remaining_count || group.count) | number}}</span>
-                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
-                                                </div>
-                                                
-                                                    
-                                                
-                                            </div>
-
+                                                <span class="metadata"><i aria-hidden="true" class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.last_retry_completion_time}}"></sp-moment></span>
+                                            </p>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="row" ng-show="vm.isBeingArchived(group)">
-                                    <div class="col-sm-12">
-                                        <div class="panel panel-default">
-                                            <div class="panel-body">
-                                                <p class="bulk-retry-progress-status">{{group.workflow_state.message}}</p>
-                                                <div>
-                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to archive: {{(group.retry_remaining_count || group.count) | number}}</span>
+                                    <div class="row" ng-show="!vm.isBeingRetried(group)">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <button type="button" class="btn btn-link btn-sm hidden-sm-down" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0">
+                                                <i aria-hidden="true" class="fa fa-eye no-link-underline">&nbsp</i>View Messages
+                                            </button>
+                                            <button type="button" class="btn btn-link btn-sm" confirm-click="vm.retryExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to retry this group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry this group of {{group.count}} messages?">
+                                                <i aria-hidden="true" class="fa fa-refresh no-link-underline">&nbsp</i>Request retry
+                                            </button>
+                                            <button type="button" class="btn btn-link btn-sm" confirm-click="vm.archiveExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to archive this group?" confirm-message="If you do, they will not be available for Retry.">
+                                                <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Archive Group
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="row" ng-show="vm.isBeingRetried(group)">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <div class="panel panel-default panel-retry">
+                                                <div class="panel-body">
+                                                    <ul class="retry-request-progress">
+                                                        <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('waiting', group.workflow_state.status)">
+                                                            <div class="bulk-retry-progress-status">Initialize retry request...</div>
+                                                        </li>
+                                                        <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('preparing', group.workflow_state.status)">
+
+                                                            <div class="row">
+                                                                <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
+                                                                    <div class="bulk-retry-progress-status">Prepare messages...</div>
+                                                                </div>
+
+                                                                <div class="col-xs-12 col-sm-6">
+                                                                    <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
+                                                                        <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
+                                                                            {{group.workflow_state.total | number : 0}}%
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </li>
+                                                        <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('forwarding', group.workflow_state.status)">
+
+                                                            <div class="row">
+                                                                <div class="col-xs-9 col-sm-4 col-md-3 no-side-padding">
+                                                                    <div class="bulk-retry-progress-status">Send messages to retry...</div>
+                                                                </div>
+                                                                <div class="col-xs-3 col-sm-3 retry-op-queued" ng-show="group.workflow_state.status === 'queued'">
+                                                                    (Queued)
+                                                                </div>
+                                                                <div class="col-xs-12 col-sm-6">
+
+                                                                    <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
+                                                                        <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
+                                                                            {{group.workflow_state.total | number : 0}}%
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                        </li>
+                                                        <li ng-show="group.workflow_state.status === 'completed'">
+                                                            <div class="retry-completed bulk-retry-progress-status">Retry request completed</div>
+                                                            <button type="button" class="btn btn-default btn-primary btn-xs" ng-show="group.need_user_acknowledgement == true" ng-click="vm.acknowledgeGroup(group)">
+                                                                Dismiss
+                                                            </button>
+                                                            <div class="danger sc-restart-warning" ng-show="{{group.workflow_state.failed}}">
+                                                                <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> <strong>WARNING: </strong>Not all messages will be retried because ServiceControl had to restart. You need to request retrying the remaining messages.
+                                                            </div>
+
+                                                        </li>
+                                                    </ul>
+
+                                                    <div class="op-metadata">
+                                                        <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to send: {{(group.retry_remaining_count || group.count) | number}}</span>
+                                                        <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
+                                                    </div>
+
+
+
+                                                </div>
+
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row" ng-show="vm.isBeingArchived(group)">
+                                        <div class="col-sm-12">
+                                            <div class="panel panel-default">
+                                                <div class="panel-body">
+                                                    <p class="bulk-retry-progress-status">{{group.workflow_state.message}}</p>
+                                                    <div>
+                                                        <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to archive: {{(group.retry_remaining_count || group.count) | number}}</span>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
@@ -196,9 +198,10 @@
                             </div>
                         </div>
                     </div>
-                </div>
 
+                </div>
             </div>
+        </div>
         </div>
 
     </section>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -142,6 +142,18 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div class="row" ng-show="vm.isBeingArchived(group)">
+                                    <div class="col-sm-12">
+                                        <div class="panel panel-default">
+                                            <div class="panel-body">
+                                                <p class="bulk-retry-progress-status">{{group.workflow_state.message}}</p>
+                                                <div>
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to archive: {{(group.retry_remaining_count || group.count) | number}}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -98,7 +98,7 @@
                                 <div class="row" ng-show="!vm.canBeRetried(group)">
                                     <div class="col-sm-12">
                                         <i class="fa fa-spinner fa-pulse pull-left"></i>
-                                        <p class="lead">{{group.workflow_state.message}} - {{group.workflow_state.total}}% done</p>
+                                        <p class="lead">{{group.workflow_state.getDisplayMessage()}}</p>
                                     </div>
                                 </div>
                             </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -147,6 +147,9 @@
                                                     </li>
                                                     <li ng-class="{active: group.workflow_state.status === 'completed'}">
                                                         <p class="bulk-retry-progress-status">Messages successfully submitted for retrying</p>
+                                                        <button type="button" class="btn btn-link btn-sm" ng-show="group.need_user_acknowledgement == true" confirm-click="vm.acknowledgeGroup(group)" confirm-title="Are you sure you want to acknowledge this group?">
+                                                            <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Acknowledge Group
+                                                        </button>
                                                     </li>
                                                 </ul>
                                                 <div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -11,12 +11,12 @@
 
         <failed-message-tabs></failed-message-tabs>
 
-        <div class="row">
+        <div class="row" ng-show="vm.historicGroups.length">
             <div class="col-sm-12 list-section">
                 <h5>
                     <span class="fake-link" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
                     <span class="fake-link" aria-hidden="true" ng-show="!vm.showHistoricRetries"><i class="fa fa-angle-right" aria-hidden="true"></i> </span>
-                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed group retries</a>
+                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last {{vm.historicGroups.length}} completed group retries</a>
                 </h5>
             </div>
             <div class="col-sm-12" ng-show="vm.showHistoricRetries">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -34,9 +34,9 @@
                                 <div class="row">
                                     <div class="col-sm-12 no-side-padding">
                                         <p class="metadata">
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages sent: {{group.number_of_messages_processed}}</span>
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
-                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages retried: {{group.number_of_messages_processed}}</span>
                                         </p>
                                     </div>
                                 </div>
@@ -171,16 +171,11 @@
                                                     </ul>
 
                                                     <div class="op-metadata">
-                                                        <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to send: {{(group.retry_remaining_count || group.count) | number}}</span>
-                                                        <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
+                                                        <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.workflow_state.status === 'completed' ? 'Messages sent:' : 'Messages to send:'}} {{(group.retry_remaining_count || group.count) | number}}</span>
+                                                        <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
 														<span class="metadata" ng-show="group.workflow_state.status === 'completed'"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.retry_completion_time}}"></sp-moment></span>
                                                     </div>
-
-
-
-                                                    
                                                 </div>
-
                                             </div>
                                         </div>
                                     </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -12,13 +12,6 @@
         <failed-message-tabs></failed-message-tabs>
 
         <div class="row">
-            <div class="col-sm-12">
-                <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
-
-                <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
-            </div>
-        </div>
-        <div class="row">
             <div class="col-sm-12 list-section">
                 <h5>
                     <span class="fake-link" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
@@ -50,6 +43,13 @@
                 </div>
             </div>
         </div>
+
+        <div class="row">
+            <div class="col-sm-12">
+                <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
+                 <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
+            </div>
+        </div>
         
         <div class="row" ng-show="vm.availableClassifiers.length && vm.initialLoadComplete">
             <div class="col-sm-12">
@@ -66,7 +66,7 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="row" ng-show="vm.exceptionGroups.length > 0">
             <div class="col-sm-12 list-section" ng-show="vm.exceptionGroups.length">
                 <h5>Failed message groups</h5>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -53,7 +53,7 @@
         </div>
 
         <div class="row">
-            <div class="col-xs-12 col-sm-6 list-section" ng-show="vm.exceptionGroups.length">
+            <div class="col-xs-12 col-sm-6 list-section">
                 <h6>Failed message groups</h6>
             </div>
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -132,7 +132,7 @@
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
                                                 </div>
-                                                <div ng-show="{{group.retry_failed}}">
+                                                <div ng-show="{{group.workflow_state.failed}}">
                                                     <span class="danger">
                                                         <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> Warning: Not all messages in this operation will be retried because ServiceControl had to restart during the operation.
                                                     </span>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -47,8 +47,8 @@
                         </div>
                     </div>
                 </div>
-                <p ng-show="vm.historicGroups.length === 1">There is only 1 completed group.</p>
-                <p ng-show="vm.historicGroups.length < 10 && vm.historicGroups.length > 1">There are only {{vm.historicGroups.length}} completed groups.</p>
+                <p ng-show="vm.historicGroups.length === 1">There is only 1 completed group retry</p>
+                <p ng-show="vm.historicGroups.length < 10 && vm.historicGroups.length > 1">There are only {{vm.historicGroups.length}} completed group retries</p>
             </div>
         </div>
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -122,12 +122,12 @@
                                     <div class="col-sm-12">
                                         <div class="panel panel-default">
                                             <div class="panel-body">
-                                                <ul>
+                                                <ul class="retry-request-progress">
                                                     <li ng-class="{active: group.workflow_state.status === 'waiting'}">
                                                         <p class="bulk-retry-progress-status">Retry request initiated...</p>        
                                                     </li>
                                                     <li ng-class="{active: group.workflow_state.status === 'preparing'}">
-                                                        <p class="bulk-retry-progress-status">Retry request in progress. Step 1/2 - Preparing messages...</p>
+                                                        <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Step 1/2 - Preparing messages...</p>
                                                         <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
                                                             <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
                                                                 {{group.workflow_state.total | number : 0}}%
@@ -135,10 +135,10 @@
                                                         </div>
                                                     </li>
                                                     <li ng-class="{active: group.workflow_state.status === 'queued'}">
-                                                        <p class="bulk-retry-progress-status">Retry request in progress. Next Step - Queued.</p>
+                                                        <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Retry request in progress. Next Step - Queued.</p>
                                                     </li>
                                                     <li ng-class="{active: group.workflow_state.status === 'forwarding'}">
-                                                        <p class="bulk-retry-progress-status">Retry request in progress. Step 2/2 - Sending messages to retry...</p>
+                                                        <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Step 2/2 - Sending messages to retry...</p>
                                                         <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
                                                             <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
                                                                 {{group.workflow_state.total | number : 0}}%
@@ -146,9 +146,9 @@
                                                         </div>
                                                     </li>
                                                     <li ng-class="{active: group.workflow_state.status === 'completed'}">
-                                                        <p class="bulk-retry-progress-status">Messages successfully submitted for retrying</p>
-                                                        <button type="button" class="btn btn-link btn-sm" ng-show="group.need_user_acknowledgement == true" confirm-click="vm.acknowledgeGroup(group)" confirm-title="Are you sure you want to acknowledge this group?">
-                                                            <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Acknowledge Group
+                                                        <p class="retry-completed bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-check"></i> Retry request operation complete</p>
+                                                        <button type="button" class="btn btn-default btn-primary btn-xs" ng-show="group.need_user_acknowledgement == true" confirm-click="vm.acknowledgeGroup(group)" confirm-title="Are you sure you want to acknowledge this group?">
+                                                            Dismiss
                                                         </button>
                                                     </li>
                                                 </ul>
@@ -158,7 +158,7 @@
                                                 </div>
                                                 <div ng-show="{{group.workflow_state.failed}}">
                                                     <span class="danger">
-                                                        <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> Warning: Not all messages in this operation will be retried because ServiceControl had to restart during the operation.
+                                                        <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> Warning: Not all messages in this operation will be retried because ServiceControl had to restart during the request operation.
                                                     </span>
                                                 </div>
                                             </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -11,19 +11,23 @@
 
         <failed-message-tabs></failed-message-tabs>
 
-        <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
-
-        <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
         <div class="row">
-            <button type="button" class="btn btn-link btn-sm" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">
-                <p class="lead">
-                    <i class="fa fa-sort-desc" aria-hidden="true" ng-show="vm.showHistoricRetries"></i>
-                    <i class="fa fa-sort-asc" aria-hidden="true" ng-show="!vm.showHistoricRetries"></i>
-                    Last 10 successful group retries
-                </p>
-            </button>
+            <div class="col-sm-12">
+                <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
+
+                <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-12 list-section">
+                <h5>
+                    <span class="fake-link" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
+                    <span class="fake-link" aria-hidden="true" ng-show="!vm.showHistoricRetries"><i class="fa fa-angle-right" aria-hidden="true"></i> </span>
+                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 successful group retries</a>
+                </h5>
+            </div>
             <div class="col-sm-12" ng-show="vm.showHistoricRetries">
-                <div class="row box repeat-modify" ng-repeat="group in vm.historicGroups">
+                <div class="row box extra-box-padding repeat-modify" ng-repeat="group in vm.historicGroups">
                     <div class="col-sm-12">
                         <div class="row">
                             <div class="col-sm-12">
@@ -35,8 +39,9 @@
                                 
                                 <div class="row">
                                     <div class="col-sm-12">
-                                        <i class="fa fa-envelope pull-left"></i>
-                                        <p class="lead">Retry completed: <sp-moment date="{{group.completion_time}}"></sp-moment></p>
+                                        <p class="metadata">
+                                            <span class="metadata"><i class="fa fa-envelope"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
+                                        </p>
                                     </div>
                                 </div>
                             </div>
@@ -63,8 +68,9 @@
         </div>
         
         <div class="row" ng-show="vm.exceptionGroups.length > 0">
-            <p class="lead">Failed message groups</p>
-            <div class="col-sm-12" ng-show="vm.exceptionGroups.length">
+            <div class="col-sm-12 list-section" ng-show="vm.exceptionGroups.length">
+                <h5>Failed message groups</h5>
+            </div>
                 <div class="row box wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups">
                     <div class="col-sm-12">
                         <div class="row">
@@ -97,11 +103,19 @@
                                 </div>
                                 <div class="row" ng-show="!vm.canBeRetried(group)">
                                     <div class="col-sm-12">
-                                        <i class="fa fa-spinner fa-pulse pull-left"></i>
-                                        <p class="lead">{{group.workflow_state.message}} - {{group.workflow_state.total}}% done</p>
+                                        <div class="panel panel-default">
+                                            <div class="panel-body">
+                                                <p>{{group.workflow_state.message}}</p>
+                                                <div class="progress">
+                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em;">
+                                                        0%
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
+                             </div>
                         </div>
                     </div>
                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -13,11 +13,11 @@
 
         <div class="row" ng-show="vm.historicGroups.length">
             <div class="col-sm-12 list-section">
-                <h5>
-                    <span class="fake-link" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
+                <h6>
+                    <span class="no-link-underline" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
                     <span class="fake-link" aria-hidden="true" ng-show="!vm.showHistoricRetries"><i class="fa fa-angle-right" aria-hidden="true"></i> </span>
                     <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed group retries</a>
-                </h5>
+                </h6>
             </div>
             <div class="col-sm-12" ng-show="vm.showHistoricRetries">
                 <div class="row box extra-box-padding repeat-modify" ng-repeat="group in vm.historicGroups">
@@ -75,9 +75,9 @@
 
         <div class="row" ng-show="vm.exceptionGroups.length > 0">
             <div class="col-sm-12 list-section" ng-show="vm.exceptionGroups.length">
-                <h5>Failed message groups</h5>
+                <h6>Failed message groups</h6>
             </div>
-                <div class="row box wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups">
+                <div class="row box box-no-interaction wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups">
                     <div class="col-sm-12">
                         <div class="row">
                             <div class="col-sm-12">
@@ -87,9 +87,10 @@
                                         <p class="metadata" ng-show="!vm.isBeingRetried(group)">
                                             <span class="metadata"><i class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>
 
+                                            <span class="metadata"><i class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
+
                                             <span class="metadata"><i class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
-                                            <span class="metadata"><i class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
                                             <span class="metadata"><i class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.completion_time}}"></sp-moment></span>
                                             <span class="metadata" ng-show="group.workflow_state.status !== 'completed'"><i class="fa fa-clock-o"></i> Retry started: <sp-moment empty-message="never" date="{{group.start_time}}"></sp-moment></span>
                                         </p>
@@ -97,13 +98,13 @@
                                 </div>
                                 <div class="row" ng-show="!vm.isBeingRetried(group)">
                                     <div class="col-sm-12">
-                                        <button type="button" class="btn btn-link btn-sm hidden-sm-down" title="View messages in this Group" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0">
-                                            View Messages
+                                        <button type="button" class="btn btn-link btn-sm hidden-sm-down" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0">
+                                            <span class="no-link-underline"><i class="fa fa-eye"></i> </span>View Messages
                                         </button>
-                                        <button type="button" class="btn btn-link btn-sm" title="Retry messages in this Group" confirm-click="vm.retryExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to retry this group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry this group of {{group.count}} messages?">
-                                            Retry Group
+                                        <button type="button" class="btn btn-link btn-sm" confirm-click="vm.retryExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to retry this group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry this group of {{group.count}} messages?" confirm-second-paragraph="NOTE: Additional failed messages will be automatically included in the retry operation while it is queued.">
+                                            Request retry
                                         </button>
-                                        <button type="button" class="btn btn-link btn-sm" title="Archive messages in this Group" confirm-click="vm.archiveExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to archive this group?" confirm-message="If you do, they will not be available for Retry.">
+                                        <button type="button" class="btn btn-link btn-sm" confirm-click="vm.archiveExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to archive this group?" confirm-message="If you do, they will not be available for Retry.">
                                             Archive Group
                                         </button>
                                     </div>
@@ -112,19 +113,23 @@
                                     <div class="col-sm-12">
                                         <div class="panel panel-default">
                                             <div class="panel-body">
-                                                <p>{{group.workflow_state.message}}</p>
+                                                <p class="bulk-retry-progress-status">{{group.workflow_state.message}}</p>
                                                 <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status !== 'waiting'">
                                                     <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}%;">
                                                         {{group.workflow_state.total | number : 0}}%
                                                     </div>
                                                 </div>
+                                                <div>
+                                                    <span class="metadata"><i class="fa fa-envelope"></i> Messages to retry: {{group.retry_remaining_count | number}}</span>
+                                                    <span class="metadata"><i class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.start_time}}"></sp-moment></span>
+                                                </div>
                                             </div>
-                                            <p ng-show="{{group.retry_failed}}">
-                                                During retry an error occured which might have caused that not all messages were retried. 
+                                            <div ng-show="{{group.retry_failed}}">
+                                                Error occurred during  retry request. Not all messages were retried. 
                                                 <span>Current number of messages in a group: {{group.count | number}}</span>
                                                 <span>Current number of messages being retried: {{group.retry_remaining_count | number}}</span>
                                                 <span>Amount of new messages: {{(group.count - group.retry_remaining_count) | number}}</span>
-                                            </p>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -16,7 +16,7 @@
                 <h6>
                     <span class="no-link-underline" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
                     <span class="fake-link" aria-hidden="true" ng-show="!vm.showHistoricRetries"><i class="fa fa-angle-right" aria-hidden="true"></i> </span>
-                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed group retries</a>
+                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed retry requests</a>
                 </h6>
             </div>
             <div class="col-sm-12" ng-show="vm.showHistoricRetries">
@@ -53,11 +53,11 @@
         </div>
 
         <div class="row">
-            <div class="cpl-xs-12 col-md-8 list-section" ng-show="vm.exceptionGroups.length">
+            <div class="col-xs-12 col-sm-6 list-section" ng-show="vm.exceptionGroups.length">
                 <h6>Failed message groups</h6>
             </div>
 
-            <div class="col-md-4 col-xs-12 toolbar-menus no-side-padding">
+            <div class="col-sm-6 col-xs-12 toolbar-menus no-side-padding">
 
                 <div class="msg-group-menu dropdown">
                     <label class="control-label">Group by:</label>
@@ -124,27 +124,47 @@
                                             <div class="panel-body">
                                                 <ul class="retry-request-progress">
                                                     <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('waiting', group.workflow_state.status)">
-                                                        <p class="bulk-retry-progress-status">Retry request initiated...</p>        
+                                                        <div class="bulk-retry-progress-status">Initialize retry request...</div>        
                                                     </li>
                                                     <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('preparing', group.workflow_state.status)">
-                                                        <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Step 1/2 - Preparing messages...</p>
-                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
-                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
-                                                                {{group.workflow_state.total | number : 0}}%
+                                                        
+                                                        <div class="row">
+                                                            <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
+                                                                <div class="bulk-retry-progress-status">Prepare messages...</div>
+                                                            </div>
+
+                                                            <div class="col-xs-12 col-sm-6">
+                                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
+                                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
+                                                                        {{group.workflow_state.total | number : 0}}%
+                                                                    </div>
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     </li>
                                                     <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('forwarding', group.workflow_state.status)">
-                                                        <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Step 2/2 - Sending messages to retry...</p>
-                                                        <p ng-show="group.workflow_state.status === 'queued'">Queued</p>
-                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
-                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
-                                                                {{group.workflow_state.total | number : 0}}%
+
+                                                        <div class="row">
+                                                            <div class="col-xs-9 col-sm-4 col-md-3 no-side-padding">
+                                                                <div class="bulk-retry-progress-status">Send messages to retry...</div>
                                                             </div>
-                                                        </div>
-                                                    </li>
+                                                            <div class="col-xs-3 col-sm-3 retry-op-queued" ng-show="group.workflow_state.status === 'queued'">
+                                                                (Queued)
+                                                            </div>
+                                                            <div class="col-xs-12 col-sm-6">
+
+                                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
+                                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
+                                                                        {{group.workflow_state.total | number : 0}}%
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+</li>
                                                     <li ng-show="group.workflow_state.status === 'completed'">
-                                                        <p class="retry-completed bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-check"></i> Retry request operation complete</p>
+                                                        <div class="retry-completed bulk-retry-progress-status">Retry request completed</div>
+                                                        <div class="danger" ng-show="{{group.workflow_state.failed}}">
+                                                            <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> Warning: Not all messages will be retried because ServiceControl had to restart during the request operation.
+                                                        </div>
                                                         <button type="button" class="btn btn-default btn-primary btn-xs" ng-show="group.need_user_acknowledgement == true" ng-click="vm.acknowledgeGroup(group)">
                                                             Dismiss
                                                         </button>
@@ -152,14 +172,12 @@
                                                 </ul>
 
                                                 <div>
-                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to send: {{(group.retry_remaining_count || group.count) | number}}</span>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
                                                 </div>
-                                                <div ng-show="{{group.workflow_state.failed}}">
-                                                    <span class="danger">
-                                                        <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> Warning: Not all messages in this operation will be retried because ServiceControl had to restart during the request operation.
-                                                    </span>
-                                                </div>
+                                                
+                                                    
+                                                
                                             </div>
 
                                         </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -33,8 +33,8 @@
                                 <div class="row">
                                     <div class="col-sm-12">
                                         <p class="metadata">
-                                            <span class="metadata"><i class="fa fa-envelope"></i> Retry request started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
-                                            <span class="metadata"><i class="fa fa-envelope"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata"><i class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
+                                            <span class="metadata"><i class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
                                             <span class="metadata"><i class="fa fa-envelope"></i> Messages retried: {{group.number_of_messages_processed}}</span>
                                         </p>
                                         <p ng-show="{{group.was_failed}}">
@@ -119,6 +119,12 @@
                                                     </div>
                                                 </div>
                                             </div>
+                                            <p ng-show="{{group.retry_failed}}">
+                                                During retry an error occured which might have caused that not all messages were retried. 
+                                                <span>Current number of messages in a group: {{group.count | number}}</span>
+                                                <span>Current number of messages being retried: {{group.retry_remaining_count | number}}</span>
+                                                <span>Amount of new messages: {{(group.count - group.retry_remaining_count) | number}}</span>
+                                            </p>
                                         </div>
                                     </div>
                                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -120,7 +120,7 @@
                                 </div>
                                 <div class="row" ng-show="vm.isBeingRetried(group)">
                                     <div class="col-sm-12">
-                                        <div class="panel panel-default">
+                                        <div class="panel panel-default panel-retry">
                                             <div class="panel-body">
                                                 <ul class="retry-request-progress">
                                                     <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('waiting', group.workflow_state.status)">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -92,7 +92,7 @@
 
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
-                                            <span class="metadata"><i aria-hidden="true" class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.last_retry_completion_time}}"></sp-moment></span>
                                         </p>
                                     </div>
                                 </div>
@@ -121,7 +121,7 @@
                                                 </div>
                                                 <div>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
-                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.start_time}}"></sp-moment></span>
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
                                                 </div>
                                                 <div ng-show="{{group.retry_failed}}">
                                                     <span class="danger">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -84,7 +84,7 @@
                                 <div class="row box-header">
                                     <div class="col-sm-12" ng-click="vm.viewExceptionGroup(group)">
                                         <p class="lead break"> {{group.title}}</p>
-                                        <p class="metadata">
+                                        <p class="metadata" ng-show="!vm.isBeingRetried(group)">
                                             <span class="metadata"><i class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>
 
                                             <span class="metadata"><i class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
@@ -95,20 +95,20 @@
                                         </p>
                                     </div>
                                 </div>
-                                <div class="row" ng-show="vm.canBeRetried(group)">
+                                <div class="row" ng-show="!vm.isBeingRetried(group)">
                                     <div class="col-sm-12">
                                         <button type="button" class="btn btn-link btn-sm hidden-sm-down" title="View messages in this Group" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0">
                                             View Messages
                                         </button>
-                                        <button type="button" class="btn btn-link btn-sm" title="Retry messages in this Group" confirm-click="vm.retryExceptionGroup(group)" ng-disabled="group.count == 0 || !vm.canBeRetried(group)" confirm-title="Are you sure you want to retry this group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry this group of {{group.count}} messages?">
+                                        <button type="button" class="btn btn-link btn-sm" title="Retry messages in this Group" confirm-click="vm.retryExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to retry this group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry this group of {{group.count}} messages?">
                                             Retry Group
                                         </button>
-                                        <button type="button" class="btn btn-link btn-sm" title="Archive messages in this Group" confirm-click="vm.archiveExceptionGroup(group)" ng-disabled="group.count == 0 || !vm.canBeRetried(group)" confirm-title="Are you sure you want to archive this group?" confirm-message="If you do, they will not be available for Retry.">
+                                        <button type="button" class="btn btn-link btn-sm" title="Archive messages in this Group" confirm-click="vm.archiveExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to archive this group?" confirm-message="If you do, they will not be available for Retry.">
                                             Archive Group
                                         </button>
                                     </div>
                                 </div>
-                                <div class="row" ng-show="!vm.canBeRetried(group)">
+                                <div class="row" ng-show="vm.isBeingRetried(group)">
                                     <div class="col-sm-12">
                                         <div class="panel panel-default">
                                             <div class="panel-body">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -84,7 +84,7 @@
                         <div class="row">
                             <div class="col-sm-12">
                                 <div class="row box-header">
-                                    <div class="col-sm-12" ng-click="vm.viewExceptionGroup(group)">
+                                    <div class="col-sm-12">
                                         <p class="lead break"> {{group.title}}</p>
                                         <p class="metadata" ng-show="!vm.isBeingRetried(group)">
                                             <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -106,7 +106,7 @@
                                         <div class="panel panel-default">
                                             <div class="panel-body">
                                                 <p>{{group.workflow_state.message}}</p>
-                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status !== 'working'">
+                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status !== 'waiting'">
                                                     <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}%;">
                                                         {{group.workflow_state.total}}%
                                                     </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -16,7 +16,7 @@
                 <h5>
                     <span class="fake-link" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
                     <span class="fake-link" aria-hidden="true" ng-show="!vm.showHistoricRetries"><i class="fa fa-angle-right" aria-hidden="true"></i> </span>
-                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last {{vm.historicGroups.length}} completed group retries</a>
+                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed group retries</a>
                 </h5>
             </div>
             <div class="col-sm-12" ng-show="vm.showHistoricRetries">
@@ -41,6 +41,7 @@
                         </div>
                     </div>
                 </div>
+                <p ng-show="vm.historicGroups.length < 10">There are only {{vm.historicGroups.length}} completed groups.</p>
             </div>
         </div>
 

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -23,7 +23,7 @@
                 <h5>
                     <span class="fake-link" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
                     <span class="fake-link" aria-hidden="true" ng-show="!vm.showHistoricRetries"><i class="fa fa-angle-right" aria-hidden="true"></i> </span>
-                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 successful group retries</a>
+                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed group retries</a>
                 </h5>
             </div>
             <div class="col-sm-12" ng-show="vm.showHistoricRetries">
@@ -79,12 +79,13 @@
                                     <div class="col-sm-12" ng-click="vm.viewExceptionGroup(group)">
                                         <p class="lead break"> {{group.title}}</p>
                                         <p class="metadata">
-                                            <span class="metadata"><i class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span></span>
+                                            <span class="metadata"><i class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>
 
                                             <span class="metadata"><i class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
                                             <span class="metadata"><i class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
                                             <span class="metadata"><i class="fa fa-refresh"></i> Last retried: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata" ng-show="group.workflow_state.status !== 'completed'"><i class="fa fa-clock-o"></i> Retry started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
                                         </p>
                                     </div>
                                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -123,10 +123,10 @@
                                         <div class="panel panel-default">
                                             <div class="panel-body">
                                                 <ul class="retry-request-progress">
-                                                    <li ng-class="{active: group.workflow_state.status === 'waiting'}">
+                                                    <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('waiting', group.workflow_state.status)">
                                                         <p class="bulk-retry-progress-status">Retry request initiated...</p>        
                                                     </li>
-                                                    <li ng-class="{active: group.workflow_state.status === 'preparing'}">
+                                                    <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('preparing', group.workflow_state.status)">
                                                         <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Step 1/2 - Preparing messages...</p>
                                                         <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
                                                             <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
@@ -134,24 +134,23 @@
                                                             </div>
                                                         </div>
                                                     </li>
-                                                    <li ng-class="{active: group.workflow_state.status === 'queued'}">
-                                                        <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Retry request in progress. Next Step - Queued.</p>
-                                                    </li>
-                                                    <li ng-class="{active: group.workflow_state.status === 'forwarding'}">
+                                                    <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClasses('forwarding', group.workflow_state.status)">
                                                         <p class="bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-arrow-right"></i> Step 2/2 - Sending messages to retry...</p>
+                                                        <p ng-show="group.workflow_state.status === 'queued'">Queued</p>
                                                         <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
                                                             <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}% ; ">
                                                                 {{group.workflow_state.total | number : 0}}%
                                                             </div>
                                                         </div>
                                                     </li>
-                                                    <li ng-class="{active: group.workflow_state.status === 'completed'}">
+                                                    <li ng-show="group.workflow_state.status === 'completed'">
                                                         <p class="retry-completed bulk-retry-progress-status"><i aria-hidden="true" class="fa fa-check"></i> Retry request operation complete</p>
-                                                        <button type="button" class="btn btn-default btn-primary btn-xs" ng-show="group.need_user_acknowledgement == true" confirm-click="vm.acknowledgeGroup(group)" confirm-title="Are you sure you want to acknowledge this group?">
+                                                        <button type="button" class="btn btn-default btn-primary btn-xs" ng-show="group.need_user_acknowledgement == true" ng-click="vm.acknowledgeGroup(group)">
                                                             Dismiss
                                                         </button>
                                                     </li>
                                                 </ul>
+
                                                 <div>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -108,7 +108,7 @@
                                                 <p>{{group.workflow_state.message}}</p>
                                                 <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status !== 'waiting'">
                                                     <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}%;">
-                                                        {{group.workflow_state.total}}%
+                                                        {{group.workflow_state.total | number : 0}}%
                                                     </div>
                                                 </div>
                                             </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -11,7 +11,7 @@
 
         <failed-message-tabs></failed-message-tabs>
 
-        <div class="row" ng-show="vm.historicGroups.length">
+        <div class="row">
             <div class="col-sm-12 list-section">
                 <h6>
                     <span class="no-link-underline" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
@@ -20,7 +20,8 @@
                 </h6>
             </div>
             <div class="col-sm-12" ng-show="vm.showHistoricRetries">
-                <div class="row box extra-box-padding repeat-modify" ng-repeat="group in vm.historicGroups">
+                <no-data ng-show="vm.historicGroups.length === 0" title="message group retries" message="No group retry requests have ever been completed"></no-data>
+                <div class="row box extra-box-padding repeat-modify" ng-repeat="group in vm.historicGroups" ng-show="vm.historicGroups.length">
                     <div class="col-sm-12">
                         <div class="row">
                             <div class="col-sm-12">
@@ -29,7 +30,7 @@
                                         <p class="lead break"> {{group.originator}}</p>
                                     </div>
                                 </div>
-                                
+
                                 <div class="row">
                                     <div class="col-sm-12">
                                         <p class="metadata">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -33,12 +33,12 @@
                                 <div class="row">
                                     <div class="col-sm-12">
                                         <p class="metadata">
-                                            <span class="metadata"><i class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
-                                            <span class="metadata"><i class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
-                                            <span class="metadata"><i class="fa fa-envelope"></i> Messages retried: {{group.number_of_messages_processed}}</span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages retried: {{group.number_of_messages_processed}}</span>
                                         </p>
-                                        <p ng-show="{{group.was_failed}}">
-                                            During retry an error occured which might have cause that not all messages were retried. Please verify if there are no more failed messages.
+                                        <p class="danger" ng-show="{{group.was_failed}}">
+                                            <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> Warning: Not all messages in this operation have been retried because ServiceControl had to restart during the operation.
                                         </p>
                                     </div>
                                 </div>
@@ -85,13 +85,13 @@
                                     <div class="col-sm-12" ng-click="vm.viewExceptionGroup(group)">
                                         <p class="lead break"> {{group.title}}</p>
                                         <p class="metadata" ng-show="!vm.isBeingRetried(group)">
-                                            <span class="metadata"><i class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.retry_remaining_count > 0">(currently retrying {{group.retry_remaining_count | number}})</span></span>
 
-                                            <span class="metadata"><i class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
 
-                                            <span class="metadata"><i class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
-                                            <span class="metadata"><i class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata"><i aria-hidden="true" class="fa fa-refresh"></i> Last retried: <sp-moment empty-message="never" date="{{group.completion_time}}"></sp-moment></span>
                                             <span class="metadata" ng-show="group.workflow_state.status !== 'completed'"><i class="fa fa-clock-o"></i> Retry started: <sp-moment empty-message="never" date="{{group.start_time}}"></sp-moment></span>
                                         </p>
                                     </div>
@@ -99,13 +99,13 @@
                                 <div class="row" ng-show="!vm.isBeingRetried(group)">
                                     <div class="col-sm-12">
                                         <button type="button" class="btn btn-link btn-sm hidden-sm-down" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0">
-                                            <span class="no-link-underline"><i class="fa fa-eye"></i> </span>View Messages
+                                            <i aria-hidden="true" class="fa fa-eye no-link-underline">&nbsp</i>View Messages
                                         </button>
                                         <button type="button" class="btn btn-link btn-sm" confirm-click="vm.retryExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to retry this group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry this group of {{group.count}} messages?" confirm-second-paragraph="NOTE: Additional failed messages will be automatically included in the retry operation while it is queued.">
-                                            Request retry
+                                            <i aria-hidden="true" class="fa fa-refresh no-link-underline">&nbsp</i>Request retry
                                         </button>
                                         <button type="button" class="btn btn-link btn-sm" confirm-click="vm.archiveExceptionGroup(group)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" confirm-title="Are you sure you want to archive this group?" confirm-message="If you do, they will not be available for Retry.">
-                                            Archive Group
+                                            <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Archive Group
                                         </button>
                                     </div>
                                 </div>
@@ -120,16 +120,16 @@
                                                     </div>
                                                 </div>
                                                 <div>
-                                                    <span class="metadata"><i class="fa fa-envelope"></i> Messages to retry: {{group.retry_remaining_count | number}}</span>
-                                                    <span class="metadata"><i class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.start_time}}"></sp-moment></span>
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to retry: {{group.retry_remaining_count | number}}</span>
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.start_time}}"></sp-moment></span>
+                                                </div>
+                                                <div ng-show="{{group.retry_failed}}">
+                                                    <span class="danger">
+                                                        <i aria-hidden="true" class="fa fa-exclamation-triangle danger"></i> Warning: Not all messages in this operation will be retried because ServiceControl had to restart during the operation.
+                                                    </span>
                                                 </div>
                                             </div>
-                                            <div ng-show="{{group.retry_failed}}">
-                                                Error occurred during  retry request. Not all messages were retried. 
-                                                <span>Current number of messages in a group: {{group.count | number}}</span>
-                                                <span>Current number of messages being retried: {{group.retry_remaining_count | number}}</span>
-                                                <span>Amount of new messages: {{(group.count - group.retry_remaining_count) | number}}</span>
-                                            </div>
+                                            
                                         </div>
                                     </div>
                                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -120,7 +120,7 @@
                                                     </div>
                                                 </div>
                                                 <div>
-                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to retry: {{group.retry_remaining_count | number}}</span>
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to retry: {{(group.retry_remaining_count || group.count) | number}}</span>
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.start_time}}"></sp-moment></span>
                                                 </div>
                                                 <div ng-show="{{group.retry_failed}}">

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -123,7 +123,7 @@
                                         <div class="panel panel-default">
                                             <div class="panel-body">
                                                 <p class="bulk-retry-progress-status">{{group.workflow_state.message}}</p>
-                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status !== 'waiting'">
+                                                <div class="progress bulk-retry-progress" ng-hide="group.workflow_state.status === 'waiting' || (group.workflow_state.status === 'preparing' && group.workflow_state.total === 100)">
                                                     <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}%;">
                                                         {{group.workflow_state.total | number : 0}}%
                                                     </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -33,7 +33,12 @@
                                 <div class="row">
                                     <div class="col-sm-12">
                                         <p class="metadata">
+                                            <span class="metadata"><i class="fa fa-envelope"></i> Retry request started: <sp-moment date="{{group.start_time}}"></sp-moment></span>
                                             <span class="metadata"><i class="fa fa-envelope"></i> Retry request completed: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata"><i class="fa fa-envelope"></i> Messages retried: {{group.number_of_messages_processed}}</span>
+                                        </p>
+                                        <p ng-show="{{group.was_failed}}">
+                                            During retry an error occured which might have cause that not all messages were retried. Please verify if there are no more failed messages.
                                         </p>
                                     </div>
                                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -98,7 +98,7 @@
                                 <div class="row" ng-show="!vm.canBeRetried(group)">
                                     <div class="col-sm-12">
                                         <i class="fa fa-spinner fa-pulse pull-left"></i>
-                                        <p class="lead">{{group.workflow_state.getDisplayMessage()}}</p>
+                                        <p class="lead">{{group.workflow_state.message}} - {{group.workflow_state.total}}% done</p>
                                     </div>
                                 </div>
                             </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -53,17 +53,16 @@
         </div>
 
         <div class="row">
-            <div class="col-sm-12">
-                <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
-                 <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
+            <div class="cpl-xs-12 col-md-8 list-section" ng-show="vm.exceptionGroups.length">
+                <h6>Failed message groups</h6>
             </div>
-        </div>
-        
-        <div class="row" ng-show="vm.availableClassifiers.length && vm.initialLoadComplete">
-            <div class="col-sm-12">
-                <div class="btn-group pull-right">
-                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="hidden-xs hidden-sm">Grouped by </span>{{vm.selectedClassification}}
+
+            <div class="col-md-4 col-xs-12 toolbar-menus no-side-padding">
+
+                <div class="msg-group-menu dropdown">
+                    <label class="control-label">Group by:</label>
+                    <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {{vm.selectedClassification}}
                         <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu">
@@ -75,10 +74,19 @@
             </div>
         </div>
 
-        <div class="row" ng-show="vm.exceptionGroups.length > 0">
-            <div class="col-sm-12 list-section" ng-show="vm.exceptionGroups.length">
-                <h6>Failed message groups</h6>
+
+        <div class="row">
+            <div class="col-sm-12">
+                <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
+                 <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
             </div>
+        </div>
+        
+        
+
+
+            <div class="" ng-show="vm.exceptionGroups.length > 0">
+
                 <div class="row box box-no-interaction wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups">
                     <div class="col-sm-12">
                         <div class="row">
@@ -130,11 +138,11 @@
                                                     </span>
                                                 </div>
                                             </div>
-                                            
+
                                         </div>
                                     </div>
                                 </div>
-                             </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -173,10 +173,12 @@
                                                     <div class="op-metadata">
                                                         <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages to send: {{(group.retry_remaining_count || group.count) | number}}</span>
                                                         <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry requested: <sp-moment date="{{group.retry_start_time}}"></sp-moment></span>
+														<span class="metadata" ng-show="group.workflow_state.status === 'completed'"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.retry_completion_time}}"></sp-moment></span>
                                                     </div>
 
 
 
+                                                    
                                                 </div>
 
                                             </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -84,7 +84,7 @@
                                             <span class="metadata"><i class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
 
                                             <span class="metadata"><i class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
-                                            <span class="metadata"><i class="fa fa-clock-o"></i> Last retried: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
+                                            <span class="metadata"><i class="fa fa-refresh"></i> Last retried: <sp-moment date="{{group.completion_time}}"></sp-moment></span>
                                         </p>
                                     </div>
                                 </div>
@@ -106,9 +106,9 @@
                                         <div class="panel panel-default">
                                             <div class="panel-body">
                                                 <p>{{group.workflow_state.message}}</p>
-                                                <div class="progress">
-                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em;">
-                                                        0%
+                                                <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status !== 'working'">
+                                                    <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.workflow_state.total}}%;">
+                                                        {{group.workflow_state.total}}%
                                                     </div>
                                                 </div>
                                             </div>

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -60,7 +60,7 @@
                     <div class="col-sm-12" ng-click="vm.toggleRowSelect(message)" ng-mouseenter="message.hover = true" ng-mouseleave="message.hover = false">
                         <div class="row" ng-class="{rowSelected: message.selected == true}" style="cursor: pointer;">
                             <div class="check col-md-1">
-                                <input isolate-click type="checkbox" id="onoffswitch{{$id}}" name="onoffswitch{{$id}}" ng-disabled="message.retried || message.archived" ng-checked="message.selected" ng-click="vm.toggleRowSelect(message)" ng-class="{check-hover: message.hover}">
+                                <input isolate-click type="checkbox" id="onoffswitch{{$id}}" name="onoffswitch{{$id}}" ng-disabled="message.retried || message.archived" ng-checked="message.selected" ng-click="vm.toggleRowSelect(message)" ng-class="{'check-hover': message.hover}">
                             </div>
                             <div class="col-sm-9">
                                 <div class="row box-header">

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -57,9 +57,9 @@
         <div ng-show="vm.failedMessages.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup)" infinite-scroll-distance="0" infinite-scroll-disabled="vm.disableLoadingData">
 
                 <div class="row box repeat-item" ng-repeat="message in vm.failedMessages">
-                    <div class="col-sm-12" ng-click="vm.toggleRowSelect(message)">
+                    <div class="col-sm-12" ng-click="vm.toggleRowSelect(message)" ng-mouseenter="message.hover = true" ng-mouseleave="message.hover = false">
                         <div class="row" ng-class="{rowSelected: message.selected == true}" style="cursor: pointer;">
-                            <div class="check col-md-1">
+                            <div class="check col-md-1" ng-class="{hovered: message.hover}">
                                 <input isolate-click type="checkbox" id="onoffswitch{{$id}}" name="onoffswitch{{$id}}" ng-disabled="message.retried || message.archived" ng-checked="message.selected" ng-click="vm.toggleRowSelect(message)">
                             </div>
                             <div class="col-sm-9">

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -59,8 +59,8 @@
                 <div class="row box repeat-item" ng-repeat="message in vm.failedMessages">
                     <div class="col-sm-12" ng-click="vm.toggleRowSelect(message)" ng-mouseenter="message.hover = true" ng-mouseleave="message.hover = false">
                         <div class="row" ng-class="{rowSelected: message.selected == true}" style="cursor: pointer;">
-                            <div class="check col-md-1" ng-class="{hovered: message.hover}">
-                                <input isolate-click type="checkbox" id="onoffswitch{{$id}}" name="onoffswitch{{$id}}" ng-disabled="message.retried || message.archived" ng-checked="message.selected" ng-click="vm.toggleRowSelect(message)">
+                            <div class="check col-md-1">
+                                <input isolate-click type="checkbox" id="onoffswitch{{$id}}" name="onoffswitch{{$id}}" ng-disabled="message.retried || message.archived" ng-checked="message.selected" ng-click="vm.toggleRowSelect(message)" ng-class="{check-hover: message.hover}">
                             </div>
                             <div class="col-sm-9">
                                 <div class="row box-header">

--- a/src/SmokeTest.Client/Program.cs
+++ b/src/SmokeTest.Client/Program.cs
@@ -28,7 +28,7 @@ class Program
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.WriteLine("-------------------------------------");
                 Console.WriteLine("[ A ] Send 1 good Message");
-                Console.WriteLine("[ B ] Send 10 bad Messages");
+                Console.WriteLine("[ B ] Send 1000 bad Messages");
                 Console.WriteLine("[ C ] Send Infinite bad Messages ");
                 Console.WriteLine("[ Q ] Quit");
                 Console.WriteLine("-------------------------------------");
@@ -47,7 +47,7 @@ class Program
                         break;
                     case ConsoleKey.B:
                         
-                        for (var i = 0; i < 10; i++)
+                        for (var i = 0; i < 1000; i++)
                         {
                             SendMessage(bus, true, text);
                         }


### PR DESCRIPTION
Support for tracking progress on retry requests performed on failure groups.

Retry requests may take a while to finish. This feature lets Service Pulse users monitor the state and progress of operations initiated, both by them and others. Users can track this across different browser sessions.

Connects to Particular/PlatformDevelopment#936
