### PR TITLE
Retries graph on endpoints list and details pages

### DIFF
--- a/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
+++ b/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
@@ -31,14 +31,21 @@
                 </div>
             </div>
         </div>
-        <div class="col-sm-3 no-side-padding">
+        <div class="col-sm-2 no-side-padding">
+            <div class="row box-header">
+                <div class="col-sm-12 no-side-padding">
+                    <p class="lead">Retries (msgs)</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-2 no-side-padding">
             <div class="row box-header">
                 <div class="col-sm-12 no-side-padding">
                     <p class="lead">Processing Time (ms) </p>
                 </div>
             </div>
         </div>
-        <div class="col-sm-3 no-side-padding">
+        <div class="col-sm-2 no-side-padding">
             <div class="row box-header">
                 <div class="col-sm-12 no-side-padding">
                     <p class="lead">Critical Time (ms) </p>
@@ -61,14 +68,21 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-3 no-side-padding">
+                        <div class="col-sm-2 no-side-padding">
+                            <div class="row box-header">
+                                <div class="col-sm-12 no-side-padding">
+                                    <graph ng-if="instance.retries.points" plot-points="instance.retries.points" plot-average="instance.retries.average" color="#4286f4"></graph>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-2 no-side-padding">
                             <div class="row box-header">
                                 <div class="col-sm-12 no-side-padding">
                                     <graph ng-if="instance.processingTime.points" plot-points="instance.processingTime.points" plot-x-axis="instance.processingTime.pointsAxisValues" plot-average="instance.processingTime.average" color="#40bc42"></graph>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-3 no-side-padding">
+                        <div class="col-sm-2 no-side-padding">
                             <div class="row box-header">
                                 <div class="col-sm-12 no-side-padding">
                                     <graph ng-if="instance.criticalTime.points" plot-points="instance.criticalTime.points" x-axis="instance.criticalTime.pointsAxisValues" plot-average="instance.criticalTime.average" color="#d64f21"></graph>

--- a/src/ServicePulse.Host/app/js/views/monitored_endpoints/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/monitored_endpoints/monitored_endpoints.html
@@ -25,28 +25,35 @@
         <no-data ng-show="!endpoints.length" message="No active endpoints"></no-data>
 
         <div class="row box box-no-click">
-            <div class="col-sm-3 no-side-padding">
+            <div class="col-sm-4 no-side-padding">
                 <div class="row box-header">
                     <div class="col-sm-12 no-side-padding">
                         <p class="lead"> Name</p>
                     </div>
                 </div>
             </div>
-            <div class="col-sm-3 no-side-padding">
+            <div class="col-sm-2 no-side-padding">
                 <div class="row box-header">
                     <div class="col-sm-12 no-side-padding">
                         <p class="lead">Queue Length (msgs)</p>
                     </div>
                 </div>
             </div>
-            <div class="col-sm-3 no-side-padding">
+            <div class="col-sm-2 no-side-padding">
+                <div class="row box-header">
+                    <div class="col-sm-12 no-side-padding">
+                        <p class="lead">Retries (msgs)</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-2 no-side-padding">
                 <div class="row box-header">
                     <div class="col-sm-12 no-side-padding">
                         <p class="lead">Processing Time (ms)</p>
                     </div>
                 </div>
             </div>
-            <div class="col-sm-3 no-side-padding">
+            <div class="col-sm-2 no-side-padding">
                 <div class="row box-header">
                     <div class="col-sm-12 no-side-padding">
                         <p class="lead">Critical Time (ms)</p>
@@ -60,7 +67,7 @@
                 <div class="row box box-no-click" ng-repeat="endpoint in endpoints">
                     <div class="col-sm-12 no-side-padding">
                         <div class="row">
-                            <div class="col-sm-3 no-side-padding">
+                            <div class="col-sm-4 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
                                         <a class="hard-wrap" ng-click="endpoint.isExpanded = !endpoint.isExpanded" href="#/endpoint_details/{{endpoint.name}}/{{endpoint.sourceIndex}}">
@@ -69,21 +76,28 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-sm-3 no-side-padding">
+                            <div class="col-sm-2 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
                                         <graph ng-if="endpoint.queueLength.points" plot-points="endpoint.queueLength.points" plot-average="endpoint.queueLength.average" plot-x-axis="endpoint.queueLength.pointsAxisValues" color="#e09365"></graph>
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-sm-3 no-side-padding">
+                            <div class="col-sm-2 no-side-padding">
+                                <div class="row box-header">
+                                    <div class="col-sm-12 no-side-padding">
+                                        <graph ng-if="endpoint.retries.points" plot-points="endpoint.retries.points" plot-average="endpoint.retries.average" color="#4286f4"></graph>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-2 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
                                         <graph ng-if="endpoint.processingTime.points" plot-points="endpoint.processingTime.points" plot-average="endpoint.processingTime.average" color="#40bc42"></graph>
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-sm-3 no-side-padding">
+                            <div class="col-sm-2 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
                                         <graph ng-if="endpoint.criticalTime.points" plot-points="endpoint.criticalTime.points" plot-average="endpoint.criticalTime.average" color="#d64f21"></graph>


### PR DESCRIPTION
This requires changes from https://github.com/Particular/ServiceControl.Monitoring/pull/37 to work.

## Description
This PR introduces retries metric graph to Endpoint List and Endpoint Details pages. Columns on those pages have been made narrower make enough room for new column.

## Endpoint List 
![image](https://user-images.githubusercontent.com/1092707/28569561-8c7c65e8-713a-11e7-9743-ceb397fc1d5d.png)

## Endpoint Details
![image](https://user-images.githubusercontent.com/1092707/28569577-a3690c98-713a-11e7-8eac-6d254ed477d4.png)
