### PR TITLE
Show a notification when a metrics endpoint isn't reachable

### DIFF
--- a/src/ServicePulse.Host.Tests/SpecsRunner.html
+++ b/src/ServicePulse.Host.Tests/SpecsRunner.html
@@ -31,6 +31,7 @@
     <script src="../ServicePulse.Host/app/bower_components/angular-ui-select/dist/select.js"></script>
     <script src="../ServicePulse.Host/app/bower_components/d3/d3.js"></script>
     <script src="../ServicePulse.Host/app/bower_components/rxjs/dist/rx.all.js"></script>
+    <script src="../ServicePulse.Host/app/bower_components/toastr/toastr.min.js"></script>
     <!-- endbower -->
 
     <script src="../servicepulse.host/app/lib/page-width-functions.js"></script>

--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -24,6 +24,7 @@
 	<link rel="stylesheet" href="bower_components/toaster/toaster.css" />
 	<link rel="stylesheet" href="bower_components/animate-css/animate.css" />
 	<link rel="stylesheet" href="bower_components/angular-ui-select/dist/select.css" />
+	<link rel="stylesheet" href="bower_components/toastr/toastr.min.css" />
 	<!-- endbower -->
 	
      
@@ -92,6 +93,7 @@
 <script src="bower_components/angular-ui-select/dist/select.js"></script>
 <script src="bower_components/d3/d3.js"></script>
 <script src="bower_components/rxjs/dist/rx.all.js"></script>
+<script src="bower_components/toastr/toastr.min.js"></script>
 <!-- endbower -->
 
 <script src="lib/page-width-functions.js"></script>

--- a/src/ServicePulse.Host/app/js/app.constants.js
+++ b/src/ServicePulse.Host/app/js/app.constants.js
@@ -5,7 +5,7 @@
         .constant('showPendingRetry', false)
         .constant('scConfig', {
             service_control_url: 'http://localhost:33333/api/',
-            monitoring_urls: ['http://localhost:1234/diagrams/']
+            monitoring_urls: ['http://localhost:3000/fake/']
         });
 
 }(window, window.angular));

--- a/src/ServicePulse.Host/app/js/services/service.toast.js
+++ b/src/ServicePulse.Host/app/js/services/service.toast.js
@@ -32,6 +32,14 @@
     ];
 
     angular.module('sc')
-        .service('toastService', service);
+        .service('toastService', service)
+        .factory('toastr', function () {
+            toastr.options = {
+                preventDuplicates: true,
+                positionClass: "toast-bottom-right",
+            };
+
+            return toastr;
+        });
 
 } (window, window.angular));

--- a/src/ServicePulse.Host/app/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/js/services/services.monitoring.js
@@ -2,8 +2,7 @@
 (function (window, angular, $, undefined) {
     'use strict';
 
-    function Service($http, rx, scConfig, uri) {
-        toastr.options.preventDuplicates = true;
+    function Service($http, rx, scConfig, uri, toastr) {
 
         var connectionToasts = [];
         var mappedUrls;
@@ -40,7 +39,7 @@
                         observer.onNext(result.data);
                     }, function (error) {
                         if (connectionToasts[url] === undefined) {
-                            var message = "unable to connect to " + url;
+                            var message = "unable to connect to ServiceControl.Monitoring at: " + url;
                             var x = toastr.warning(message,
                                 '',
                                 {
@@ -60,7 +59,7 @@
         return service;
     }
 
-    Service.$inject = ['$http', 'rx', 'scConfig', 'uri'];
+    Service.$inject = ['$http', 'rx', 'scConfig', 'uri', 'toastr'];
 
     angular.module('services.monitoringService', ['sc'])
         .service('monitoringService', Service);

--- a/src/ServicePulse.Host/app/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/js/services/services.monitoring.js
@@ -4,7 +4,7 @@
 
     function Service($http, rx, scConfig, uri, toastr) {
 
-        var connectionToasts = [];
+        var connectionToasts = {};
         var mappedUrls;
         var source = Rx.Observable.create(function (observer) {
             mappedUrls = scConfig.monitoring_urls.map(function (url) {
@@ -17,6 +17,18 @@
 
             return function () {
                 clearInterval(interval);
+
+                // clear open toasts
+                for(var toastEntry in connectionToasts) {
+                    if (connectionToasts.hasOwnProperty(toastEntry)) {
+                        var toast = connectionToasts[toastEntry];
+                        if (toast) {
+                            // toastr.remove would probably be better, but it seems to be buggy: https://github.com/CodeSeven/toastr/issues/494
+                            toastr.clear(toast);
+                            connectionToasts[toastEntry] = undefined;
+                        }
+                    }
+                }
             };
         });
 

--- a/src/ServicePulse.Host/app/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/js/services/services.monitoring.js
@@ -2,7 +2,9 @@
 (function (window, angular, $, undefined) {
     'use strict';
 
-    function Service($http, rx, scConfig, uri, toastService) {
+    function Service($http, rx, scConfig, uri) {
+        toastr.options.preventDuplicates = true;
+
         var connectionToasts = [];
         var mappedUrls;
         var source = Rx.Observable.create(function (observer) {
@@ -32,15 +34,20 @@
                         if (connectionToasts[url] !== undefined) {
                             var message = connectionToasts[url];
                             // doesn't exist
-                            toastService.remove(message);
+                            toastr.clear(message);
                             connectionToasts[url] = undefined;
                         }
                         observer.onNext(result.data);
                     }, function (error) {
                         if (connectionToasts[url] === undefined) {
                             var message = "unable to connect to " + url;
-                            toastService.showWarning("unable to connect to " + url);
-                            connectionToasts[url] = message;
+                            var x = toastr.warning(message,
+                                '',
+                                {
+                                    closeButton: true,
+                                    timeOut: 0
+                                });
+                            connectionToasts[url] = x;
                         }
                     });
             });
@@ -53,7 +60,7 @@
         return service;
     }
 
-    Service.$inject = ['$http', 'rx', 'scConfig', 'uri', 'toastService'];
+    Service.$inject = ['$http', 'rx', 'scConfig', 'uri'];
 
     angular.module('services.monitoringService', ['sc'])
         .service('monitoringService', Service);

--- a/src/ServicePulse.Host/bower.json
+++ b/src/ServicePulse.Host/bower.json
@@ -20,13 +20,14 @@
     "signalr": "2.2.0",
     "angular-ui-select": "0.18.1",
     "d3": "4.9.1",
-    "rxjs": "4.1.0"
+    "rxjs": "4.1.0",
+    "toastr": "^2.1.3"
   },
-  "overrides":{
-	"angular":{
-		"dependencies":{
-			"jquery": "2.1.4"
-		}
-	}
+  "overrides": {
+    "angular": {
+      "dependencies": {
+        "jquery": "2.1.4"
+      }
+    }
   }
 }


### PR DESCRIPTION
Connects to https://github.com/Particular/ServiceControl/issues/979

shows a toastr notification when a connection to a monitoring server fails. The notification does not fade out until clicked on by the user or when the page is switched (or to be more precise: once no more subscriber is subscribed to the monitoring servers data) or data has been successfully received from that server again.