### PR TITLE
Adding karma as a runner, this is a first step to remove run-jasmine.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ src/scaffolding.config
 
 # npm artifacts
 src/ServicePulse.Host/node_modules
+src/ServicePulse.Host.Tests/node_modules
 package-lock.json
 
 # bower artifacts

--- a/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
+++ b/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
@@ -65,6 +65,8 @@
     </Content>
     <Content Include="Content\jasmine\jasmine.css" />
     <Content Include="Content\jasmine\jasmine_favicon.png" />
+    <Content Include="karma.conf.js" />
+    <Content Include="package.json" />
     <Content Include="phantomjs-license.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/ServicePulse.Host.Tests/karma.conf.js
+++ b/src/ServicePulse.Host.Tests/karma.conf.js
@@ -1,0 +1,47 @@
+// karma.conf.js
+module.exports = function(config) {
+    config.set({
+        browsers: ['PhantomJS', 'PhantomJS_custom', 'Chrome'],
+        basePath: '../ServicePulse.Host/app',
+        files: [
+            './modules/dist/shell.dist.js',
+            '../../ServicePulse.Host.Tests/tests/js/angular-mocks.js',
+            './js/app.js',            
+            './js/**/*.html',
+            './js/app.constants.js',
+            './js/**/*.module.js',
+            './js/**/*.tabset.js',
+            './js/**/*.js',            
+            './modules/dist/configuration.dist.js',
+            './modules/dist/monitoring.dist.js',            
+            '../../ServicePulse.Host.Tests/tests/**/*.spec.js'],        
+        frameworks: ['jasmine'],
+        // you can define custom flags
+        customLaunchers: {
+            'PhantomJS_custom': {
+                base: 'PhantomJS',
+                options: {
+                    windowName: 'SpecsRunner.html',
+                    settings: {
+                        webSecurityEnabled: false
+                    },
+                },
+                flags: ['--load-images=true'],
+                debug: true
+            },
+            'chrome_without_security': {
+                base: 'Chrome',
+                flags: ['--disable-web-security']
+            },
+        },
+
+        proxies: {
+            '/js/views/dashboard/dashboard.html': '/base/js/views/dashboard/dashboard.html'            
+        },
+        
+        phantomjsLauncher: {
+            // Have phantomjs exit if a ResourceError is encountered (useful if karma exits without killing phantom)
+            exitOnResourceError: true
+        }        
+    })
+}

--- a/src/ServicePulse.Host.Tests/package.json
+++ b/src/ServicePulse.Host.Tests/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ServicePulse.Host.Tests",
+  "version": "1.0.0",
+  "dependencies": {
+    
+  },  
+  "devDependencies": {
+    "karma-phantomjs-launcher": "^1.0.4",
+    "karma-chrome-launcher": "^2.2.0",    
+    "karma-jasmine": "^2.0.1",
+    "karma": "^3.1.4",
+    "karma-cli": "^2.0.0",
+    "karma-teamcity-reporter": "^1.1.0"
+  },
+  "scripts": {
+    "test": "karma start --browsers PhantomJS",    
+    "test-chrome": "karma start --browsers Chrome",
+    "test-teamcity": "karma start --browsers PhantomJS --reporters teamcity --single-run"
+  }
+}


### PR DESCRIPTION
@WilliamBZA after yesterday fix to run-jasmine, I decided that we should eliminate that part of handcrafter TC runner. Given that I introduced karma to run tests. For now I left jasmine as is. When this code gets into master I will change TC config to use karma, and remove old run-jasmine scripts and anything else that we don't need. If for some reason you don't want to pull it into this branch, I can wait with this PR after your feature is done and then do it on master.