### PR TITLE
removing plot-x-axis from graph tag

### DIFF
--- a/src/ServicePulse.Host/app/js/directives/ui.particular.graph.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.graph.js
@@ -8,7 +8,6 @@
                     restrict: 'E',
                     scope: {
                         data: '=plotPoints',
-                        xAxis: '=plotXAxis',
                         avg: '=plotAverage'
                     },
                     template: '<svg></svg>',
@@ -26,20 +25,12 @@
                             .domain([0, max])
                             .range([heigth - margin, margin]);
 
-                        var xAxisEnd = points.length - 1;
-                        if (scope.xAxis && scope.xAxis.length) {
-                            xAxisEnd = scope.xAxis[scope.xAxis.length - 1];
-                        }
-
                         var scaleX = d3.scaleLinear()
-                            .domain([0, xAxisEnd])
+                            .domain([0, points.length - 1])
                             .range([margin, graphWidth - margin]);
 
                         var area = d3.area()
                             .x(function (d, i) {
-                                if (scope.xAxis) {
-                                    return scaleX(scope.xAxis[i]);
-                                }
                                 return scaleX(i);
                             })
                             .y(function (d, i) { return scaleY(d); })
@@ -48,9 +39,6 @@
 
                         var line = d3.line()
                             .x(function (d, i) {
-                                if (scope.xAxis) {
-                                    return scaleX(scope.xAxis[i]);
-                                }
                                 return scaleX(i);
                             })
                             .y(function(d, i) {

--- a/src/ServicePulse.Host/app/js/views/monitored_endpoints/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/monitored_endpoints/monitored_endpoints.html
@@ -79,7 +79,7 @@
                             <div class="col-sm-2 no-side-padding">
                                 <div class="row box-header">
                                     <div class="col-sm-12 no-side-padding">
-                                        <graph ng-if="endpoint.queueLength.points" plot-points="endpoint.queueLength.points" plot-average="endpoint.queueLength.average" plot-x-axis="endpoint.queueLength.pointsAxisValues" color="#e09365"></graph>
+                                        <graph ng-if="endpoint.queueLength.points" plot-points="endpoint.queueLength.points" plot-average="endpoint.queueLength.average" color="#e09365"></graph>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
This PR removes `plot-x-axis` support from `graph` tag as it's not longer needed after [changes](https://github.com/Particular/ServiceControl.Monitoring/pull/40) to queue-length are applied to `SC.Monitoring`.