### PR TITLE
Stop using decimals for badge counts

### DIFF
--- a/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
+++ b/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
@@ -20,7 +20,7 @@
                         <div class="col-sm-4">
                             <a class="summary-item" ng-class="{  'summary-danger' : failedheartbeats > 0 , 'summary-info' : failedheartbeats === 0 || !failedheartbeats  }" href="#/endpoints">
                                 <i class="fa fa-heart fa-3x"></i>
-                                <span ng-show="failedheartbeats > 0" class="badge badge-important">{{failedheartbeats | largeNumber:1}}</span>
+                                <span ng-show="failedheartbeats > 0" class="badge badge-important">{{failedheartbeats | largeNumber:0}}</span>
                                 <h4>
                                     Heartbeats
                                     
@@ -31,7 +31,7 @@
                         <div class="col-sm-4">
                             <a class="summary-item" ng-class="{  'summary-danger'  : failedmessages > 0 , 'summary-info' : failedmessages === 0 || !failedmessages }" href="#/failed-messages/groups">
                                 <i class="fa fa-envelope fa-3x "></i>
-                                <span ng-show="failedmessages > 0" class="badge badge-important">{{failedmessages | largeNumber:1}}</span>
+                                <span ng-show="failedmessages > 0" class="badge badge-important">{{failedmessages | largeNumber:0}}</span>
                                 <h4>
                                     Failed Messages
                                     
@@ -41,7 +41,7 @@
                         <div class="col-sm-4">
                             <a class="summary-item" ng-class="{  'summary-danger'  : failedcustomchecks > 0, 'summary-info' : failedcustomchecks === 0 || !failedcustomchecks }" href="#/custom-checks">
                                 <i class="fa fa-check  fa-3x "></i>
-                                <span ng-show="failedcustomchecks > 0" class="badge badge-important">{{failedcustomchecks | largeNumber:1}}</span>
+                                <span ng-show="failedcustomchecks > 0" class="badge badge-important">{{failedcustomchecks | largeNumber:0}}</span>
                                 <h4>
                                     Custom Checks
                                     

--- a/src/ServicePulse.Host/app/layout/navbar.html
+++ b/src/ServicePulse.Host/app/layout/navbar.html
@@ -27,7 +27,7 @@
                     <a href="#/endpoints">
                         <i class="fa fa-heart icon-white"></i>
                         <span class="navbar-label">Endpoints</span>
-                        <span ng-show="failedheartbeats > 0" class="badge badge-important ">{{failedheartbeats | largeNumber:1}}</span>
+                        <span ng-show="failedheartbeats > 0" class="badge badge-important ">{{failedheartbeats | largeNumber:0}}</span>
                     </a>
                 </li>
 
@@ -42,14 +42,14 @@
                     <a href="#/failed-messages/groups">
                         <i class="fa fa-envelope icon-white"></i>
                         <span class="navbar-label">Failed Messages</span>
-                        <span ng-show="failedmessages > 0" class="badge badge-important ">{{failedmessages | largeNumber:1}}</span>
+                        <span ng-show="failedmessages > 0" class="badge badge-important ">{{failedmessages | largeNumber:0}}</span>
                     </a>
                 </li>
                 <li ng-class="{ active: isActive('/custom-checks') }">
                     <a href="#/custom-checks">
                         <i class="fa fa-check icon-white"></i>
                         <span class="navbar-label">Custom Checks</span>
-                        <span ng-show="failedcustomchecks > 0" class="badge badge-important ">{{failedcustomchecks | largeNumber:1}}</span>
+                        <span ng-show="failedcustomchecks > 0" class="badge badge-important ">{{failedcustomchecks | largeNumber:0}}</span>
                     </a>
                 </li>
                 <li ng-class="{ active: isActive('/configuration/endpoints') || isActive('/configuration/redirects') }">


### PR DESCRIPTION
Connects to https://github.com/Particular/ServicePulse/issues/563

Stops using a decimal point for things that will be whole numbers only.

Smaller number will show the actual value, larger will be e.g. `25k` instead of `25.3k`