### PR TITLE
Notify users of long-running reindex processes

### DIFF
--- a/src/ServicePulse.Host.Tests/SpecsRunner.html
+++ b/src/ServicePulse.Host.Tests/SpecsRunner.html
@@ -61,6 +61,7 @@
     <script src="../servicepulse.host/app/js/directives/ui.particular.redirectLink.js"></script>
     <script src="../servicepulse.host/app/js/directives/ui.particular.largenumber.js"></script>
     <script src="../servicepulse.host/app/js/directives/ui.particular.multi-checkboxlist.js"></script>
+    <script src="../servicepulse.host/app/js/directives/ui.particular.reindexingStatus.js"></script>
 
     <!-- Mystery -->
     <script src="../servicepulse.host/app/js/views/event_log_items/eventLogItems.js"></script>

--- a/src/ServicePulse.Host.Tests/SpecsRunner.html
+++ b/src/ServicePulse.Host.Tests/SpecsRunner.html
@@ -34,6 +34,7 @@
     <script src="../servicepulse.host/app/js/services/services.uri.js"></script>
     <script src="../servicepulse.host/app/js/services/service.toast.js"></script>
     <script src="../servicepulse.host/app/js/services/factory.listener.js"></script>
+    <script src="../servicepulse.host/app/js/services/factory.reindexingChecker.js"></script>
     <script src="../servicepulse.host/app/js/services/factory.notifier.js"></script>
     <script src="../servicepulse.host/app/js/services/factory.shareddata.js"></script>
     <script src="../servicepulse.host/app/js/services/services.endpoints.js"></script>

--- a/src/ServicePulse.Host/ServicePulse.Host.csproj
+++ b/src/ServicePulse.Host/ServicePulse.Host.csproj
@@ -273,7 +273,6 @@
     <Content Include="app\modules\monitoring\views\endpoint_details.html" />
     <Content Include="app\modules\monitoring\views\monitored_endpoints.html" />
     <Content Include="app\modules\monitoring\views\monitoring_not_available.html" />
-    <Content Include="app\modules\recoverability\recoverability.js" />
     <Content Include="app\modules\shell\shell.js" />
     <Content Include="app\NoIE.html" />
     <Content Include="app\js\views\dashboard\dashboard.html" />
@@ -296,12 +295,14 @@
     <Content Include="app\js\services\services.uri.js" />
     <Content Include="app\modules\monitoring\js\directives\ui.particular.graph.js" />
     <Content Include="app\js\directives\ui.particular.largenumber.js" />
+    <Content Include="app\js\services\factory.reindexingChecker.js" />
     <None Include="bundleconfig.json" />
     <None Include="package.json" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/ServicePulse.Host/ServicePulse.Host.csproj
+++ b/src/ServicePulse.Host/ServicePulse.Host.csproj
@@ -93,12 +93,14 @@
     <Content Include="app\img\redirect-source.svg" />
     <Content Include="app\js\app.http.js" />
     <Content Include="app\js\app.logging.js" />
+    <Content Include="app\js\directives\ui.particular.reindexingstatus.tpl.html" />
     <Content Include="app\js\directives\ui.particular.confirmclick.tpl.html" />
     <Content Include="app\js\directives\ui.particular.busy.js" />
     <Content Include="app\js\directives\ui.particular.busy.tpl.html" />
     <Content Include="app\js\directives\ui.particular.configurationTabs.js" />
     <Content Include="app\js\directives\ui.particular.multi-checkboxlist.tpl.html" />
     <Content Include="app\js\directives\ui.particular.multi-checkboxlist.js" />
+    <Content Include="app\js\directives\ui.particular.reindexingStatus.js" />
     <Content Include="app\js\polyfill\array.prototype.find.js" />
     <Content Include="app\modules\modules.webpackconfig.builder.js" />
     <Content Include="app\modules\monitoring\js\constant.diagrams.js" />

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2183,7 +2183,8 @@ div.alert.alert-warning strong {
     text-transform: uppercase;
 }
 
