### PR TITLE
Remove other javascript: url references

### DIFF
--- a/src/ServicePulse.Host/app/js/views/message/controller.js
+++ b/src/ServicePulse.Host/app/js/views/message/controller.js
@@ -46,6 +46,10 @@
             toastService.showInfo(messageId + ' copied to clipboard');
         };
 
+        vm.goBack = function () {
+            $window.history.go(-1);
+        };
+
         vm.togglePanel = function (message, panelnum) {
             if (message.notFound || message.error)
                 return false;

--- a/src/ServicePulse.Host/app/js/views/message/messages-view.html
+++ b/src/ServicePulse.Host/app/js/views/message/messages-view.html
@@ -4,7 +4,7 @@
     <section name="failed_message">
         <div class="row">
             <div class="col-sm-12">
-                <div><span class="fake-link">&#9664;</span> <a href="javascript:javascript:history.go(-1)">BACK</a></div>
+                <div><span class="fake-link">&#9664;</span> <a href="#" ng-click="$event.preventDefault();vm.goBack();">BACK</a></div>
                 <div ng-show="vm.message" class="active break group-title"><h1 class="message-type-title">{{vm.message.message_type}}</h1></div>
             </div>
         </div>

--- a/src/ServicePulse.Host/app/js/views/pending_retries/view.html
+++ b/src/ServicePulse.Host/app/js/views/pending_retries/view.html
@@ -37,16 +37,16 @@
                                 </button>
                                 <ul class="dropdown-menu">
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectTimeGroup()">All Pending Retries</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup()">All Pending Retries</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectTimeGroup('2', 'hours')">Retried in the last 2 Hours</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup('2', 'hours')">Retried in the last 2 Hours</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectTimeGroup('1', 'days')">Retried in the last 1 Day</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup('1', 'days')">Retried in the last 1 Day</a>
                                     </li>
                                     <li>
-                                        <a href="javascript://" ng-click="vm.selectTimeGroup('7', 'days')">Retried in the last 7 Days</a>
+                                        <a href="#" ng-click="$event.preventDefault();vm.selectTimeGroup('7', 'days')">Retried in the last 7 Days</a>
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
Fixes #637 

There are still outsnatnding `javascript:` URLs that result in angular altering the URL to be unsafes. This removes them.