### PR TITLE
Metrics breakdown by message type

### DIFF
--- a/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.controller.js
@@ -13,6 +13,8 @@
         $scope.endpointName = $routeParams.endpointName;
         $scope.sourceIndex = $routeParams.sourceIndex;
         $scope.loading = true;
+        $scope.showInstancesBreakdown = true;
+
         var subscription;
 
         $scope.periods = historyPeriods;

--- a/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.controller.js
@@ -35,15 +35,15 @@
                 subscription.dispose();
             }
 
-            subscription = monitoringService.createEndpointDetailsSource($routeParams.endpointName, $routeParams.sourceIndex, $scope.selectedPeriod.value).subscribe(function (endpointInstances) {
-                if (endpointInstances.error) {
+            subscription = monitoringService.createEndpointDetailsSource($routeParams.endpointName, $routeParams.sourceIndex, $scope.selectedPeriod.value).subscribe(function (endpoint) {
+                if (endpoint.error) {
                     toastService.showWarning('Could not load endpoint details');
                 } else {
-                    $scope.endpointInstances = endpointInstances;
+                    $scope.endpoint = endpoint;
                     $scope.loading = false;
                 }
 
-                $scope.endpointInstances.forEach(function (instance) {
+                $scope.endpoint.instances.forEach(function (instance) {
                     serviceControlService.getExceptionGroupsForEndpointInstance(instance.id).then(function (result) {
                         instance.serviceControlId = result.data[0].id;
                         instance.errorCount = result.data[0].count;

--- a/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
+++ b/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
@@ -30,7 +30,7 @@
     </h5>
 </div>
 
-<section ng-show="showInstancesBreakdown">
+<section ng-if="showInstancesBreakdown">
     <div class="row">
         <div class="col-sm-12 no-side-padding">
 
@@ -146,7 +146,7 @@
     </div>
 </section>
 
-<section ng-show="!showInstancesBreakdown">
+<section ng-if="!showInstancesBreakdown">
     <div class="row">
         <div class="col-sm-12 no-side-padding">
             <!-- Breakdown by message type-->

--- a/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
+++ b/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
@@ -21,104 +21,216 @@
 </div>
 
 <div class="container">
-    <busy ng-show="loading" message="Loading details"></busy>
+<div class="tabs">
+    <h5 ng-class="{active: showInstancesBreakdown}">
+        <a ng-click="showInstancesBreakdown = true" class="ng-binding">Instances</a>
+    </h5>
+    <h5 ng-class="{active: !showInstancesBreakdown}">
+        <a ng-click="showInstancesBreakdown = false" class="ng-binding">Message Types</a>
+    </h5>
+</div>
 
-    <div ng-show="!loading" class="row box box-no-click">
-        <div class="col-sm-4 no-side-padding">
-            <div class="row box-header">
-                <div class="col-sm-12 no-side-padding">
-                    <p class="lead">Instance Name</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-sm-2 no-side-padding">
-            <div class="row box-header">
-                <div class="col-sm-12 no-side-padding">
-                    <p class="lead">Throughput (msgs/s)</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-sm-2 no-side-padding">
-            <div class="row box-header">
-                <div class="col-sm-12 no-side-padding">
-                    <p class="lead">Retries (msgs)</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-sm-2 no-side-padding">
-            <div class="row box-header">
-                <div class="col-sm-12 no-side-padding">
-                    <p class="lead">Processing Time (ms) </p>
-                </div>
-            </div>
-        </div>
-        <div class="col-sm-2 no-side-padding">
-            <div class="row box-header">
-                <div class="col-sm-12 no-side-padding">
-                    <p class="lead">Critical Time (ms) </p>
-                </div>
-            </div>
-        </div>
-    </div>
-
+<section ng-show="showInstancesBreakdown">
     <div class="row">
         <div class="col-sm-12 no-side-padding">
-            <div class="row box box-no-click" ng-repeat="instance in endpoint.instances">
+
+            <!-- Breakdown by instance -->
+            <busy ng-show="loading" message="Loading details"></busy>
+
+            <div ng-show="!loading" class="row box box-no-click">
+                <div class="col-sm-4 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Instance Name</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Throughput (msgs/s)</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Retries (msgs)</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Processing Time (ms) </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Critical Time (ms) </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
                 <div class="col-sm-12 no-side-padding">
-                    <div class="row endpoint-row">
-                        <div class="col-sm-4 no-side-padding">
-                            <div class="row box-header">
-                                <div class="col-sm-12 no-side-padding">
-                                    <div class="hard-wrap">
-                                        {{instance.id}}
-                                        <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{endpointName}}/{{sourceIndex}}/{{instance.serviceControlId}}">
-                                            <i class="fa fa-envelope"></i>
-                                            <span class="badge badge-important ng-binding">{{instance.errorCount | largeNumber:1}}</span>
-                                            <span ng-if="instance.isStale" class="warning pull-right">
+                    <div class="row box box-no-click" ng-repeat="instance in endpoint.instances">
+                        <div class="col-sm-12 no-side-padding">
+                            <div class="row endpoint-row">
+                                <div class="col-sm-4 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <div class="hard-wrap">
+                                                {{instance.id}}
+                                                <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{endpointName}}/{{sourceIndex}}/{{instance.serviceControlId}}">
+                                                    <i class="fa fa-envelope"></i>
+                                                    <span class="badge badge-important ng-binding">{{instance.errorCount | largeNumber:1}}</span>
+                                                    <span ng-if="instance.isStale" class="warning pull-right">
+                                                        <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
+                                                    </span>
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="instance.metrics.throughput.points" plot-points="instance.metrics.throughput.points" plot-average="instance.metrics.throughput.average" color="#e09365" class="graph pull-left"></graph>
+                                            <span ng-if="instance.isStale" class="warning pull-right graphicon">
                                                 <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                             </span>
-                                        </a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="instance.metrics.retries.points" plot-points="instance.metrics.retries.points" plot-average="instance.metrics.retries.average" color="#4286f4" class="graph pull-left"></graph>
+                                            <span ng-if="instance.isStale" class="warning pull-right graphicon">
+                                                <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="instance.metrics.processingTime.points" plot-points="instance.metrics.processingTime.points" plot-average="instance.metrics.processingTime.average" color="#40bc42" class="graph pull-left"></graph>
+                                            <span ng-if="instance.isStale" class="warning pull-right graphicon">
+                                                <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="instance.metrics.criticalTime.points" plot-points="instance.metrics.criticalTime.points" plot-average="instance.metrics.criticalTime.average" color="#d64f21" class="graph pull-left"></graph>
+                                            <span ng-if="instance.isStale" class="warning pull-right graphicon">
+                                                <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-2 no-side-padding">
-                            <div class="row box-header">
-                                <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.metrics.throughput.points" plot-points="instance.metrics.throughput.points" plot-average="instance.metrics.throughput.average" color="#e09365" class="graph pull-left"></graph>
-                                    <span ng-if="instance.isStale" class="warning pull-right graphicon">
-                                        <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
-                                    </span>
-                                </div>
-                            </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</section>
+
+<section ng-show="!showInstancesBreakdown">
+    <div class="row">
+        <div class="col-sm-12 no-side-padding">
+            <!-- Breakdown by message type-->
+            <busy ng-show="loading" message="Loading details"></busy>
+
+            <div ng-show="!loading" class="row box box-no-click">
+                <div class="col-sm-4 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Message Type</p>
                         </div>
-                        <div class="col-sm-2 no-side-padding">
-                            <div class="row box-header">
-                                <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.metrics.retries.points" plot-points="instance.metrics.retries.points" plot-average="instance.metrics.retries.average" color="#4286f4" class="graph pull-left"></graph>
-                                    <span ng-if="instance.isStale" class="warning pull-right graphicon">
-                                        <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
-                                    </span>
-                                </div>
-                            </div>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Throughput (msgs/s)</p>
                         </div>
-                        <div class="col-sm-2 no-side-padding">
-                            <div class="row box-header">
-                                <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.metrics.processingTime.points" plot-points="instance.metrics.processingTime.points" plot-average="instance.metrics.processingTime.average" color="#40bc42" class="graph pull-left"></graph>
-                                    <span ng-if="instance.isStale" class="warning pull-right graphicon">
-                                        <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
-                                    </span>
-                                </div>
-                            </div>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Retries (msgs)</p>
                         </div>
-                        <div class="col-sm-2 no-side-padding">
-                            <div class="row box-header">
-                                <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.metrics.criticalTime.points" plot-points="instance.metrics.criticalTime.points" plot-average="instance.metrics.criticalTime.average" color="#d64f21" class="graph pull-left"></graph>
-                                    <span ng-if="instance.isStale" class="warning pull-right graphicon">
-                                        <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
-                                    </span>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Processing Time (ms) </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-2 no-side-padding">
+                    <div class="row box-header">
+                        <div class="col-sm-12 no-side-padding">
+                            <p class="lead">Critical Time (ms) </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-sm-12 no-side-padding">
+                    <div class="row box box-no-click" ng-repeat="messageType in endpoint.messageTypes">
+                        <div class="col-sm-12 no-side-padding">
+                            <div class="row endpoint-row">
+                                <div class="col-sm-4 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <div class="hard-wrap">
+                                                {{messageType.messageType}}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="messageType.metrics.throughput.points" plot-points="messageType.metrics.throughput.points" plot-average="messageType.metrics.throughput.average" color="#e09365" class="graph pull-left"></graph>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="messageType.metrics.retries.points" plot-points="messageType.metrics.retries.points" plot-average="messageType.metrics.retries.average" color="#4286f4" class="graph pull-left"></graph>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="messageType.metrics.processingTime.points" plot-points="messageType.metrics.processingTime.points" plot-average="messageType.metrics.processingTime.average" color="#40bc42" class="graph pull-left"></graph>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-2 no-side-padding">
+                                    <div class="row box-header">
+                                        <div class="col-sm-12 no-side-padding">
+                                            <graph ng-if="messageType.metrics.criticalTime.points" plot-points="messageType.metrics.criticalTime.points" plot-average="messageType.metrics.criticalTime.average" color="#d64f21" class="graph pull-left"></graph>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -127,4 +239,5 @@
             </div>
         </div>
     </div>
+</section>
 </div>

--- a/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
+++ b/src/ServicePulse.Host/app/js/views/endpoint_details/endpoint_details.html
@@ -63,7 +63,7 @@
 
     <div class="row">
         <div class="col-sm-12 no-side-padding">
-            <div class="row box box-no-click" ng-repeat="instance in endpointInstances">
+            <div class="row box box-no-click" ng-repeat="instance in endpoint.instances">
                 <div class="col-sm-12 no-side-padding">
                     <div class="row endpoint-row">
                         <div class="col-sm-4 no-side-padding">
@@ -85,7 +85,7 @@
                         <div class="col-sm-2 no-side-padding">
                             <div class="row box-header">
                                 <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.throughput.points" plot-points="instance.throughput.points" plot-average="instance.throughput.average" color="#e09365" class="graph pull-left"></graph>
+                                    <graph ng-if="instance.metrics.throughput.points" plot-points="instance.metrics.throughput.points" plot-average="instance.metrics.throughput.average" color="#e09365" class="graph pull-left"></graph>
                                     <span ng-if="instance.isStale" class="warning pull-right graphicon">
                                         <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                     </span>
@@ -95,7 +95,7 @@
                         <div class="col-sm-2 no-side-padding">
                             <div class="row box-header">
                                 <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.retries.points" plot-points="instance.retries.points" plot-average="instance.retries.average" color="#4286f4" class="graph pull-left"></graph>
+                                    <graph ng-if="instance.metrics.retries.points" plot-points="instance.metrics.retries.points" plot-average="instance.metrics.retries.average" color="#4286f4" class="graph pull-left"></graph>
                                     <span ng-if="instance.isStale" class="warning pull-right graphicon">
                                         <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                     </span>
@@ -105,7 +105,7 @@
                         <div class="col-sm-2 no-side-padding">
                             <div class="row box-header">
                                 <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.processingTime.points" plot-points="instance.processingTime.points" plot-x-axis="instance.processingTime.pointsAxisValues" plot-average="instance.processingTime.average" color="#40bc42" class="graph pull-left"></graph>
+                                    <graph ng-if="instance.metrics.processingTime.points" plot-points="instance.metrics.processingTime.points" plot-average="instance.metrics.processingTime.average" color="#40bc42" class="graph pull-left"></graph>
                                     <span ng-if="instance.isStale" class="warning pull-right graphicon">
                                         <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                     </span>
@@ -115,7 +115,7 @@
                         <div class="col-sm-2 no-side-padding">
                             <div class="row box-header">
                                 <div class="col-sm-12 no-side-padding">
-                                    <graph ng-if="instance.criticalTime.points" plot-points="instance.criticalTime.points" x-axis="instance.criticalTime.pointsAxisValues" plot-average="instance.criticalTime.average" color="#d64f21" class="graph pull-left"></graph>
+                                    <graph ng-if="instance.metrics.criticalTime.points" plot-points="instance.metrics.criticalTime.points" plot-average="instance.metrics.criticalTime.average" color="#d64f21" class="graph pull-left"></graph>
                                     <span ng-if="instance.isStale" class="warning pull-right graphicon">
                                         <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                     </span>

--- a/src/ServicePulse.Host/app/js/views/monitored_endpoints/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/monitored_endpoints/monitored_endpoints.html
@@ -102,7 +102,7 @@
                                 <div class="col-sm-2 col-xl-1 no-side-padding" ng-if="endpoint.isConnected">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <graph ng-if="endpoint.queueLength.points" plot-points="endpoint.queueLength.points" plot-average="endpoint.queueLength.average" color="#e09365" class="graph pull-left"></graph>
+                                            <graph ng-if="endpoint.metrics.queueLength.points" plot-points="endpoint.metrics.queueLength.points" plot-average="endpoint.metrics.queueLength.average" color="#e09365" class="graph pull-left"></graph>
                                             <span ng-if="endpoint.isStale" class="warning graphicon" ng-class="{'graphicon-row-hover': endpoint.hover1}">
                                                 <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                             </span>
@@ -112,7 +112,7 @@
                                 <div class="col-sm-2 col-xl-1 no-side-padding" ng-if="endpoint.isConnected">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <graph ng-if="endpoint.throughput.points" plot-points="endpoint.throughput.points" plot-average="endpoint.throughput.average" color="#e09365" class="graph pull-left"></graph>
+                                            <graph ng-if="endpoint.metrics.throughput.points" plot-points="endpoint.metrics.throughput.points" plot-average="endpoint.metrics.throughput.average" color="#e09365" class="graph pull-left"></graph>
                                             <span ng-if="endpoint.isStale" class="warning graphicon" ng-class="{'graphicon-row-hover': endpoint.hover1}">
                                                 <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                             </span>
@@ -122,7 +122,7 @@
                                 <div class="col-sm-2 col-xl-1 no-side-padding" ng-if="endpoint.isConnected">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <graph ng-if="endpoint.retries.points" plot-points="endpoint.retries.points" plot-average="endpoint.retries.average" color="#4286f4" class="graph pull-left"></graph>
+                                            <graph ng-if="endpoint.metrics.retries.points" plot-points="endpoint.metrics.retries.points" plot-average="endpoint.metrics.retries.average" color="#4286f4" class="graph pull-left"></graph>
                                             <span ng-if="endpoint.isStale" class="warning graphicon" ng-class="{'graphicon-row-hover': endpoint.hover1}">
                                                 <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                             </span>
@@ -132,7 +132,7 @@
                                 <div class="col-sm-2 col-xl-1 no-side-padding" ng-if="endpoint.isConnected">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <graph ng-if="endpoint.processingTime.points" plot-points="endpoint.processingTime.points" plot-average="endpoint.processingTime.average" color="#40bc42" class="graph pull-left"></graph>
+                                            <graph ng-if="endpoint.metrics.processingTime.points" plot-points="endpoint.metrics.processingTime.points" plot-average="endpoint.metrics.processingTime.average" color="#40bc42" class="graph pull-left"></graph>
                                             <span ng-if="endpoint.isStale" class="warning graphicon" ng-class="{'graphicon-row-hover': endpoint.hover1}">
                                                 <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                             </span>
@@ -142,7 +142,7 @@
                                 <div class="col-sm-2 col-xl-1 no-side-padding" ng-if="endpoint.isConnected">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <graph ng-if="endpoint.criticalTime.points" plot-points="endpoint.criticalTime.points" plot-average="endpoint.criticalTime.average" color="#d64f21" class="graph pull-left"></graph>
+                                            <graph ng-if="endpoint.metrics.criticalTime.points" plot-points="endpoint.metrics.criticalTime.points" plot-average="endpoint.metrics.criticalTime.average" color="#d64f21" class="graph pull-left"></graph>
                                             <span ng-if="endpoint.isStale" class="warning graphicon" ng-class="{'graphicon-row-hover': endpoint.hover1}">
                                                 <i class="fa fa-exclamation-triangle" uib-tooltip="Endpoint does not appear to be connected to the monitoring server anymore"></i>
                                             </span>


### PR DESCRIPTION
This PR is part of https://github.com/Particular/LaunchWave.DevOpsAdvancedMonitoring/issues/167 and requires https://github.com/Particular/ServiceControl.Monitoring/pull/54 to work.

It introduces following changes:
  * Changes to bindings on list and detail pages adding `metrics.` in metrics bindings - this is result of new generic metrics calculation logic,
  * It introduces new section on details page that provides breakdown by message-type
  * It introduces 2 tabs for instances and mesasge-type breakdown.