### PR TITLE
Default feature selection on

### DIFF
--- a/src/Setup/ServicePulse.aip
+++ b/src/Setup/ServicePulse.aip
@@ -27,7 +27,7 @@
     <ROW Property="DEFAULT_SC_MONITORING_URI" Value="http://localhost:33633"/>
     <ROW Property="DEFAULT_SC_URI" Value="http://localhost:33333/api"/>
     <ROW Property="DialogBitmap" Value="dialog" MultiBuildValue="DefaultBuild:dialog.jpg" Type="1" MsiKey="DialogBitmap"/>
-    <ROW Property="ENABLE_FEATURE_SELECTION" Value="FALSE"/>
+    <ROW Property="ENABLE_FEATURE_SELECTION" Value="TRUE"/>
     <ROW Property="IGNORE_SERVICECONTROLMONITORING_OFFLINE" Value="IDNO"/>
     <ROW Property="IGNORE_SERVICECONTROL_OFFLINE" Value="IDNO"/>
     <ROW Property="INST_PORT_PULSE" Value="9090" Type="4"/>


### PR DESCRIPTION
Switches the feature toggle default value from FALSE to TRUE. This will mean that the user does not need to use command line arguments to show the installer URI anymore.