-.sticky-warning.alert.alert-warning {
+.sticky-warning.alert.alert-warning,
+.alert.alert-warning {
     font-size: 16px;
     margin-bottom: 32px;
 }

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2182,3 +2182,8 @@ div.alert.alert-warning i.fa.fa-warning {
 div.alert.alert-warning strong {
     text-transform: uppercase;
 }
+
+.sticky-warning.alert.alert-warning {
+    font-size: 16px;
+    margin-bottom: 32px;
+}

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -163,6 +163,12 @@ footer {
     transition: box-shadow 0.25s ease 0s;
 }
 
+.box.bg-warning {
+    background-color: #fcf8e3;
+    margin-bottom: 1em;
+    border: 0px;
+}
+
 .fa {
     color: #929e9e;
 }

--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -179,6 +179,7 @@
 <script src="js/directives/ui.particular.redirectLink.js"></script>
 <script src="js/directives/ui.particular.largenumber.js"></script>
 <script src="js/directives/ui.particular.multi-checkboxlist.js"></script>
+<script src="js/directives/ui.particular.reindexingStatus.js"></script>
 
 <!-- Mystery -->
 <script src="js/views/event_log_items/eventLogItems.js"></script>

--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -155,6 +155,7 @@
 <script src="js/services/services.historyperiods.js"></script>
 <script src="js/services/service.toast.js"></script>
 <script src="js/services/factory.listener.js"></script>
+<script src="js/services/factory.reindexingChecker.js"></script>
 <script src="js/services/factory.notifier.js"></script>
 <script src="js/services/factory.shareddata.js"></script>
 <script src="js/services/services.endpoints.js"></script>

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -1,6 +1,6 @@
 ﻿;
 (function(window, angular, undefined) {
-    "use strict";
+    'use strict';
 
     function controller(
         $scope,
@@ -15,7 +15,8 @@
         notifyService,
         semverService,
         scConfig,
-        uriService
+        uriService,
+        reindexingChecker
     ) {
         $scope.isMonitoringEnabled = scConfig.monitoring_urls && scConfig.monitoring_urls.reduce(function (currentlyEnabled, url) {
             return currentlyEnabled || url;
@@ -38,8 +39,8 @@
             }
         });
 
-        $scope.$on("$routeChangeError", function(event, current, previous, rejection) {
-            toastService.showError("Route change error");
+        $scope.$on('$routeChangeError', function(event, current, previous, rejection) {
+            toastService.showError('Route change error');
         });
 
         $scope.showAlertBadgeOnCollapsedMenu = function () {
@@ -48,7 +49,7 @@
 
         function customChecksUpdated(event, data) {
             $timeout(function() { //http://davidburgosonline.com/dev/2014/correctly-fix-angularjs-error-digest-already-in-progress/
-                data = (data === 0 || data === "0") ? undefined : data;
+                data = (data === 0 || data === '0') ? undefined : data;
                 $scope.failedcustomchecks = data;
                 logit(data);
             });
@@ -56,7 +57,7 @@
 
         function messageFailuresUpdated(event, data) {
             $timeout(function() {
-                data = (data === 0 || data === "0") ? undefined : data;
+                data = (data === 0 || data === '0') ? undefined : data;
                 $scope.failedmessages = data;
                 logit(data);
             });
@@ -64,7 +65,7 @@
 
         function heartbeatsUpdated(event, data) {
             $timeout(function() {
-                data = (data === 0 || data === "0") ? undefined : data;
+                data = (data === 0 || data === '0') ? undefined : data;
                 $scope.failedheartbeats = data.failing;
                 logit(data);
             });
@@ -76,40 +77,40 @@
 
         var notifier = notifyService();
 
-        notifier.subscribe($scope, customChecksUpdated, "CustomChecksUpdated");
-        notifier.subscribe($scope, messageFailuresUpdated, "MessageFailuresUpdated");
-        notifier.subscribe($scope, heartbeatsUpdated, "HeartbeatsUpdated");
-        notifier.subscribe($scope, logit, "ArchiveGroupRequestAccepted");
+        notifier.subscribe($scope, customChecksUpdated, 'CustomChecksUpdated');
+        notifier.subscribe($scope, messageFailuresUpdated, 'MessageFailuresUpdated');
+        notifier.subscribe($scope, heartbeatsUpdated, 'HeartbeatsUpdated');
+        notifier.subscribe($scope, logit, 'ArchiveGroupRequestAccepted');
 
         notifier.subscribe($scope, function(event, data) {
             $scope.SCVersion = data.sc_version;
             $scope.is_compatible_with_sc = data.is_compatible_with_sc;
             if (!data.is_compatible_with_sc) {
-                var scNeedsUpgradeMessage = "You are using Service Control version " + data.sc_version + ". Please, upgrade to version " + data.minimum_supported_sc_version + " or higher to unlock new functionality in ServicePulse.";
+                var scNeedsUpgradeMessage = 'You are using Service Control version ' + data.sc_version + '. Please, upgrade to version ' + data.minimum_supported_sc_version + ' or higher to unlock new functionality in ServicePulse.';
                 toastService.showError(scNeedsUpgradeMessage);
                 $location.path('/about');
             }
-        }, "EnvironmentUpdated");
+        }, 'EnvironmentUpdated');
 
         notifier.subscribe($scope, function (event, data) {
             toastService.showError('Your license has expired. Please contact Particular Software support at: <a href="http://particular.net/support">http://particular.net/support</a>');
-        }, "ExpiredLicense");
+        }, 'ExpiredLicense');
 
         notifier.subscribe($scope, function(event, data) {
             logit(event, data);
-            toastService.showError("Group" + data.title + " Archive Request Rejected");
-        }, "ArchiveGroupRequestRejected");
+            toastService.showError('Group' + data.title + ' Archive Request Rejected');
+        }, 'ArchiveGroupRequestRejected');
 
-        notifier.subscribe($scope, logit, "RetryGroupRequestAccepted");
+        notifier.subscribe($scope, logit, 'RetryGroupRequestAccepted');
 
         notifier.subscribe($scope, function(event, data) {
             logit(event, data);
-            toastService.showError("Group" + data.title + " Retry Request Rejected");
-        }, "RetryGroupRequestRejected");
+            toastService.showError('Group' + data.title + ' Retry Request Rejected');
+        }, 'RetryGroupRequestRejected');
 
-        notifier.subscribe($scope, logit, "MessageFailedRepeatedly");
-        notifier.subscribe($scope, logit, "MessageFailed");
-        notifier.subscribe($scope, logit, "MessagesSubmittedForRetry");
+        notifier.subscribe($scope, logit, 'MessageFailedRepeatedly');
+        notifier.subscribe($scope, logit, 'MessageFailed');
+        notifier.subscribe($scope, logit, 'MessagesSubmittedForRetry');
 
         notifier.subscribe($scope, function(event, data) {
             logit(event, data);
@@ -125,142 +126,146 @@
                     toastService.showWarning(data);
                     break;
             }
-
        
-        }, "SignalREvent");
+        }, 'SignalREvent');
 
         notifier.subscribe($scope, function(event, data) {
             logit(event, data);
             toastService.showError(data);
-        }, "SignalRError");
+        }, 'SignalRError');
 
         notifier.subscribe($scope, function(event, data) {
-            var message = "There was a problem retrieving your data";
+            var message = 'There was a problem retrieving your data';
             logit(event, message);
             toastService.showError(message);
-        }, "HttpError");
+        }, 'HttpError');
 
