### PR TITLE
Display connecting screen while loading

### DIFF
--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -48,11 +48,11 @@
         </div>
     </noscript>
 
-    <ng-include src="'layout/navbar.html'"></ng-include>
+    <ng-include src="'layout/navbar.html'" ng-show="!loadingInitialData"></ng-include>
 
     <div class="container-fluid">
         <a id="pagetop"></a>
-        <div id="connectingToServiceControl" ng-if="::false">
+        <div id="connectingToServiceControl" ng-if="loadingInitialData">
             <div class="row">
                 <div class="sp-loader"></div>
             </div>
@@ -68,10 +68,10 @@
                 </div>
             </div>
         </div>
-        <div id="view" ng-view=""></div>
+        <div id="view" ng-view="" ng-show="!loadingInitialData"></div>
     </div>
 
-    <ng-include src="'layout/footer.html'"></ng-include>
+    <ng-include src="'layout/footer.html'" ng-show="!loadingInitialData"></ng-include>
 
     <toaster-container toaster-options="{'position-class': 'toast-bottom-right'}">
     </toaster-container>

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -26,6 +26,7 @@
             return currentlyEnabled || url;
         }, false);
 
+        $scope.loadingInitialData = true;
         $scope.isRecoverabilityEnabled = scConfig.service_control_url;
 
         $scope.SCVersion = '';
@@ -167,6 +168,19 @@
             logit(event, message);
             toastService.showError(message);
         }, 'HttpError');
+
+        $scope.$on('$viewContentLoaded', function (event) {
+            if ($scope.loadingInitialData) {
+                if (serviceControlService.performingDataLoadInitially) {
+                    var unsubscribe = notifier.subscribe($scope, function () {
+                        $scope.loadingInitialData = false;
+                        unsubscribe();
+                    }, 'InitialLoadComplete');
+                } else {
+                    $scope.loadingInitialData = false;
+                }
+            }
+        });
 
         notifier.subscribe($scope, function (event, data) {
             toastService.showInfo(data);

--- a/src/ServicePulse.Host/app/js/services/factory.notifier.js
+++ b/src/ServicePulse.Host/app/js/services/factory.notifier.js
@@ -12,6 +12,8 @@
                             callback(event, data);
                         });
                     scope.$on('$destroy', handler);
+
+                    return handler;
                 },
                 notify: function (event, data) {
                     $rootScope.$emit(event, data);

--- a/src/ServicePulse.Host/app/js/views/archive/controller.js
+++ b/src/ServicePulse.Host/app/js/views/archive/controller.js
@@ -16,6 +16,8 @@
         failedMessageGroupsService,
         archivedMessageService) {
 
+        serviceControlService.performingDataLoadInitially = true;
+
         var vm = this;
         var notifier = notifyService();
 
@@ -86,7 +88,7 @@
             return {
                 amount: amount,
                 unit: unit
-            }
+            };
         };
 
         var init = function () {
@@ -266,6 +268,8 @@
                 vm.sort.direction,
                 vm.sort.start,
                 vm.sort.end).then(function (response) {
+                    notifier.notify('InitialLoadComplete');
+
                     vm.total = response.total;
                     processLoadedMessages(response.data);
                 });

--- a/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/controller.js
@@ -28,6 +28,8 @@
 
         var vm = this;
         var notifier = notifyService();
+
+        serviceControlService.performingDataLoadInitially = true;
        
         vm.loadingData = false;
         vm.exceptionGroups = [];
@@ -203,6 +205,8 @@
                 autoGetExceptionGroups().then(function () {
                     vm.loadingData = false;
                     vm.initialLoadComplete = true;
+                    
+                    notifier.notify('InitialLoadComplete');
 
                     return true;
                 });

--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -4,21 +4,21 @@
 
     function controller(
         $scope,
-        $timeout,
+        $rootScope,
         $location,
         $routeParams,
         $cookies,
-        scConfig,
         toastService,
         sharedDataService,
         notifyService,
         serviceControlService,
         failedMessageGroupsService) {
 
+        serviceControlService.performingDataLoadInitially = true;
+
         var vm = this;
-
         var notifier = notifyService();
-
+        
         vm.selectedExceptionGroup = { 'id': $routeParams.groupId ? $routeParams.groupId : undefined, 'title': 'All Failed Messages', 'count': 0, 'initialLoad': true };
         vm.selectedExceptionGroup.parentTitle = $routeParams.parentGroupId;
         vm.selectedExceptionGroup.parentGroupIndex = $routeParams.parentGroupIndex;
@@ -68,6 +68,7 @@
                 vm.allMessagesLoaded = (vm.failedMessages.length >= vm.selectedExceptionGroup.count);
                 vm.page++;
             }
+
             vm.loadingData = false;
         };
 
@@ -225,7 +226,6 @@
             }
 
             vm.loadingData = true;
-            delete group.initialLoad;
 
             var allExceptionsGroupSelected = (!group || !group.id);
 
@@ -242,6 +242,12 @@
                 }
 
                 processLoadedMessages(response.data);
+
+                if (group.initialLoad) {
+                    notifier.notify('InitialLoadComplete');
+                }
+
+                delete group.initialLoad;
             });
         };
 
@@ -249,20 +255,18 @@
     }
 
     controller.$inject = [
-        "$scope",
-        "$timeout",
-        "$location",
-        "$routeParams",
-        "$cookies",
-        "scConfig",
-        "toastService",
-        "sharedDataService",
-        "notifyService",
-        "serviceControlService",
-        "failedMessageGroupsService"
+        '$scope',
+        '$rootScope',
+        '$location',
+        '$routeParams',
+        '$cookies',
+        'toastService',
+        'sharedDataService',
+        'notifyService',
+        'serviceControlService',
+        'failedMessageGroupsService'
     ];
 
-    angular.module("sc")
-        .controller("failedMessagesController", controller);
-
+    angular.module('sc')
+        .controller('failedMessagesController', controller);
 })(window, window.angular);

--- a/src/ServicePulse.Host/app/modules/shell/js/licensenotifier/trialexpiring.html
+++ b/src/ServicePulse.Host/app/modules/shell/js/licensenotifier/trialexpiring.html
@@ -1,7 +1,7 @@
 ﻿<div class="license-warning">
     <strong>Trial expiring</strong>
     <div>Your trial will expire soon. To continue using the Particular Service Platform you'll need to extend your trial or purchase a license.</div>
-    <a href="configuration/redirects" class="btn btn-license-warning">
+    <a href="http://particular.net/extend-your-trial?p=servicepulse" class="btn btn-license-warning">
         <i class="fa fa-external-link-alt"></i> Extend your trial
     </a>
     <a href="/#/configuration/license" class="btn btn-license-warning-light">View license details</a>


### PR DESCRIPTION
Keeps the connecting screen displayed if a page performs an initial load.

This is opt-in from the controller's perspective. In order to opt in, the controller sets the `performingDataLoadInitially` property on the `serviceControlService` service to true and the publishes an event once the initial load is complete.

The base controller then looks at the `performingDataLoadInitially` property once a view has been rendered to determine whether or not it's ok to remove the connecting screen.