### PR TITLE
Removed experimental icon from queue length headers

### DIFF
--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -54,13 +54,7 @@
                 <div class="col-sm-12 no-side-padding graph-values">
                     <div class="row queue-length-values tooltip-trigger">
                         <div class="metric-digest-header">
-                            Queue Length <i class="fa fa-flask fake-link"></i>
-                        </div>
-                        <div class="interactive-tooltip">
-                            <div class="tooltip-contents">
-                                <p>Queue length: The estimated number of messages in an endpoint's queue.</p>
-                                <p>NOTE: This is an experimental feature. <a href="https://docs.particular.net/monitoring/metrics/definitions#metrics-captured-queue-length-known-limitations" target="_blank">Learn more</a> <i class="fa fa-external-link fake-link"></i></p>
-                            </div>
+                            Queue Length
                         </div>
                     </div>
                     <div class="row metric-digest-value current">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -52,9 +52,11 @@
                 </large-graph>
 
                 <div class="col-sm-12 no-side-padding graph-values">
-                    <div class="row queue-length-values tooltip-trigger">
-                        <div class="metric-digest-header">
-                            Queue Length
+                    <div class="queue-length-values">
+                        <div class="row">
+                            <span class="metric-digest-header" uib-tooltip="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint.">
+                                Queue Length
+                            </span>
                         </div>
                     </div>
                     <div class="row metric-digest-value current">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -28,14 +28,7 @@
                 <div class="row box-header">
                     <div class="col-sm-12 no-side-padding">
                         <div class="tooltip-trigger">
-                            Queue Length <span class="table-header-unit">(msgs)</span> <i class="fa fa-flask fake-link"></i>
-                            <div class="interactive-tooltip">
-                                <div class="tooltip-contents">
-                                    <p>Queue length: The estimated number of messages in an endpoint's queue.</p>
-                                    <p>WARNING: This is an experimental feature. <a href="https://docs.particular.net/monitoring/metrics/definitions#metrics-captured-queue-length-known-limitations" target="_blank">Learn more</a> <i class="fa fa-external-link fake-link"></i>
-                                    </p>
-                                </div>
-                            </div>
+                            Queue Length <span class="table-header-unit">(msgs)</span>
                         </div>
                     </div>
                 </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -26,10 +26,8 @@
             </div>
             <div class="col-sm-2 col-xl-1 no-side-padding">
                 <div class="row box-header">
-                    <div class="col-sm-12 no-side-padding">
-                        <div class="tooltip-trigger">
-                            Queue Length <span class="table-header-unit">(msgs)</span>
-                        </div>
+                    <div class="col-sm-12 no-side-padding" uib-tooltip="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint.">
+                        Queue Length <span class="table-header-unit">(msgs)</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This is part of Native Queue length implementation. Native ql is not experimental anymore.