+        notifier.subscribe($scope, function (event, data) {
+            toastService.showInfo(data);
+        }, 'reindexing');
 
         // signalR Listener
-        var listener = signalRListener(uriService.join(scConfig.service_control_url, "messagestream"));
+        var listener = signalRListener(uriService.join(scConfig.service_control_url, 'messagestream'));
 
         listener.subscribe($scope, function(message) {
-            notifier.notify("SignalREvent", message);
-        }, "SignalREvent");
+            notifier.notify('SignalREvent', message);
+        }, 'SignalREvent');
 
         listener.subscribe($scope, function(message) {
-            notifier.notify("SignalRError", message);
-        }, "SignalRError");
+            notifier.notify('SignalRError', message);
+        }, 'SignalRError');
 
         listener.subscribe($scope, function(message) {
-            notifier.notify("CustomChecksUpdated", message.failed);
-        }, "CustomChecksUpdated");
+            notifier.notify('CustomChecksUpdated', message.failed);
+        }, 'CustomChecksUpdated');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("MessageRedirectCreated", message);
-        }, "MessageRedirectCreated");
+            notifier.notify('MessageRedirectCreated', message);
+        }, 'MessageRedirectCreated');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("MessageRedirectChanged", message);
-        }, "MessageRedirectChanged");
+            notifier.notify('MessageRedirectChanged', message);
+        }, 'MessageRedirectChanged');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("MessageRedirectRemoved", message);
-        }, "MessageRedirectRemoved");
+            notifier.notify('MessageRedirectRemoved', message);
+        }, 'MessageRedirectRemoved');
 
         listener.subscribe($scope, function(message) {
-            notifier.notify("MessageFailed", message);
-        }, "MessageFailed");
+            notifier.notify('MessageFailed', message);
+        }, 'MessageFailed');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("MessageFailureResolvedManually", message);
-        }, "MessageFailureResolvedManually");
+            notifier.notify('MessageFailureResolvedManually', message);
+        }, 'MessageFailureResolvedManually');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("MessagesSubmittedForRetry", message);
-        }, "MessagesSubmittedForRetry");
+            notifier.notify('MessagesSubmittedForRetry', message);
+        }, 'MessagesSubmittedForRetry');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("MessageFailureResolvedByRetry", message);
-        }, "MessageFailureResolvedByRetry");
+            notifier.notify('MessageFailureResolvedByRetry', message);
+        }, 'MessageFailureResolvedByRetry');
         
         listener.subscribe($scope, function (message) {
             logit(message);
        
-            notifier.notify("MessageFailuresUpdated", message.unresolved_total || message.total);
-            notifier.notify("ArchivedMessagesUpdated", message.archived_total || 0);
+            notifier.notify('MessageFailuresUpdated', message.unresolved_total || message.total);
+            notifier.notify('ArchivedMessagesUpdated', message.archived_total || 0);
 
             
-        }, "MessageFailuresUpdated");
+        }, 'MessageFailuresUpdated');
 
         listener.subscribe($scope, function(message) {
-            notifier.notify("HeartbeatsUpdated", {
+            notifier.notify('HeartbeatsUpdated', {
                 failing: message.failing,
                 active: message.active
             });
-        }, "HeartbeatsUpdated");
+        }, 'HeartbeatsUpdated');
 
         listener.subscribe($scope, function(message) {
-            notifier.notify("EventLogItemAdded", message);
-        }, "EventLogItemAdded");
+            notifier.notify('EventLogItemAdded', message);
+        }, 'EventLogItemAdded');
 
         listener.subscribe($scope, function(message) {
-            notifier.notify("MessagesSubmittedForRetry", message);
-        }, "MessagesSubmittedForRetry");
+            notifier.notify('MessagesSubmittedForRetry', message);
+        }, 'MessagesSubmittedForRetry');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("FailedMessageGroupArchived", message);
-        }, "FailedMessageGroupArchived");
+            notifier.notify('FailedMessageGroupArchived', message);
+        }, 'FailedMessageGroupArchived');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("ArchiveOperationStarting", message);
-        }, "ArchiveOperationStarting");
+            notifier.notify('ArchiveOperationStarting', message);
+        }, 'ArchiveOperationStarting');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("ArchiveOperationBatchCompleted", message);
-        }, "ArchiveOperationBatchCompleted");
+            notifier.notify('ArchiveOperationBatchCompleted', message);
+        }, 'ArchiveOperationBatchCompleted');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("ArchiveOperationCompleted", message);
-        }, "ArchiveOperationCompleted");
+            notifier.notify('ArchiveOperationCompleted', message);
+        }, 'ArchiveOperationCompleted');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("RetryOperationWaiting", message);
-        }, "RetryOperationWaiting");
+            notifier.notify('RetryOperationWaiting', message);
+        }, 'RetryOperationWaiting');
         
         listener.subscribe($scope, function (message) {
-            notifier.notify("RetryOperationPreparing", message);
-        }, "RetryOperationPreparing");
+            notifier.notify('RetryOperationPreparing', message);
+        }, 'RetryOperationPreparing');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("RetryOperationForwarding", message);
-        }, "RetryOperationForwarding");
+            notifier.notify('RetryOperationForwarding', message);
+        }, 'RetryOperationForwarding');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("RetryOperationForwarded", message);
-        }, "RetryOperationForwarded");
+            notifier.notify('RetryOperationForwarded', message);
+        }, 'RetryOperationForwarded');
 
         listener.subscribe($scope, function (message) {
-            notifier.notify("RetryOperationCompleted", message);
-        }, "RetryOperationCompleted");
+            notifier.notify('RetryOperationCompleted', message);
+        }, 'RetryOperationCompleted');
+
+        reindexingChecker.startTrackingStatus();
     };
 
     controller.$inject = [
-        "$scope",
-        "$log",
-        "$timeout",
-        "$location",
-        "$window",
-        "serviceControlService",
-        "version",
-        "toastService",
-        "signalRListener",
-        "notifyService",
-        "semverService",
-        "scConfig",
-        "uri"
+        '$scope',
+        '$log',
+        '$timeout',
+        '$location',
+        '$window',
+        'serviceControlService',
+        'version',
+        'toastService',
+        'signalRListener',
+        'notifyService',
+        'semverService',
+        'scConfig',
+        'uri',
+        'reindexingChecker'
     ];
 
