### PR TITLE
Allow deep-linking to failed message groups

### DIFF
--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -36,7 +36,7 @@
 
         vm.viewExceptionGroup = function(group) {
             sharedDataService.set(group);
-            $location.path('/failedMessages');
+            $location.path('/failedMessages/' + group.id);
         };
 
         vm.acknowledgeGroup = function (group) {

--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -216,7 +216,11 @@
                 loadPromise = serviceControlService.getFailedMessagesForExceptionGroup(group.id, vm.sort, vm.page, vm.direction);
             }
 
-            loadPromise.then(function(response) {
+            loadPromise.then(function (response) {
+                if (group.count === 0) {
+                    group.count = response.total;
+                }
+
                 processLoadedMessages(response.data);
             });
         };

--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -6,6 +6,7 @@
         $scope,
         $timeout,
         $location,
+        $routeParams,
         scConfig,
         toastService,
         sharedDataService,
@@ -19,7 +20,7 @@
         vm.selectedExceptionGroup = sharedDataService.get();
 
         if (!vm.selectedExceptionGroup) {
-            vm.selectedExceptionGroup = { 'id': undefined, 'title': 'All Failed Messages', 'count': 0, 'initialLoad': true };
+            vm.selectedExceptionGroup = { 'id': $routeParams.groupId ? $routeParams.groupId : undefined, 'title': 'All Failed Messages', 'count': 0, 'initialLoad': true };
         }
 
         if (!vm.selectedExceptionGroup.hasOwnProperty('title')) {
@@ -227,6 +228,7 @@
         "$scope",
         "$timeout",
         "$location",
+        "$routeParams",
         "scConfig",
         "toastService",
         "sharedDataService",

--- a/src/ServicePulse.Host/app/js/views/failed_messages/route.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/route.js
@@ -2,7 +2,7 @@
     'use strict';
 
     function routeProvider($routeProvider) {
-        $routeProvider.when('/failedMessages', {
+        $routeProvider.when('/failedMessages/:groupId?', {
             data: {
                 pageTitle: 'Failed Messages'
             },


### PR DESCRIPTION
Allows for deep linking to failed message groups. This will provide users the ability to bookmark failed groups, or to send links to other people so that they can navigate directly tot he failed groups.

Connects to: https://github.com/Particular/ServicePulse/issues/394

Ping @Particular/servicepulse-maintainers for review.