### PR TITLE
Show endpoint name instead of id on instace breakdown grid

### DIFF
--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -220,7 +220,7 @@
                                             <div class="row box-header">
                                                 <div class="col-sm-12 no-side-padding lead">
 
-                                                        {{instance.id}}
+                                                        {{instance.name}}
                                                         <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{endpointName}}/{{sourceIndex}}/{{instance.serviceControlId}}">
                                                             <i class="fa fa-envelope"></i>
                                                             <span class="badge badge-important ng-binding">{{instance.errorCount | metricslargenumber}}</span>


### PR DESCRIPTION
## Overview
Currently we are showing `instance.id` on the instance breakdown grid. This does not work as expected when users overrides `HostDisplayName` and does not use `instanceId` argument.

/cc: @danielmarbach 