### PR TITLE
Returning constant max yAxis value for empty data series

### DIFF
--- a/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.largeGraph.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.largeGraph.js
@@ -50,6 +50,12 @@
     }
 
     function padToWholeValue(value) {
+        var emptyDataSetyAxisMax = 10;
+
+        if (!value) {
+            return emptyDataSetyAxisMax;
+        }
+
         var upperBound = 10;
 
         while (value > upperBound) {


### PR DESCRIPTION
## Overview
This PR makes sure that yAxis has a fixed height for large graphs with empty data sets.