### PR TITLE
Failed msg group links removed from message type detail table

### DIFF
--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -280,6 +280,12 @@
                                                 <span class="warning" ng-if="instance.isStale">
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
                                                 </span>
+                                                <span class="warning" ng-if="instance.errorCount">
+                                                    <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{endpointName}}/{{sourceIndex}}/{{instance.serviceControlId}}">
+                                                        <i class="fa fa-envelope"></i>
+                                                        <span class="badge badge-important ng-binding">{{instance.errorCount | metricslargenumber}}</span>
+                                                    </a>
+                                                </span>
                                             </div>
                                         </div>
                                     </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -280,12 +280,6 @@
                                                 <span class="warning" ng-if="instance.isStale">
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
                                                 </span>
-                                                <span class="warning" ng-if="instance.errorCount">
-                                                    <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{endpointName}}/{{sourceIndex}}/{{instance.serviceControlId}}">
-                                                        <i class="fa fa-envelope"></i>
-                                                        <span class="badge badge-important ng-binding">{{instance.errorCount | metricslargenumber}}</span>
-                                                    </a>
-                                                </span>
                                             </div>
                                         </div>
                                     </div>
@@ -406,12 +400,6 @@
                                                 </span>
                                                 <span class="warning" ng-if="endpoint.isStale">
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
-                                                </span>
-                                                <span class="warning" ng-if="endpoint.errorCount">
-                                                    <a ng-if="endpoint.errorCount" class="warning btn" href="#/failed-messages/groups/{{endpoint.serviceControlId}}">
-                                                        <i class="fa fa-envelope"></i>
-                                                        <span class="badge badge-important ng-binding">{{endpoint.errorCount | metricslargenumber}}</span>
-                                                    </a>
                                                 </span>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Overview
This PR removes the failed message group links from breakdown tables by message type on monitored endpoint details. This is caused by the fact that current grouping in SC is performed on the basis of `messageType` value. 

This is problematic as different logical endpoints can process the same message type. This can be solved in the future by introducing new groupings in SC that will be based on (endpoint_name, message_type) pairs.

## Sample problematic setup (based on `MonitoringDemo`)
Two endpoints `Shipping` and `Billing` each subscribed to `OrderCreated` event. 