### PR TITLE
Formatted message types

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -1618,3 +1618,14 @@ p.col-sort-active {
     font-weight: bold;
     font-size: 1.3em;
 }
+
+.message-type {
+    font-size: 1.3em;
+    font-weight: bold;
+}
+
+.message-type-part {
+    margin-right: 20px;
+    float: left;
+    color: gray;
+}

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -234,6 +234,14 @@
                         </div>
                     </div>
                 </div>
+                
+                <!--
+                "typeName": "Messages.PlaceOrder",
+                "assemblyName": "Messages",
+                "assemblyVersion": "1.0.0.0",
+                "culture": "neutral",
+                "publicKeyToken": "null",
+                -->
 
                 <div class="row">
                     <div class="col-sm-12 no-side-padding">
@@ -246,8 +254,8 @@
                                                 <div class="hard-wrap">
                                                     <div class="message-type">{{messageType.typeName == "" ? "N/A" : messageType.typeName}}</div>
                                                     <div class="message-type-part">{{messageType.assemblyName + '-' + messageType.assemblyVersion}}</div>
-                                                    <div ng-show="{{messageType.culture != 'neutral'}}" class="message-type-part">{{'Culture=' + messageType.culture}}</div>
-                                                    <div ng-show="{{messageType.publicKeyToken != 'null'}}"class="message-type-part">{{'PublicKeyToken=' + messageType.publicKeyToken}}</div>
+                                                    <div ng-show="{{messageType.culture}}" class="message-type-part">{{'Culture=' + messageType.culture}}</div>
+                                                    <div ng-show="{{messageType.publicKeyToken}}"class="message-type-part">{{'PublicKeyToken=' + messageType.publicKeyToken}}</div>
                                                 </div>
                                             </div>
                                         </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -244,7 +244,10 @@
                                         <div class="row box-header">
                                             <div class="col-sm-12 no-side-padding">
                                                 <div class="hard-wrap">
-                                                    {{messageType.messageType}}
+                                                    <div class="message-type">{{messageType.typeName == "" ? "N/A" : messageType.typeName}}</div>
+                                                    <div class="message-type-part">{{messageType.assemblyName + '-' + messageType.assemblyVersion}}</div>
+                                                    <div ng-show="{{messageType.culture != 'neutral'}}" class="message-type-part">{{'Culture=' + messageType.culture}}</div>
+                                                    <div ng-show="{{messageType.publicKeyToken != 'null'}}"class="message-type-part">{{'PublicKeyToken=' + messageType.publicKeyToken}}</div>
                                                 </div>
                                             </div>
                                         </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -234,14 +234,6 @@
                         </div>
                     </div>
                 </div>
-                
-                <!--
-                "typeName": "Messages.PlaceOrder",
-                "assemblyName": "Messages",
-                "assemblyVersion": "1.0.0.0",
-                "culture": "neutral",
-                "publicKeyToken": "null",
-                -->
 
                 <div class="row">
                     <div class="col-sm-12 no-side-padding">


### PR DESCRIPTION
## Overview
This PR changes the way message types are displayed on the endpoint details page. It aligns it with https://github.com/Particular/LaunchWave.DevOpsAdvancedMonitoring/issues/242#issuecomment-334741184.

This requires https://github.com/Particular/ServiceControl.Monitoring/pull/78

## Outcome
![image](https://user-images.githubusercontent.com/1092707/33061668-392a6d16-ce9d-11e7-9575-d8a2ff638386.png)
