### PR TITLE
Rename mute to dismiss

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -831,11 +831,6 @@ nav {
     overflow-y: scroll;
 }
 
-.no-side-padding {
-    padding-right: 0;
-    padding-left: 0;
-}
-
 .row.list-count {
     margin-left: -10px;
     font-weight: bold;
@@ -910,6 +905,11 @@ p.lead hard-wrap.ng-binding {
     color: #777f7f;
 }
 
+.no-side-padding {
+        padding-right: 0;
+        padding-left: 0;
+}
+
 @media only screen and (min-width: 993px) {
     .filter-period-menu {
     margin-right: 0px;
@@ -964,11 +964,11 @@ p.lead hard-wrap.ng-binding {
     .filter-toolbar, .action-toolbar {
         margin-top: 2px;
     }
-
-    div.sp-pull-right {
+    
+    div.sp-pull-right { 
         display: inline-block;
         float: none;
-        margin-top: 4px;
+        margin-top: 4px;    
     }
 
 }

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -134,7 +134,7 @@
             });
         }
 
-        function muteCustomChecks(customCheck) {
+        function dismissCustomChecks(customCheck) {
             var url = uri.join(scConfig.service_control_url, 'customchecks', customCheck.id);
 
             $http.delete(url)
@@ -265,7 +265,7 @@
             getTotalPendingRetries: getTotalPendingRetries,
             getFailingCustomChecks: getFailingCustomChecks,
             getFailedMessageStats: getFailedMessageStats,
-            muteCustomChecks: muteCustomChecks,
+            dismissCustomChecks: dismissCustomChecks,
             retryAllFailedMessages: retryAllFailedMessages,
             retryPendingMessagesForQueue: retryPendingMessagesForQueue,
             retryFailedMessages: retryFailedMessages,

--- a/src/ServicePulse.Host/app/js/views/configuration/configuration.html
+++ b/src/ServicePulse.Host/app/js/views/configuration/configuration.html
@@ -18,7 +18,7 @@
         <div class="row">
             <div class="col-sm-12">
                 <div class="row box box-no-click" ng-class="{'box-info': e.monitor_heartbeat, 'box-danger':  !e.monitor_heartbeat}" ng-repeat="e in model.endpoints | orderBy:'name'">
-                    <div class="col-sm-12">
+                    <div class="col-sm-12 no-side-padding">
                         <div class="row">
                             <div class="col-xs-3 col-sm-2 col-lg-1">
                                 <div class="onoffswitch">

--- a/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.controller.js
+++ b/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.controller.js
@@ -22,8 +22,8 @@
             load(page++);
         };
 
-        $scope.mute = function (row) {
-            serviceControlService.muteCustomChecks(row);
+        $scope.dismiss = function (row) {
+            serviceControlService.dismissCustomChecks(row);
         };
 
         var notifier = notifyService();

--- a/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
+++ b/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
@@ -17,12 +17,12 @@
             <div class="col-sm-12">
                 <div infinite-scroll="loadMoreResults()" infinite-scroll-distance="0" infinite-scroll-disabled="disableLoadingData">
                     <div class="row box box-warning box-no-click" ng-repeat="item in model.data | orderBy: '-reported_at'">
-                        <div class="col-sm-12">
+                        <div class="col-sm-12 no-side-padding">
                             <div class="row">
 
-                                <div class="col-sm-10">
+                                <div class="col-xs-10">
                                     <div class="row box-header">
-                                        <div class="col-sm-12">
+                                        <div class="col-sm-12 no-side-padding">
                                             <p class="lead">{{item.failure_reason}}</p>
                                             <p>{{item.custom_check_id}} </p>
                                             <p>{{item.category}} reported by {{item.originating_endpoint.name}} on {{item.originating_endpoint.host}} <sp-moment date="{{item.reported_at}}"></sp-moment>
@@ -30,9 +30,9 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="col-sm-2">
+                                <div class="col-xs-2 pull-right">
                                     <button type="button" class="btn btn-default pull-right" title="Dismiss this custom check so it doesn't show up as an alert" ng-click="dismiss(item)">
-                                        <i>Dismiss</i>
+                                        Dismiss
                                     </button>
                                 </div>
                             </div>

--- a/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
+++ b/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
@@ -31,8 +31,8 @@
                                     </div>
                                 </div>
                                 <div class="col-sm-2">
-                                    <button type="button" class="btn btn-link btn-sm pull-right" title="Mute this custom check so it doesn't show up as an alert" ng-click="mute(item)">
-                                        <i>Mute</i>
+                                    <button type="button" class="btn btn-default pull-right" title="Dismiss this custom check so it doesn't show up as an alert" ng-click="dismiss(item)">
+                                        <i>Dismiss</i>
                                     </button>
                                 </div>
                             </div>

--- a/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
@@ -19,12 +19,12 @@
         <div class="row">
             <div class="col-sm-12">
                 <div class="row box box-no-click" ng-repeat="endpoint in model.active | orderBy:'name'">
-                    <div class="col-sm-12">
+                    <div class="col-sm-12 no-side-padding">
                         <div class="row">
 
-                            <div class="col-sm-12">
+                            <div class="col-sm-12 no-side-padding">
                                 <div class="row box-header">
-                                    <div class="col-sm-12">
+                                    <div class="col-sm-12 no-side-padding">
                                         <p class="lead hard-wrap">{{endpoint.name}}@{{endpoint.host_display_name}} </p>
                                         <p>
                                             latest heartbeat received <sp-moment date="{{endpoint.heartbeat_information.last_report_at}}"></sp-moment>
@@ -46,11 +46,11 @@
         <div class="row">
             <div class="col-sm-12">
                 <div class="row box box-no-click" ng-repeat="endpoint in model.inactive | orderBy:'name'">
-                    <div class="col-sm-12">
+                    <div class="col-sm-12 no-side-padding">
                         <div class="row">
-                            <div class="col-sm-12">
+                            <div class="col-sm-12 no-side-padding">
                                 <div class="row box-header">
-                                    <div class="col-sm-12">
+                                    <div class="col-sm-12 no-side-padding">
                                         <p class="lead hard-wrap">{{endpoint.name}}@{{endpoint.host_display_name}} </p>
                                         <p>
                                             latest heartbeat received <sp-moment date="{{endpoint.heartbeat_information.last_report_at}}"></sp-moment>


### PR DESCRIPTION
As an outcome of: https://github.com/Particular/ServiceControl/issues/793

@sergioc as we discussed today I renamed mute to dismiss and changed the style to be a button
![image](https://cloud.githubusercontent.com/assets/604826/19763680/7ec3163e-9c3f-11e6-8d73-09c0954a4530.png)

Please have a look
