### PR TITLE
Fix IE11 compatibility

### DIFF
--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -1,7 +1,7 @@
 ﻿<!doctype html>
 <html lang="en" ng-app="sc">
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"> 
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <style>
         /* This helps the ng-show/ng-hide animations start at the right place. */
         /* Since Angular has this but needs to load, this gives us the class early. */
@@ -57,6 +57,15 @@
 
 <toaster-container toaster-options="{'position-class': 'toast-bottom-right'}">
 </toaster-container>
+<!-- Polyfills -->
+<script type="text/javascript">
+    if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function (searchString, position) {
+            position = position || 0;
+            return this.substr(position, searchString.length) === searchString;
+        };
+    }
+</script>
 
 <!-- Vendor -->
 <script src="lib/jQuery/jquery.min.js"></script>

--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -109,7 +109,7 @@
         vm.retrySelected = function () {
             toastService.showInfo("Retrying " + vm.selectedIds.length + " messages...");
             serviceControlService.retryFailedMessages(vm.selectedIds)
-                .then(() => {
+                .then(function () {
                     vm.selectedIds = [];
 
                     vm.failedMessages = vm.failedMessages.filter(function(item) {
@@ -121,7 +121,7 @@
         vm.archiveSelected = function () {
             toastService.showInfo("Archiving " + vm.selectedIds.length + " messages...");
             serviceControlService.archiveFailedMessages(vm.selectedIds)
-                .then(() => {
+                .then(function () {
                     vm.selectedIds = [];
 
                     vm.failedMessages = vm.failedMessages.filter(function(item) {
@@ -139,7 +139,7 @@
                     notifier.notify('ArchiveGroupRequestRejected', group);
                 })
                 .finally(function () {
-                    
+
                 });
         }
 
@@ -161,10 +161,10 @@
                     notifier.notify('RetryGroupRequestRejected', group);
                 })
                 .finally(function () {
-                    
+
                 });
         }
-        
+
         vm.debugInServiceInsight = function (index) {
             var messageId = vm.failedMessages[index].message_id;
             var dnsName = scConfig.service_control_url.toLowerCase();
@@ -186,7 +186,7 @@
             vm.sort = sort;
             vm.direction = direction;
             setSortButtonText(sort, direction);
-            
+
             if (changeToMessagesTab) {
                 vm.activePageTab = "messages";
             }


### PR DESCRIPTION
fixes https://github.com/Particular/ServicePulse/issues/408
The minimal changeset required to make SP work from IE 11

It might be even easier to just use `substr` instead of `startsWith` to remove the polyfill again. Thoughts @Particular/servicepulse-maintainers ?