### PR TITLE
Showing zeros for empty data sets in graphs

### DIFF
--- a/src/ServicePulse.Host/app/js/directives/ui.particular.graph.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.graph.js
@@ -71,7 +71,7 @@
                             .attr('stroke', 'gray');
 
                         var displayValue = average.toFixed(2);
-                        if (scope.plotData.displayValue !== undefined) {
+                        if (typeof scope.plotData.displayValue !== "undefined") {
                             displayValue = scope.plotData.displayValue;
                         }
 

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.graph.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.graph.js
@@ -71,7 +71,7 @@
                             .attr('stroke', 'gray');
 
                         var displayValue = average.toFixed(2);
-                        if (typeof scope.plotData.displayValue !== undefined) {
+                        if (scope.plotData.displayValue !== undefined) {
                             displayValue = scope.plotData.displayValue;
                         }
 


### PR DESCRIPTION
This removes `typeof` from the check on undefined property. Otherwise even if the property is undefined the typeof will return string `"undefined"`. As a result `"undefined" !== undefined" will always evaluate to false as `!==` operator does not do type coertion.