### PR TITLE
Show instance count

### DIFF
--- a/src/ServicePulse.Host.Tests/tests/js/services/services.monitoring.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/services/services.monitoring.spec.js
@@ -31,7 +31,7 @@
     it('should push endpoints retrieved from monitoring server', function () {
         scConfig.monitoring_urls = ['http://localhost:1234/diagrams'];
 
-        $httpBackend.whenGET('http://localhost:1234/diagrams/data').respond(monitoredEndpointWithData);
+        $httpBackend.whenGET('http://localhost:1234/diagrams/monitored-endpoints').respond(monitoredEndpointWithData);
 
         var monitoredEndpoints = [];
         monitoringService.endpoints.subscribe(function (response) {
@@ -51,10 +51,10 @@
     });
 
     it('should push endpoints retrieved from multiple monitoring servers', function () {
-        scConfig.monitoring_urls = ['http://localhost:1234/diagrams', 'http://localhost:5678/diagrams'];
+        $httpBackend.whenGET('http://localhost:1234/diagrams/monitored-endpoints').respond(monitoredEndpointWithData);
+        $httpBackend.whenGET('http://localhost:5678/diagrams/monitored-endpoints').respond(monitoredEndpointWithData);
 
-        $httpBackend.whenGET('http://localhost:1234/diagrams/data').respond(monitoredEndpointWithData);
-        $httpBackend.whenGET('http://localhost:5678/diagrams/data').respond(monitoredEndpointWithData);
+        scConfig.monitoring_urls = ['http://localhost:1234/diagrams', 'http://localhost:5678/diagrams'];
 
         var monitoredEndpoints = [];
         monitoringService.endpoints.subscribe(function (response) {

--- a/src/ServicePulse.Host/app/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/js/services/services.monitoring.js
@@ -4,7 +4,6 @@
 
     function Service($http, rx, scConfig, uri, $q) {
 
-        var urls = scConfig.monitoring_urls;
         var source = Rx.Observable.create(function (observer) {
 
             updateData(observer);
@@ -23,8 +22,8 @@
             });
 
         function updateData(observer) {
-            urls.forEach(function (url) {
-                $http.get(url)
+            scConfig.monitoring_urls.forEach(function (url) {
+                $http.get(uri.join(url, 'monitored-endpoints'))
                     .then(function (result) {
                         observer.onNext(result.data);
                     });

--- a/src/ServicePulse.Host/app/js/views/monitored-endpoints/monitored-endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/monitored-endpoints/monitored-endpoints.html
@@ -42,21 +42,23 @@
                             <div class="col-sm-4 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
-                                        <p class="hard-wrap">{{endpoint.name}}</p> <span ng-if="endpoint.count">has {{endpoint.count}} errors</span>
+                                        <p class="hard-wrap" ng-click="endpoint.isExpanded = !endpoint.isExpanded">
+                                            {{endpoint.name}} <span ng-if="endpoint.endpointInstanceIds.length && endpoint.endpointInstanceIds.length > 1">({{endpoint.endpointInstanceIds.length}})</span>
+                                        </p>
                                     </div>
                                 </div>
                             </div>
                             <div class="col-sm-3 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
-                                        <graph plot-points="endpoint.processingTime" color="#40bc42"></graph>
+                                        <graph ng-if="endpoint.data.processingTime" plot-points="endpoint.data.processingTime" color="#40bc42"></graph>
                                     </div>
                                 </div>
                             </div>
                             <div class="col-sm-3 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
-                                        <graph plot-points="endpoint.criticalTime" color="#d64f21"></graph>
+                                        <graph ng-if="endpoint.data.criticalTime" plot-points="endpoint.data.criticalTime" color="#d64f21"></graph>
                                     </div>
                                 </div>
                             </div>

--- a/src/ServicePulse.Host/app/js/views/monitored-endpoints/monitored-endpoints.module.js
+++ b/src/ServicePulse.Host/app/js/views/monitored-endpoints/monitored-endpoints.module.js
@@ -12,7 +12,6 @@
                     template: '<svg></svg>',
                     link: function link(scope, element, attrs) {
                         var svg = element.find('svg')[0];
-
                         var heigth = 50;
                         var graphWidth = 130;
                         var totalWidth = 180;


### PR DESCRIPTION
Assumes that the metrics server sends EndpointInstanceIds property down. If the property is missing, no data is shown.

Relies on https://github.com/Particular/ServiceControl.Monitoring/pull/30