### PR TITLE
Fixing long names

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -422,7 +422,9 @@ body {
     font-size: 14px !important;
     font-weight: bold;
     margin-bottom: 3px;
-    word-wrap: break-word;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .break {

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -8,7 +8,7 @@
             <a href="/#/monitored_endpoints">All endpoints</a>
         </div>
         <div class="col-sm-9 no-side-padding list-section">
-            <h1>
+            <h1 uib-tooltip="{{endpointName}}">
                 {{endpointName}}
                 <div class="endpoint-status">
                     <span ng-if="endpoint.isStale" class="warning">
@@ -391,7 +391,7 @@
                                     <div class="col-sm-2 col-xl-8 endpoint-name">
                                         <div class="row box-header">
                                             <div class="col-lg-max-9 no-side-padding lead message-type-label">
-                                                <div class="lead">
+                                                <div class="lead" uib-tooltip="{{messageType.typeName}}">
                                                     {{messageType.typeName ? messageType.typeName : 'Unknown'}}
                                                 </div>
                                             </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -68,7 +68,7 @@
                         <div class="row">
                                 <div class="col-sm-2 col-xl-7 endpoint-name name-overview">
                                     <div class="row box-header">
-                                        <div class="col-lg-max-8 no-side-padding lead">
+                                        <div class="col-lg-max-8 no-side-padding lead" uib-tooltip="{{endpoint.name}}">
                                             <a ng-click="endpoint.isExpanded = !endpoint.isExpanded" ng-href="{{getDetailsUrl(endpoint)}}">{{endpoint.name}}</a>
                                         </div>
                                         <div class="col-lg-5 no-side-padding endpoint-status">

--- a/src/ServicePulse.Host/package.json
+++ b/src/ServicePulse.Host/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "angular": "^1.6.9",
     "angular-animate": "^1.6.9",
-    "angular-pretty-xml": "^0.1.1",
     "angular-cookies": "^1.6.9",
+    "angular-pretty-xml": "^0.1.1",
     "angular-route": "^1.6.9",
     "angular-sanitize": "^1.6.9",
     "angular-ui-bootstrap": "0.14.3",
@@ -21,7 +21,7 @@
     "ng-infinite-scroll": "^1.3.0",
     "ng-page-title": "^1.1.1",
     "ngstorage": "git://github.com/gsklee/ngStorage#0.3.10",
-    "npm": "^5.0.3",
+    "npm": "^6.1.0",
     "rx": "^4.1.0",
     "signalr": "^2.2.1",
     "ui-select": "^0.18.1",


### PR DESCRIPTION
This is how the screen looks in current version:
![image](https://user-images.githubusercontent.com/604826/41155484-83635fa0-6b1e-11e8-937a-a29755a0369b.png)

And this is the new presentation:
![image](https://user-images.githubusercontent.com/604826/41155493-8976546a-6b1e-11e8-8659-36d7ac4fedd5.png)

I decided to remove line wrapping, as normally we display the data in 2 lines. If the name is to long then it is being shortened by ellipsis and the name is available using a tooltip. 

I decided to use css to shorten the text so that it automatically works with any width of the container. It seems like the easiest solution to fix the problem. 

Next steps could be to display only the actual type of the message ignoring the namespace and showing it in a tooltip. That would give us more space.