-    angular.module("sc").controller("AppCtrl", controller);
-
+    angular.module('sc').controller('AppCtrl', controller);
 }(window, window.angular));

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -8,6 +8,7 @@
         $timeout,
         $location,
         $window,
+        $rootScope,
         serviceControlService,
         version,
         toastService,
@@ -142,6 +143,12 @@
 
         notifier.subscribe($scope, function (event, data) {
             toastService.showInfo(data);
+
+            if (data === 'ServiceControl is busy recreating indexes after a database upgrade...') {
+                $rootScope.busyReindexingDatabase = true;
+            } else if (data === 'Reindexing after database upgrade has completed.') {
+                $rootScope.busyReindexingDatabase = false;
+            }
         }, 'reindexing');
 
         // signalR Listener
@@ -256,6 +263,7 @@
         '$timeout',
         '$location',
         '$window',
+        '$rootScope',
         'serviceControlService',
         'version',
         'toastService',

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.js
@@ -21,6 +21,7 @@
         'ui.particular.graphduration',
         'ui.particular.graphdecimal',
         'ui.particular.multicheckboxList',
+        'ui.particular.reindexingstatus',
     ]);
 
 } (window, window.angular));

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.reindexingStatus.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.reindexingStatus.js
@@ -1,0 +1,29 @@
+﻿; (function (window, angular, undefined) {
+    'use strict';
+
+    function directive($rootScope) {
+        return {
+            scope: {
+                busyReindexingDatabase: '@'
+            },
+            restrict: 'E',
+            replace: true,
+            templateUrl: 'js/directives/ui.particular.reindexingstatus.tpl.html',
+            link: function (scope, element) {
+                scope.busyReindexingDatabase = $rootScope.busyReindexingDatabase;
+
+                scope.$watch(function () {
+                    return $rootScope.busyReindexingDatabase;
+                }, function () {
+                    scope.busyReindexingDatabase = $rootScope.busyReindexingDatabase;
+                }, true);
+            }
+        };
+    }
+
+    directive.$inject = ['$rootScope'];
+
+    angular.module('ui.particular.reindexingstatus', [])
+        .directive('reindexingstatus', directive);
+
+} (window, window.angular));

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.reindexingstatus.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.reindexingstatus.tpl.html
@@ -1,8 +1,9 @@
 ﻿<div class="row" ng-if="busyReindexingDatabase">
