### PR TITLE
Stop using javascript://

### DIFF
--- a/src/ServicePulse.Host/app/js/directives/ui.particular.redirectLink.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.redirectLink.tpl.html
@@ -1,10 +1,10 @@
 ﻿<span class="version-info">
     <span ng-hide="redirect">
         <i class="fa pa-redirect-source pa-redirect-small" uib-tooltip="Redirect"></i>
-        No redirect (<a href="javascript://" ng-click="createRedirect()">create</a>)
+        No redirect (<a href="#" ng-click="$event.preventDefault();createRedirect()">create</a>)
     </span>
     <span ng-show="redirect" uib-tooltip="{{redirect.to_physical_address}}">
         <i class="fa pa-redirect-source pa-redirect-small" uib-tooltip="Redirect"></i>
-        Redirect: {{redirect.to_physical_address}} (<a href="javascript://" ng-click="editRedirect(redirect)">modify</a>)
+        Redirect: {{redirect.to_physical_address}} (<a href="#" ng-click="$event.preventDefault();editRedirect(redirect)">modify</a>)
     </span>
 </span>

--- a/src/ServicePulse.Host/app/js/views/archive/view.html
+++ b/src/ServicePulse.Host/app/js/views/archive/view.html
@@ -16,16 +16,16 @@
                         </button>
                         <ul class="dropdown-menu">
                             <li>
-                                <a href="javascript://" ng-click="vm.selectTimeGroup()"><span class="fa fa-calendar" aria-hidden="true"></span> All Archived</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup()"><span class="fa fa-calendar" aria-hidden="true"></span> All Archived</a>
                             </li>
                             <li>
-                                <a href="javascript://" ng-click="vm.selectTimeGroup('2', 'hours')"><span class="fa fa-calendar" aria-hidden="true"></span> Archived in the last 2 Hours</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup('2', 'hours')"><span class="fa fa-calendar" aria-hidden="true"></span> Archived in the last 2 Hours</a>
                             </li>
                             <li>
-                                <a href="javascript://" ng-click="vm.selectTimeGroup('1', 'days')"><span class="fa fa-calendar" aria-hidden="true"></span> Archived in the last 1 Day</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup('1', 'days')"><span class="fa fa-calendar" aria-hidden="true"></span> Archived in the last 1 Day</a>
                             </li>
                             <li>
-                                <a href="javascript://" ng-click="vm.selectTimeGroup('7', 'days')"><span class="fa fa-calendar " aria-hidden="true"></span> Archived in the last 7 Days</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup('7', 'days')"><span class="fa fa-calendar " aria-hidden="true"></span> Archived in the last 7 Days</a>
                             </li>
                         </ul>
                     </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/view.html
@@ -57,7 +57,7 @@
                     </button>
                     <ul class="dropdown-menu">
                         <li ng-repeat="classifier in vm.availableClassifiers">
-                            <a href="javascript://" ng-click="vm.selectClassification(classifier)">{{classifier}}</a>
+                            <a href="#" ng-click="$event.preventDefault();vm.selectClassification(classifier)">{{classifier}}</a>
                         </li>
                     </ul>
                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -41,16 +41,16 @@
                         </button>
                         <ul class="dropdown-menu">
                             <li>
-                                <a href="javascript://" ng-click="vm.selectGroup(vm.selectedExceptionGroup, 'message_type', 'asc')"><span class="glyphicon glyphicon-sort-by-alphabet" aria-hidden="true"></span> Message Type (ascending)</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectGroup(vm.selectedExceptionGroup, 'message_type', 'asc')"><span class="glyphicon glyphicon-sort-by-alphabet" aria-hidden="true"></span> Message Type (ascending)</a>
                             </li>
                             <li>
-                                <a href="javascript://" ng-click="vm.selectGroup(vm.selectedExceptionGroup, 'message_type', 'desc')"><span class="glyphicon glyphicon-sort-by-alphabet-alt" aria-hidden="true"></span> Message Type (descending)</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectGroup(vm.selectedExceptionGroup, 'message_type', 'desc')"><span class="glyphicon glyphicon-sort-by-alphabet-alt" aria-hidden="true"></span> Message Type (descending)</a>
                             </li>
                             <li>
-                                <a href="javascript://" ng-click="vm.selectGroup(vm.selectedExceptionGroup, 'time_of_failure', 'asc')"><span class="glyphicon glyphicon-sort-by-alphabet" aria-hidden="true"></span> Time Of Failure (ascending)</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectGroup(vm.selectedExceptionGroup, 'time_of_failure', 'asc')"><span class="glyphicon glyphicon-sort-by-alphabet" aria-hidden="true"></span> Time Of Failure (ascending)</a>
                             </li>
                             <li>
-                                <a href="javascript://" ng-click="vm.selectGroup(vm.selectedExceptionGroup, 'time_of_failure', 'desc')"><span class="glyphicon glyphicon-sort-by-alphabet-alt" aria-hidden="true"></span> Time Of Failure (descending)</a>
+                                <a href="#" ng-click="$event.preventDefault();vm.selectGroup(vm.selectedExceptionGroup, 'time_of_failure', 'desc')"><span class="glyphicon glyphicon-sort-by-alphabet-alt" aria-hidden="true"></span> Time Of Failure (descending)</a>
                             </li>
                         </ul>
                     </div>

--- a/src/ServicePulse.Host/app/js/views/pending_retries/view.html
+++ b/src/ServicePulse.Host/app/js/views/pending_retries/view.html
@@ -61,22 +61,22 @@
                                 </button>
                                 <ul class="dropdown-menu pull-right">
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectGroup('message_type', 'asc')"><span class="fa fa-long-arrow-down" aria-hidden="true"></span> Message Type</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectGroup('message_type', 'asc')"><span class="fa fa-long-arrow-down" aria-hidden="true"></span> Message Type</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectGroup('message_type', 'desc')"><span class="fa fa-long-arrow-up" aria-hidden="true"></span> Message Type</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectGroup('message_type', 'desc')"><span class="fa fa-long-arrow-up" aria-hidden="true"></span> Message Type</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectGroup('time_of_failure', 'asc')"><span class="fa fa-long-arrow-down" aria-hidden="true"></span> Time Of Failure</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectGroup('time_of_failure', 'asc')"><span class="fa fa-long-arrow-down" aria-hidden="true"></span> Time Of Failure</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectGroup('time_of_failure', 'desc')"><span class="fa fa-long-arrow-up" aria-hidden="true"></span> Time Of Failure</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectGroup('time_of_failure', 'desc')"><span class="fa fa-long-arrow-up" aria-hidden="true"></span> Time Of Failure</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectGroup('last_modified', 'asc')"><span class="fa fa-long-arrow-down" aria-hidden="true"></span> Time Of Retry request</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectGroup('last_modified', 'asc')"><span class="fa fa-long-arrow-down" aria-hidden="true"></span> Time Of Retry request</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectGroup('last_modified', 'desc')"><span class="fa fa-long-arrow-up" aria-hidden="true"></span> Time Of Retry request</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectGroup('last_modified', 'desc')"><span class="fa fa-long-arrow-up" aria-hidden="true"></span> Time Of Retry request</a>
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
Fixes https://github.com/Particular/ServicePulse/issues/635

Switches to `#` instead of `javascript://` as Angular 1.7.0 marks those URLs as unsafe.

Because we're now using `#` angular might want to route those to controllers which don't exist, so `$event.preventDefault();` is used to prevent that.

It would make more sense to switch to buttons instead of anchor tags since we don't use the URLs for anything, but the styling changes proved too much for this bug.