### PR TITLE
Default route moved to app.constants.js

### DIFF
--- a/src/ServicePulse.Host/app/js/app.constants.js
+++ b/src/ServicePulse.Host/app/js/app.constants.js
@@ -4,6 +4,7 @@
         .constant('version', '1.2.0')
         .constant('showPendingRetry', false)
         .constant('scConfig', {
+            default_route: '/dashboard',
             service_control_url: 'http://localhost:33333/api/',
             monitoring_urls: ['http://localhost:33633/']
         });

--- a/src/ServicePulse.Host/app/js/app.route.js
+++ b/src/ServicePulse.Host/app/js/app.route.js
@@ -1,12 +1,13 @@
 ﻿; (function (window, angular, undefined) {
     'use strict';
 
-    function routeProvider($routeProvider) {
-        $routeProvider.otherwise({ redirectTo: '/dashboard' });
+    function routeProvider($routeProvider, scConfig) {
+        $routeProvider.otherwise({ redirectTo: scConfig.default_route });
     };
 
     routeProvider.$inject = [
-        '$routeProvider'
+        '$routeProvider',
+        'scConfig'
     ];
 
     angular.module('sc')


### PR DESCRIPTION
## Overview
This PR enables configuring what is the default route if none is specified. This will be used in monitoring demo but I think it's general enough that we should enable users define starting page if they want to.