-    <div class="col-sm-12 bg-warning box">
-        <span>
-            <i class="fa fa-warning"></i>
-            ServiceControl is in the process of re-indexing the data after a database upgrade. While this process is ongoing there will be inconsistencies in the data displayed
-        </span>
+    <div class="col-sm-12">
+        <div class="sticky-warning alert alert-warning">
+            <i class="fa fa-warning alert-warning" aria-hidden="true"></i>
+            <strong>Warning:</strong>
+            ServiceControl is in the process of re-indexing the data after a database upgrade. While this process is ongoing there will be inconsistencies in the data displayed.
+        </div>
     </div>
 </div>

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.reindexingstatus.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.reindexingstatus.tpl.html
@@ -1,0 +1,8 @@
+﻿<div class="row" ng-if="busyReindexingDatabase">
+    <div class="col-sm-12 bg-warning box">
+        <span>
+            <i class="fa fa-warning"></i>
+            ServiceControl is in the process of re-indexing the data after a database upgrade. While this process is ongoing there will be inconsistencies in the data displayed
+        </span>
+    </div>
+</div>

--- a/src/ServicePulse.Host/app/js/services/factory.reindexingChecker.js
+++ b/src/ServicePulse.Host/app/js/services/factory.reindexingChecker.js
@@ -1,0 +1,55 @@
+﻿; (function (window, angular, undefined) {
+	'use strict';
+
+	function factory($rootScope, serviceControlService, notifyService) {
+		var notifier = notifyService();
+
+		var trackingInterval;
+		var previousStatus;
+
+		function startTrackingStatus() {
+			stopTrackingStatus();
+
+			trackingInterval = setInterval(function () {
+				serviceControlService.isBusyUpgradingIndexes().then(function (result) {
+					var inProgress = result.data.in_progress;
+
+					if (inProgress != previousStatus) {
+						if (inProgress && typeof previousStatus == 'undefined') {
+							notifier.notify('reindexing', 'ServiceControl is busy recreating indexes after a database upgrade...');
+						} else if (previousStatus) {
+							notifier.notify('reindexing', 'Reindexing after database upgrade has completed.');
+						}
+
+						previousStatus = inProgress;
+					}
+				});
+			}, 60000);
+		}
+
+		function stopTrackingStatus() {
+			if (trackingInterval) {
+				clearInterval(trackingInterval);
+
+				trackingInterval = undefined;
+			}
+
+			previousStatus = undefined;
+		}
+
+		return {
+			startTrackingStatus: startTrackingStatus,
+			stopTrackingStatus: stopTrackingStatus
+		};
+	}
+
+	factory.$inject = [
+        '$rootScope',
+        'serviceControlService',
+		'notifyService'
+	];
+
+	angular.module('sc')
+        .service('reindexingChecker', factory);
+
+} (window, window.angular));

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -294,6 +294,12 @@
             return $http.get(url);
         }
 
