### PR TITLE
Changing npm scripts to support webpack configuration with watcher

### DIFF
--- a/src/ServicePulse.Host/package.json
+++ b/src/ServicePulse.Host/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "load": "npm install && bower install && node ./node_modules/webpack/bin/webpack.js --config app/modules/monitoring/monitoring.webpackconfig.builder.js",
-    "setup": "npm install && bower install && node wiredep.js && node ./node_modules/webpack/bin/webpack.js --config app/modules/monitoring/monitoring.webpackconfig.builder.js"
+    "setup": "npm install && bower install && node wiredep.js && node ./node_modules/webpack/bin/webpack.js --config app/modules/monitoring/monitoring.webpackconfig.js"
   },
   "author": "Particular Software",
   "license": "RPL-1.5"


### PR DESCRIPTION
THis allows on dev machine to call 
`npm run setup`

Which now pulls the dependencies and call webpack with watch turned on