### PR TITLE
Fixing small UI Bugs:

### DIFF
--- a/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
@@ -5,9 +5,9 @@
                 <span ng-hide="counters.message === 0" tooltip="There's varying numbers of failed message groups depending on group type">!</span>
                 <span ng-show="counters.message === 0">0</span>
             </span></h5>
-            <h5 ng-class="{ active: isActive('/failed-messages/all') }"><a ng-click="viewExceptionGroup()">All failed messages</a> <span class="badge badge-important">{{counters.message | largeNumber:1}}</span></h5>
-            <h5 ng-class="{ active: isActive('/failed-messages/archived') }"><a href="#/failed-messages/archived">Archived messages ({{counters.archived | largeNumber:1}})</a></h5>
-            <h5 ng-show="{{showPendingRetry}}" ng-class="{ active: isActive('/failed-messages/pending-retries') }"><a href="#/failed-messages/pending-retries">Pending retries ({{counters.pendingRetries | largeNumber:1}})</a></h5>
+            <h5 ng-class="{ active: isActive('/failed-messages/all') }"><a ng-click="viewExceptionGroup()">All failed messages</a> <span class="badge badge-important">{{counters.message | largeNumber:0}}</span></h5>
+            <h5 ng-class="{ active: isActive('/failed-messages/archived') }"><a href="#/failed-messages/archived">Archived messages ({{counters.archived | largeNumber:0}})</a></h5>
+            <h5 ng-show="{{showPendingRetry}}" ng-class="{ active: isActive('/failed-messages/pending-retries') }"><a href="#/failed-messages/pending-retries">Pending retries ({{counters.pendingRetries | largeNumber:0}})</a></h5>
         </div>
     </div>
 </div>

--- a/src/ServicePulse.Host/app/js/services/service.formatter.js
+++ b/src/ServicePulse.Host/app/js/services/service.formatter.js
@@ -24,8 +24,10 @@
         }
 
         function formatLargeNumber(value, decimals) {
-            var exp, rounded,
+            var exp,
                 suffixes = ['k', 'M', 'G', 'T', 'P', 'E'];
+
+            value = Number(value);
 
             if (window.isNaN(value)) {
                 return null;

--- a/src/ServicePulse.Host/app/js/views/archive/view.html
+++ b/src/ServicePulse.Host/app/js/views/archive/view.html
@@ -6,7 +6,7 @@
         <div class="row" ng-show="!vm.loadingData">
             <div class="col-sm-12">
                 <div class="btn-toolbar">
-                    <button type="button" class="btn btn-default" confirm-title="Are you sure you want to un-archive selected archived messages?" confirm-message="Unarchived messages will be moved back to the list of failed messages." confirm-click="vm.unarchiveSelected()" ng-disabled="vm.selectedIds.length == 0"><i class="fa fa-undo"></i> Unarchive {{vm.selectedIds.length | largeNumber:1}} selected</button>
+                    <button type="button" class="btn btn-default" confirm-title="Are you sure you want to un-archive selected archived messages?" confirm-message="Unarchived messages will be moved back to the list of failed messages." confirm-click="vm.unarchiveSelected()" ng-disabled="vm.selectedIds.length == 0"><i class="fa fa-undo"></i> Unarchive {{vm.selectedIds.length | number}} selected</button>
 
                     <div class="msg-group-menu dropdown msg-list-dropdown">
                         <label class="control-label">Show:</label>


### PR DESCRIPTION
 - Limiting the numbers next to All Failed Message Count and Archived Messages to not include decimal place
 - Limiting the numbers in the top menu to not include decimal place
 - Limiting the numbers on the button listing amount of selected messages to not include decimal place
 - Changing formatter to parse string's into int (it was causing JS error when the value was lower than 1000)

![image](https://user-images.githubusercontent.com/604826/31385301-14219d8c-adc3-11e7-97f2-9880d3492196.png)

![image](https://user-images.githubusercontent.com/604826/31385305-17c7134a-adc3-11e7-94e3-4bb94d191096.png)

![image](https://user-images.githubusercontent.com/604826/31385308-1b48cd1a-adc3-11e7-955e-b7f62f8f3911.png)