+        function isBusyUpgradingIndexes() {
+            var url = uri.join(scConfig.service_control_url, 'upgrade');
+
+            return $http.get(url);
+        }
+
         var service = {
             getVersion: getVersion,
             checkLicense: checkLicense,
@@ -326,7 +332,8 @@
             getHeartbeatStats: getHeartbeatStats,
             loadQueueNames: loadQueueNames,
             acknowledgeGroup: acknowledgeGroup,
-            getFailedMessageById: getFailedMessageById
+            getFailedMessageById: getFailedMessageById,
+            isBusyUpgradingIndexes: isBusyUpgradingIndexes
         };
 
         return service;

--- a/src/ServicePulse.Host/app/js/views/archive/view.html
+++ b/src/ServicePulse.Host/app/js/views/archive/view.html
@@ -1,4 +1,6 @@
 ﻿<div class="container">
+    <reindexingstatus></reindexingstatus>
+
     <section name="failed_messages">
 
         <failed-message-tabs></failed-message-tabs>
@@ -42,7 +44,7 @@
             <div class="col-sm-12 no-mobile-side-padding" ng-repeat="message in vm.archives">
 
                 <div class="row box failed-message">
- 
+
                     <multi-checkboxlist messages="vm.archives" selected-ids="vm.selectedIds" message="message" multiselection="vm.multiselection"></multi-checkboxlist>
 
                     <div class="col-xs-11 failed-message-data" ng-mouseenter="message.hover2 = true" ng-mouseleave="message.hover2 = false">
@@ -55,7 +57,7 @@
                                         <span ng-if="message.retried" tooltip="Message is being retried" class="label sidebar-label label-info">Retried</span>
                                         <span ng-if="message.archived" tooltip="Message is being archived" class="label sidebar-label label-warning">Archived</span>
                                         <span ng-if="message.number_of_processing_attempts > 1" tooltip="This message has already failed {{message.number_of_processing_attempts}} times" class="label sidebar-label label-important">{{message.number_of_processing_attempts}} Retry Failures</span>
-                                            
+
                                         <span class="metadata"><i class="fa fa-clock-o"></i> Failed: <sp-moment date="{{message.time_of_failure}}"></sp-moment></span>
                                         <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{message.receiving_endpoint.name}}</span>
                                         <span class="metadata"><i class="fa fa-laptop"></i> Machine: {{message.receiving_endpoint.host}}</span>
@@ -70,12 +72,12 @@
                             </div>
                         </a>
                     </div>
-                        
+
                 </div>
             </div>
         </div>
 
-        
+
     </section>
 
 </div>

--- a/src/ServicePulse.Host/app/js/views/configuration/configuration.html
+++ b/src/ServicePulse.Host/app/js/views/configuration/configuration.html
@@ -1,4 +1,6 @@
 <div class="container">
+    <reindexingstatus></reindexingstatus>
+
     <div class="row">
         <div class="col-sm-12 padded">
             <h1>Configuration</h1>
@@ -8,7 +10,6 @@
 
 <div class="container">
     <section name="configuration">
-        <reindexingstatus></reindexingstatus>
         <configuration-tabs></configuration-tabs>
 
         <div class="row">

--- a/src/ServicePulse.Host/app/js/views/configuration/configuration.html
+++ b/src/ServicePulse.Host/app/js/views/configuration/configuration.html
@@ -1,18 +1,14 @@
 <div class="container">
     <div class="row">
-
         <div class="col-sm-12 padded">
             <h1>Configuration</h1>
-
         </div>
-
     </div>
-
 </div>
 
 <div class="container">
     <section name="configuration">
-
+        <reindexingstatus></reindexingstatus>
         <configuration-tabs></configuration-tabs>
 
         <div class="row">

--- a/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
+++ b/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
@@ -1,4 +1,6 @@
 <div class="container">
+    <reindexingstatus></reindexingstatus>
+
     <div class="row">
         <div class="col-sm-12 padded">
             <h1>Custom checks</h1>
@@ -7,8 +9,6 @@
 </div>
 
 <div class="container">
-    <reindexingstatus></reindexingstatus>
-
     <section name="custom_checks">
 
         <busy ng-show="loadingData" message="fetching more data"></busy>

--- a/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
+++ b/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
@@ -7,11 +7,13 @@
 </div>
 
 <div class="container">
+    <reindexingstatus></reindexingstatus>
+
     <section name="custom_checks">
 
         <busy ng-show="loadingData" message="fetching more data"></busy>
 
