### PR TITLE
Missing moment-duration-format plugin added to bower.json

### DIFF
--- a/src/ServicePulse.Host/bower.json
+++ b/src/ServicePulse.Host/bower.json
@@ -14,6 +14,7 @@
     "jquery": "2.1.4",
     "zeroclipboard": "2.2.0",
     "momentjs": "2.10.6",
+    "moment-duration-format": "1.3.0", 
     "ng-infinite-scroll": "git://github.com/sroze/ngInfiniteScroll#1.0.0",
     "toaster": "1.1.0",
     "animate-css": "3.4.0",


### PR DESCRIPTION
This adds missing dependency to `bower.json` and should be part of #513.