### PR TITLE
Optimize graph y-axis range

### DIFF
--- a/src/ServicePulse.Host/app/js/views/monitored-endpoints/monitored-endpoints.module.js
+++ b/src/ServicePulse.Host/app/js/views/monitored-endpoints/monitored-endpoints.module.js
@@ -17,10 +17,9 @@
                         var width = 130;
                         var margin = 2;
                         var average = d3.mean(scope.data);
-                        var max = d3.max(scope.data);
-                        var min = d3.min(scope.data) !== d3.max(scope.data) ? d3.min(scope.data) : 0;
+                        var max = Math.max(average * 1.5, d3.max(scope.data));
                         var scaleY = d3.scaleLinear()
-                            .domain([min, max])
+                            .domain([0, max])
                             .range([heigth - margin, margin]);
 
                         var scaleX = d3.scaleLinear()


### PR DESCRIPTION
* Min value is always 0 based to not cut away areas
* Max value is designed so that the average bar will always show up in case the current data points are smaller than the average (not an issue with the current implementation which calculates average based on the data points, but that will probably change)

the following graph shows how different data points & average values would look like with the current (left) implementation and the proposed changes (right). Each row contains the exact same data on both sides.

![image](https://user-images.githubusercontent.com/3524870/27685808-1a57a8fc-5cd0-11e7-988d-430200133534.png)