-        <no-data ng-show="!loadingData && model.total == 0"  message="No failed custom checks"></no-data>
+        <no-data ng-show="!loadingData && model.total == 0" message="No failed custom checks"></no-data>
 
         <div class="row">
             <div class="col-sm-12">
@@ -25,7 +27,8 @@
                                         <div class="col-sm-12 no-side-padding">
                                             <p class="lead">{{item.failure_reason}}</p>
                                             <p>{{item.custom_check_id}} </p>
-                                            <p>{{item.category}} reported by {{item.originating_endpoint.name}} on {{item.originating_endpoint.host}} <sp-moment date="{{item.reported_at}}"></sp-moment>
+                                            <p>
+                                                {{item.category}} reported by {{item.originating_endpoint.name}} on {{item.originating_endpoint.host}} <sp-moment date="{{item.reported_at}}"></sp-moment>
                                             </p>
                                         </div>
                                     </div>
@@ -38,7 +41,7 @@
                             </div>
                         </div>
                     </div>
-                  
+
 
                 </div>
             </div>

--- a/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
+++ b/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
@@ -10,6 +10,7 @@
 </div>
 
 <div class="container">
+    <reindexingstatus></reindexingstatus>
 
     <div class="row">
         <div class="col-sm-12">
@@ -23,10 +24,10 @@
                                 <span ng-show="failedheartbeats > 0" class="badge badge-important">{{failedheartbeats | largeNumber:0}}</span>
                                 <h4>
                                     Heartbeats
-                                    
+
                                 </h4>
                             </a>
-                       
+
                         </div>
                         <div class="col-sm-4">
                             <a class="summary-item" ng-class="{  'summary-danger'  : failedmessages > 0 , 'summary-info' : failedmessages === 0 || !failedmessages }" href="#/failed-messages/groups">
@@ -34,7 +35,7 @@
                                 <span ng-show="failedmessages > 0" class="badge badge-important">{{failedmessages | largeNumber:0}}</span>
                                 <h4>
                                     Failed Messages
-                                    
+
                                 </h4>
                             </a>
                         </div>
@@ -44,12 +45,12 @@
                                 <span ng-show="failedcustomchecks > 0" class="badge badge-important">{{failedcustomchecks | largeNumber:0}}</span>
                                 <h4>
                                     Custom Checks
-                                    
+
                                 </h4>
                             </a>
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
 

--- a/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
+++ b/src/ServicePulse.Host/app/js/views/dashboard/dashboard.html
@@ -1,17 +1,14 @@
 <div class="container">
-    <div class="row">
+    <reindexingstatus></reindexingstatus>
 
+    <div class="row">
         <div class="col-sm-12">
             <h1>Dashboard</h1>
         </div>
-
     </div>
-
 </div>
 
 <div class="container">
-    <reindexingstatus></reindexingstatus>
-
     <div class="row">
         <div class="col-sm-12">
             <h6>System status</h6>

--- a/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
@@ -7,7 +7,7 @@
 </div>
 
 <div class="container">
-
+    <reindexingstatus></reindexingstatus>
 
     <div class="tabs">
         <h5 ng-class="{active: isActiveEndpoints != true}"><a ng-click="isActiveEndpoints = false">Inactive Endpoints ({{model.inactive.length | number}})</a></h5>

--- a/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
+++ b/src/ServicePulse.Host/app/js/views/endpoints/endpoints.html
@@ -1,4 +1,6 @@
 <div class="container">
+    <reindexingstatus></reindexingstatus>
+
     <div class="row">
         <div class="col-sm-12 no-side-padding">
             <h1>Endpoint heartbeats</h1>
@@ -7,8 +9,6 @@
 </div>
 
 <div class="container">
-    <reindexingstatus></reindexingstatus>
-
     <div class="tabs">
         <h5 ng-class="{active: isActiveEndpoints != true}"><a ng-click="isActiveEndpoints = false">Inactive Endpoints ({{model.inactive.length | number}})</a></h5>
         <h5 ng-class="{active: isActiveEndpoints == true}"><a ng-click="isActiveEndpoints = true">Active Endpoints ({{model.active.length | number}})</a></h5>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -1,4 +1,5 @@
 ﻿<div class="container">
+    <reindexingstatus></reindexingstatus>
 
     <section name="message_groups">
 
@@ -9,7 +10,7 @@
                 <h6>
                     <span class="no-link-underline" aria-hidden="true" ng-show="vm.showHistoricRetries"><i class="fa fa-angle-down" aria-hidden="true"></i> </span>
                     <span class="fake-link" aria-hidden="true" ng-show="!vm.showHistoricRetries"><i class="fa fa-angle-right" aria-hidden="true"></i> </span>
-                    <a type="button" ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed retry requests</a>
+                    <a ng-click="vm.showHistoricRetries = !vm.showHistoricRetries">Last 10 completed retry requests</a>
                 </h6>
             </div>
             <div class="col-sm-12 no-mobile-side-padding" ng-show="vm.showHistoricRetries">
@@ -68,7 +69,7 @@
         <div class="row">
             <div class="col-sm-12">
                 <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
-                 <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
+                <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
             </div>
         </div>
 

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -1,9 +1,10 @@
 ﻿<div class="container">
+    <reindexingstatus></reindexingstatus>
+
     <section name="failed_messages">
         <div ng-show="!vm.selectedExceptionGroup.id">
             <failed-message-tabs></failed-message-tabs>
         </div>
-
 
         <div class="row" ng-show="vm.selectedExceptionGroup.id && vm.failedMessages.length > 0">
             <div class="col-sm-12">
@@ -32,7 +33,7 @@
                     <button type="button" class="btn btn-default" confirm-title="Are you sure you want to archive the selected messages?" confirm-message="If you archive, these messages won't be available for retrying unless they're later unarchived." confirm-click="vm.archiveSelected()" ng-disabled="vm.selectedIds.length == 0"><i class="fa fa-archive"></i> Archive {{vm.selectedIds.length | number}} selected</button>
                     <button type="button" class="btn btn-default" confirm-title="Are you sure you want to retry the whole group?" confirm-message="Retrying a whole group can take some time and put extra load on your system. Are you sure you want to retry all these messages?" confirm-click="vm.retryExceptionGroup(vm.selectedExceptionGroup)"><i class="fa fa-repeat"></i> Retry all</button>
                     <button type="button" class="btn btn-default" ng-show="vm.selectedExceptionGroup.id" confirm-title="Are you sure you want to archive this group?" confirm-message="If you archive, the messages in the group won't be available for retrying unless they're later unarchived." confirm-click="vm.archiveExceptionGroup(vm.selectedExceptionGroup)"><i class="fa fa-archive"></i> Archive all</button>
-                    
+
                     <div class="msg-group-menu dropdown msg-list-dropdown">
                         <label class="control-label">Sort by:</label>
                         <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -62,9 +63,9 @@
         <div ng-show="vm.failedMessages.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup)" infinite-scroll-distance="0" infinite-scroll-disabled="vm.disableLoadingData">
             <div class="col-sm-12 no-mobile-side-padding">
                 <div class="row box repeat-item failed-message" ng-repeat="message in vm.failedMessages">
-                    
+
                     <multi-checkboxlist messages="vm.failedMessages" selected-ids="vm.selectedIds" message="message" multiselection="vm.multiselection"></multi-checkboxlist>
-                    
+
                     <div class="col-xs-11 failed-message-data" ng-mouseenter="message.hover2 = true" ng-mouseleave="message.hover2 = false">
                         <a href="#/failed-messages/message/{{message.id}}">
 
@@ -78,7 +79,7 @@
                                                 <span ng-if="message.retried" tooltip="Message is being retried" class="label sidebar-label label-info metadata-label">Retried</span>
                                                 <span ng-if="message.archived" tooltip="Message is being archived" class="label sidebar-label label-warning metadata-label">Archived</span>
                                                 <span ng-if="message.number_of_processing_attempts > 1" tooltip="This message has already failed {{message.number_of_processing_attempts}} times" class="label sidebar-label label-important metadata-label">{{message.number_of_processing_attempts}} Retry Failures</span>
-                                                
+
                                                 <span class="metadata"><i class="fa fa-clock-o"></i> Failed: <sp-moment date="{{message.time_of_failure}}"></sp-moment></span>
                                                 <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{message.receiving_endpoint.name}}</span>
                                                 <span class="metadata"><i class="fa fa-laptop"></i> Machine: {{message.receiving_endpoint.host}}</span>

--- a/src/ServicePulse.Host/app/js/views/message/messages-view.html
+++ b/src/ServicePulse.Host/app/js/views/message/messages-view.html
@@ -1,4 +1,6 @@
 ﻿<div class="container">
+    <reindexingstatus></reindexingstatus>
+
     <section name="failed_message">
         <div class="row">
             <div class="col-sm-12">


### PR DESCRIPTION
Connects to https://github.com/Particular/ServiceControl/issues/1144

This change works on all versions of SC so does not require a bump to the minimum version value. If connecting to a version 2 or greater version of ServiceControl it will report if RavenDB is busy re-indexing after a database upgrade.

The check is continual so that SP doesn't have to be refreshed after an upgrade.