### PR TITLE
Handling large number of message type in endpoint details

### DIFF
--- a/src/ServicePulse.Host/ServicePulse.Host.csproj
+++ b/src/ServicePulse.Host/ServicePulse.Host.csproj
@@ -112,6 +112,8 @@
     <Content Include="app\modules\configuration\js\redirect\redirect.route.js" />
     <Content Include="app\modules\configuration\js\redirect\redirect.service.js" />
     <Content Include="app\modules\configuration\views\redirect.html" />
+    <Content Include="app\modules\monitoring\js\directives\ui.particular.messageTypesChangeIndicator.js" />
+    <Content Include="app\modules\monitoring\js\directives\ui.particular.messageTypesChangeIndicator.tpl.html" />
     <Content Include="app\modules\shell\js\directives\upgradeProtectionExpired.html" />
     <Content Include="app\modules\shell\js\directives\platformTrialExpired.html" />
     <Content Include="app\modules\shell\js\directives\platformExpired.js" />

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2581,11 +2581,11 @@ span.fa-exclamation-triangle.danger {
 
 .endpoint-data-changed {
     text-align: center;
-    margin: 26px 0 6px;
+    margin: 26px 0 0;
 }
 
 .endpoint-data-changed a {
-    color: #23527c;
+    text-decoration: underline;
 }
 
 .endpoint-data-changed a:hover {

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2578,3 +2578,20 @@ span.fa-exclamation-triangle.danger {
 .pagination > li > a, .pagination > li > span {
     color: #00729C;
 }
+
+.endpoint-data-changed {
+    text-align: center;
+    margin: 26px 0 6px;
+}
+
+.endpoint-data-changed a {
+    color: #23527c;
+}
+
+.endpoint-data-changed a:hover {
+    cursor: pointer;
+}
+
+.sticky {
+    position: sticky;
+}

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -526,6 +526,7 @@ h6 {
 
             .tabs h5.active a {
                 color: #181919;
+                text-decoration: none;
             }
 
     .tabs a {

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2596,3 +2596,7 @@ span.fa-exclamation-triangle.danger {
 .sticky {
     position: sticky;
 }
+
+div[content="Unable to connect to instance"], div[content="Unable to connect to monitoring server"] {
+    z-index: 99999;
+}

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2564,5 +2564,16 @@ span.fa-exclamation-triangle.danger {
     position:fixed;
 }
 
-#cantConnectMessage h1 {
+.list-pagination {
+    display: flex;
+    justify-content: center;
+}
+
+.pagination > .active > a, .pagination > .active > span, .pagination > .active > a:hover, .pagination > .active > span:hover, .pagination > .active > a:focus, .pagination > .active > span:focus {
+    background-color: #00A3C4;
+    border-color: #ddd;
+}
+
+.pagination > li > a, .pagination > li > span {
+    color: #00729C;
 }

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -1916,6 +1916,7 @@ p.col-sort-active {
     position: absolute;
     top: 1px;
     margin-left: 7px;
+    padding-left: 0;
 }
 
 .endpoint-status i.fa-envelope, .endpoint-status i.fa-exclamation-triangle {
@@ -2351,7 +2352,7 @@ div.alert.alert-warning strong {
     margin-bottom: 32px;
 }
 
-.lead.righ-side-ellipsis {
+.lead.endpoint-details-link.righ-side-ellipsis {
     color: #00729C !important;
 }
 

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2593,8 +2593,17 @@ span.fa-exclamation-triangle.danger {
     cursor: pointer;
 }
 
-.sticky {
-    position: sticky;
+.endpoint-data-changed.sticky {
+    position: fixed;
+    top: 50px;
+    width: 92%;
+    z-index: 999999;
+    box-shadow: 0 3px 20px rgba(0,0,0,0.15);
+    transition-duration: 0.5s;
+}
+
+.table-head-row.add-top-margin {
+    margin-top: 86px;
 }
 
 div[content="Unable to connect to instance"], div[content="Unable to connect to monitoring server"] {

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.js
@@ -20,7 +20,8 @@
         'ui.particular.graphdecimal',
         'ui.particular.multicheckboxList',
         'ui.particular.monitoringConnectivityStatus',
-        'ui.particular.exclamation'
+        'ui.particular.exclamation',
+        'ui.particular.messageTypesChangeIndicator'
     ]);
 
 } (window, window.angular));

--- a/src/ServicePulse.Host/app/js/services/services.historyperiods.js
+++ b/src/ServicePulse.Host/app/js/services/services.historyperiods.js
@@ -4,12 +4,12 @@
     function service($cookies) {
 
         var periods = [
-                { value: 1,  text: "1m",  refreshInterval:  1 * 1000 },
-                { value: 5,  text: "5m",  refreshInterval:  5 * 1000 },
-                { value: 10, text: "10m", refreshInterval: 10 * 1000 },
-                { value: 15, text: "15m", refreshInterval: 15 * 1000 },
-                { value: 30, text: "30m", refreshInterval: 30 * 1000 },
-                { value: 60, text: "1h",  refreshInterval: 60 * 1000 }
+                { value: 1,  text: "1m",  refreshInterval: 1 * 1000,  refreshIntervalText: "1 sec" },
+                { value: 5,  text: "5m",  refreshInterval: 5 * 1000,  refreshIntervalText: "5 sec"  },
+                { value: 10, text: "10m", refreshInterval: 10 * 1000, refreshIntervalText: "10 sec" },
+                { value: 15, text: "15m", refreshInterval: 15 * 1000, refreshIntervalText: "15 sec" },
+                { value: 30, text: "30m", refreshInterval: 30 * 1000, refreshIntervalText: "30 sec" },
+                { value: 60, text: "1h",  refreshInterval: 60 * 1000, refreshIntervalText: "60 sec" }
         ];
 
         this.saveSelectedPeriod = function(period) {

--- a/src/ServicePulse.Host/app/js/services/services.historyperiods.js
+++ b/src/ServicePulse.Host/app/js/services/services.historyperiods.js
@@ -4,12 +4,12 @@
     function service($cookies) {
 
         var periods = [
-                { value: 1,  text: "1m",  refreshInterval: 1 * 1000,  refreshIntervalText: "1 sec" },
-                { value: 5,  text: "5m",  refreshInterval: 5 * 1000,  refreshIntervalText: "5 sec"  },
-                { value: 10, text: "10m", refreshInterval: 10 * 1000, refreshIntervalText: "10 sec" },
-                { value: 15, text: "15m", refreshInterval: 15 * 1000, refreshIntervalText: "15 sec" },
-                { value: 30, text: "30m", refreshInterval: 30 * 1000, refreshIntervalText: "30 sec" },
-                { value: 60, text: "1h",  refreshInterval: 60 * 1000, refreshIntervalText: "60 sec" }
+                { value: 1,  text: "1m",  refreshInterval: 1 * 1000,  refreshIntervalText: "Show data from the last minute. Refreshes every 1 second" },
+            { value: 5, text: "5m", refreshInterval: 5 * 1000, refreshIntervalText: "Show data from the last 5 minutes. Refreshes every 5 seconds"  },
+            { value: 10, text: "10m", refreshInterval: 10 * 1000, refreshIntervalText: "Show data from the last 10 minutes. Refreshes every 10 seconds" },
+            { value: 15, text: "15m", refreshInterval: 15 * 1000, refreshIntervalText: "Show data from the last 15 minutes. Refreshes every 15 seconds" },
+            { value: 30, text: "30m", refreshInterval: 30 * 1000, refreshIntervalText: "Show data from the last 30 minutes. Refreshes every 30 seconds" },
+            { value: 60, text: "1h", refreshInterval: 60 * 1000, refreshIntervalText: "Show data from the last hour. Refreshes every 1 minute" }
         ];
 
         this.saveSelectedPeriod = function(period) {

--- a/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.messageTypesChangeIndicator.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.messageTypesChangeIndicator.js
@@ -1,0 +1,27 @@
+﻿(function (window, angular) {
+    'use strict';
+
+    angular.module('ui.particular.messageTypesChangeIndicator', [])
+        .directive('messageTypesChangeIndicator',
+            function() {
+                return {
+                    restrict: 'E',
+                    scope: {
+                        refresh: '=',
+                        messageTypesAvailable: '='
+                    },
+                    templateUrl: 'modules/monitoring/js/directives/ui.particular.messageTypesChangeIndicator.tpl.html',
+                    link: function link(scope, element, attrs) {
+                        $(window).on('load scroll', function () {
+                            if ($(this).scrollTop() > 510) {
+                                $('.endpoint-data-changed').addClass('sticky');
+                                $('.table-head-row').addClass('add-top-margin');
+                            } else {
+                                $('.endpoint-data-changed').removeClass('sticky');
+                                $('.table-head-row').removeClass('add-top-margin');
+                            }
+                        });
+                    }
+                };
+            });
+}(window, window.angular));

--- a/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.messageTypesChangeIndicator.tpl.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.messageTypesChangeIndicator.tpl.html
@@ -1,0 +1,4 @@
+﻿<div ng-show="messageTypesAvailable" class="alert alert-warning endpoint-data-changed">
+    <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. 
+    <a ng-click="refresh()">Click here to reload the view</a>
+</div>

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -20,6 +20,7 @@
         $scope.sourceIndex = $routeParams.sourceIndex;
         $scope.showInstancesBreakdown = $routeParams.tab === 'instancesBreakdown'; 
         $scope.loading = true;
+        $scope.loadedSuccessfuly = false;
         $scope.largeGraphsMinimumYAxis = largeGraphsMinimumYAxis;
         $scope.smallGraphsMinimumYAxis = smallGraphsMinimumYAxis;
 
@@ -96,6 +97,9 @@
             var selectedPeriod = $scope.selectedPeriod;
 
             subscription = monitoringService.createEndpointDetailsSource($routeParams.endpointName, $routeParams.sourceIndex, selectedPeriod.value, selectedPeriod.refreshInterval).subscribe(function (endpoint) {
+
+                $scope.loading = false;
+
                 if (endpoint.error) {
                     connectivityNotifier.reportFailedConnection($routeParams.sourceIndex);
                     if ($scope.endpoint && $scope.endpoint.instances) {
@@ -132,8 +136,6 @@
                         return 0;
                     });
 
-                    $scope.loading = false;
-
                     processMessageTypes();
 
                     $scope.endpoint.isStale = true;
@@ -151,6 +153,8 @@
                     });
                         $scope.endpoint.isStale = $scope.endpoint.isStale && instance.isStale;
                     });
+
+                    $scope.loadedSuccessfuly = true;
                 }
 
                 serviceControlService.getExceptionGroupsForLogicalEndpoint($scope.endpointName).then(function(result) {

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -61,6 +61,8 @@
 
         $scope.showInstancesBreakdownTab = function(isVisible) {
             $scope.showInstancesBreakdown = isVisible;
+
+            $scope.endpoint.messageTypesForceReload();
         };
 
         $scope.endpoint = {
@@ -69,13 +71,15 @@
             messageTypesItemsPerPage: 10,
             messageTypesAvailable: false,
             messageTypesUpdatedSet: [],
-            messageTypesForceReload: function() {
-                $scope.endpoint.messageTypesAvailable = false;
+            messageTypesForceReload: function () {
+                if ($scope.endpoint.messageTypesAvailable) {
+                    $scope.endpoint.messageTypesAvailable = false;
 
-                $scope.endpoint.messageTypes = $scope.endpoint.messageTypesUpdatedSet;
-                $scope.endpoint.messageTypesUpdatedSet = null;
+                    $scope.endpoint.messageTypes = $scope.endpoint.messageTypesUpdatedSet;
+                    $scope.endpoint.messageTypesUpdatedSet = null;
 
-                processMessageTypes();
+                    processMessageTypes();
+                }
             }
         };
 

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -183,12 +183,16 @@
 
         updateUI();
 
-        $('.endpoint-message-types').scroll(function () {
-            if ($(this).scrollTop() > 65) {
-                $('.endpoint-data-changed').addClass('sticky');
-            } else {
-                $('.endpoint-data-changed').removeClass('sticky');
-            }
+        $(function () {
+            $(window).on('load scroll', function () {
+                if ($(this).scrollTop() > 510) {
+                    $('.endpoint-data-changed').addClass('sticky');
+                    $('.table-head-row').addClass('add-top-margin');
+                } else {
+                    $('.endpoint-data-changed').removeClass('sticky');
+                    $('.table-head-row').removeClass('add-top-margin');
+                }
+            });
         });
     }
 

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -44,8 +44,18 @@
             }
         }
 
-        $scope.buildUrl = function (selectedPeriodValue, showInstancesBreakdownTab) {
-            return `#/monitoring/endpoint/${$scope.endpointName}/${$scope.sourceIndex}?historyPeriod=${selectedPeriodValue}&tab=${$scope.showInstancesBreakdown ? 'instancesBreakdown' : 'messageTypeBreakdown'}`;
+        $scope.buildUrl = function (selectedPeriodValue, showInstacesBreakdown, breakdownPageNo) {
+
+            var breakdownTabName = showInstacesBreakdown ? 'instancesBreakdown' : 'messageTypeBreakdown';
+
+            return `#/monitoring/endpoint/${$scope.endpointName}/${$scope.sourceIndex}?historyPeriod=${selectedPeriodValue}&tab=${breakdownTabName}&pageNo=${breakdownPageNo}`;
+        };
+
+        $scope.updateUrl = function () {
+
+            var updatedUrl = $scope.buildUrl($scope.selectedPeriod.value, $scope.showInstancesBreakdown, $scope.endpoint.messageTypesPage);
+
+            window.location.hash = updatedUrl;
         };
 
         $scope.showInstancesBreakdownTab = function(isVisible) {
@@ -53,7 +63,7 @@
         };
 
         $scope.endpoint = {
-            messageTypesPage: 1,
+            messageTypesPage: !$scope.showInstancesBreakdown ? $routeParams.pageNo : 1,
             messageTypesTotalItems: 0,
             messageTypesItemsPerPage: 10,
             messageTypesAvailable: false,

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -5,6 +5,7 @@
         $scope,
         $routeParams,
         $location,
+        $window,
         toastService,
         serviceControlService,
         monitoringService,
@@ -56,7 +57,7 @@
 
             var updatedUrl = $scope.buildUrl($scope.selectedPeriod.value, $scope.showInstancesBreakdown, $scope.endpoint.messageTypesPage);
 
-            window.location.hash = updatedUrl;
+            $window.location.hash = updatedUrl;
         };
 
         $scope.showInstancesBreakdownTab = function(isVisible) {
@@ -200,6 +201,7 @@
         '$scope',
         '$routeParams',
         '$location',
+        '$window',
         'toastService',
         'serviceControlService',
         'monitoringService',

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -182,6 +182,14 @@
         });
 
         updateUI();
+
+        $('.endpoint-message-types').scroll(function () {
+            if ($(this).scrollTop() > 65) {
+                $('.endpoint-data-changed').addClass('sticky');
+            } else {
+                $('.endpoint-data-changed').removeClass('sticky');
+            }
+        });
     }
 
     controller.$inject = [

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -57,7 +57,11 @@
 
             var selectedPeriod = $scope.selectedPeriod;
 
-            $scope.endpoint = {};
+            $scope.endpoint = {
+                messageTypesPage: 1,
+                messageTypesTotalItems: 0,
+                messageTypesItemsPerPage: 10
+            };
 
             subscription = monitoringService.createEndpointDetailsSource($routeParams.endpointName, $routeParams.sourceIndex, selectedPeriod.value, selectedPeriod.refreshInterval).subscribe(function (endpoint) {
                 if (endpoint.error) {
@@ -87,6 +91,9 @@
                     });
 
                     $scope.loading = false;
+
+                    $scope.endpoint.messageTypesTotalItems = $scope.endpoint.messageTypes.length;
+
                     $scope.endpoint.messageTypes.forEach((messageType) => {
                         fillDisplayValues(messageType);
                         messageTypeParser.parseTheMessageTypeData(messageType);

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -20,7 +20,7 @@
         $scope.sourceIndex = $routeParams.sourceIndex;
         $scope.showInstancesBreakdown = $routeParams.tab === 'instancesBreakdown'; 
         $scope.loading = true;
-        $scope.loadedSuccessfuly = false;
+        $scope.loadedSuccessfully = false;
         $scope.largeGraphsMinimumYAxis = largeGraphsMinimumYAxis;
         $scope.smallGraphsMinimumYAxis = smallGraphsMinimumYAxis;
 
@@ -158,7 +158,7 @@
                         $scope.endpoint.isStale = $scope.endpoint.isStale && instance.isStale;
                     });
 
-                    $scope.loadedSuccessfuly = true;
+                    $scope.loadedSuccessfully = true;
                 }
 
                 serviceControlService.getExceptionGroupsForLogicalEndpoint($scope.endpointName).then(function(result) {

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -63,7 +63,7 @@
         $scope.showInstancesBreakdownTab = function(isVisible) {
             $scope.showInstancesBreakdown = isVisible;
 
-            $scope.endpoint.messageTypesForceReload();
+            $scope.endpoint.refreshMessageTypes();
         };
 
         $scope.endpoint = {
@@ -72,7 +72,7 @@
             messageTypesItemsPerPage: 10,
             messageTypesAvailable: false,
             messageTypesUpdatedSet: [],
-            messageTypesForceReload: function () {
+            refreshMessageTypes: function () {
                 if ($scope.endpoint.messageTypesAvailable) {
                     $scope.endpoint.messageTypesAvailable = false;
 

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -183,18 +183,6 @@
         });
 
         updateUI();
-
-        $(function () {
-            $(window).on('load scroll', function () {
-                if ($(this).scrollTop() > 510) {
-                    $('.endpoint-data-changed').addClass('sticky');
-                    $('.table-head-row').addClass('add-top-margin');
-                } else {
-                    $('.endpoint-data-changed').removeClass('sticky');
-                    $('.table-head-row').removeClass('add-top-margin');
-                }
-            });
-        });
     }
 
     controller.$inject = [

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -34,10 +34,12 @@
             updateUI();
         };
 
-        function mergeIn(destination, source) {
+        function mergeIn(destination, source, propertiesToSkip) {
             for (var propName in source) {
                 if (source.hasOwnProperty(propName)) {
-                    destination[propName] = source[propName];
+                    if(!propertiesToSkip || !propertiesToSkip.includes(propName)) {
+                        destination[propName] = source[propName];
+                    }
                 }
             }
         }
@@ -60,7 +62,8 @@
             $scope.endpoint = {
                 messageTypesPage: 1,
                 messageTypesTotalItems: 0,
-                messageTypesItemsPerPage: 10
+                messageTypesItemsPerPage: 10,
+                messageTypesAvailable: false
             };
 
             subscription = monitoringService.createEndpointDetailsSource($routeParams.endpointName, $routeParams.sourceIndex, selectedPeriod.value, selectedPeriod.refreshInterval).subscribe(function (endpoint) {
@@ -74,7 +77,23 @@
 
                 } else {
 
-                    mergeIn($scope.endpoint, endpoint);
+                    if ($scope.endpoint.messageTypesTotalItems > 0 &&
+                        $scope.endpoint.messageTypesTotalItems !== endpoint.messageTypes.length &&
+                        !$scope.endpoint.messageTypesForceReload) {
+
+                        mergeIn($scope.endpoint, endpoint, ['messageTypes']);
+
+                        if (!$scope.endpoint.messageTypesAvilable) {
+
+                            $scope.endpoint.messageTypesAvilable = true;
+
+                            toastService.showInfo("Available message types changed. Click to update the view.", "Info", true, updateUI);
+                        }
+
+                    } else {
+                        mergeIn($scope.endpoint, endpoint);
+                    }
+
 
                     connectivityNotifier.reportSuccessfulConnection($routeParams.sourceIndex);
 

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.module.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.module.js
@@ -16,4 +16,5 @@
     require('./directives/ui.particular.graphduration.js');
     require('./directives/ui.particular.largeGraph.js');
     require('./directives/ui.particular.metricslargenumber.js');
+    require('./directives/ui.particular.messageTypesChangeIndicator.js');
 }(window, window.angular));

--- a/src/ServicePulse.Host/app/modules/monitoring/js/monitored_endpoints.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/monitored_endpoints.controller.js
@@ -19,6 +19,7 @@
         $scope.selectedPeriod = historyPeriodsService.getDefaultPeriod();
         $scope.smallGraphsMinimumYAxis = smallGraphsMinimumYAxis;
         $scope.endpoints = [];
+        $scope.loading = true;
 
         $scope.selectPeriod = function (period) {
             $scope.selectedPeriod = period;
@@ -59,7 +60,10 @@
             var selectedPeriod = $scope.selectedPeriod;
 
             subscription = monitoringService.createEndpointsSource(selectedPeriod.value, selectedPeriod.refreshInterval)
-                .subscribe(function(endpoint) {
+                .subscribe(function (endpoint) {
+
+                    $scope.loading = false;
+
                     if (endpoint.error) {
                         connectivityNotifier.reportFailedConnection(endpoint.sourceIndex);
                         if ($scope.endpoints) {

--- a/src/ServicePulse.Host/app/modules/monitoring/js/monitored_endpoints.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/monitored_endpoints.controller.js
@@ -1,4 +1,4 @@
-﻿(function(window, angular, undefined) {
+(function(window, angular, undefined) {
     'use strict';
 
     function controller(
@@ -63,6 +63,10 @@
                 .subscribe(function (endpoint) {
 
                     $scope.loading = false;
+
+                    if (endpoint.empty) {
+                        return;
+                    }
 
                     if (endpoint.error) {
                         connectivityNotifier.reportFailedConnection(endpoint.sourceIndex);

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -28,7 +28,9 @@
                             endpoint.sourceIndex = sourceIndex;
                         });
 
-                        return result.data;
+                        return result.data.length !== 0
+                                ? result.data
+                                : [{empty: true, sourceIndex: sourceIndex}];
                     },
                     (error) => {
                         var sourceIndex = scConfig.monitoring_urls.indexOf(url);

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -343,12 +343,14 @@
     </section>
 
     <section ng-if="!showInstancesBreakdown" class="endpoint-message-types">
-        <div ng-show="endpoint.messageTypesAvailable" class="alert alert-warning">
-            <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. Click <a ng-click="endpoint.messageTypesForceReload()">here </a> to re-load the view
-        </div>
+        
         <div class="row">
             <div class="col-xs-12 no-side-padding">
-                
+
+                <div ng-show="endpoint.messageTypesAvailable" class="alert alert-warning endpoint-data-changed">
+                    <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. <a ng-click="endpoint.messageTypesForceReload()">Click here to re-load the view</a>
+                </div>
+
                 <!-- Breakdown by message type-->
                 <div ng-show="loadedSuccessfuly" class="row box box-no-click table-head-row">
                     <div class="col-xs-4 col-xl-8">
@@ -478,7 +480,7 @@
                     </div>
                 </div>
                 <div class="row list-pagination">
-                        <ul uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems" ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10" boundary-link-numbers="true" ng-change="updateUrl()"></ul>
+                    <ul uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems" ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10" boundary-link-numbers="true" ng-change="updateUrl()"></ul>
                 </div>
             </div>
         </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -346,10 +346,8 @@
         
         <div class="row">
             <div class="col-xs-12 no-side-padding">
-
-                <div ng-show="endpoint.messageTypesAvailable" class="alert alert-warning endpoint-data-changed">
-                    <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. <a ng-click="endpoint.refreshMessageTypes()">Click here to reload the view</a>
-                </div>
+                
+                <message-types-change-indicator refresh="endpoint.refreshMessageTypes" message-types-available="endpoint.messageTypesAvailable"></message-types-change-indicator>
 
                 <!-- Breakdown by message type-->
                 <div ng-show="loadedSuccessfully" class="row box box-no-click table-head-row">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -482,8 +482,8 @@
                 </div>
             </div>
         </div>
-        <uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems" 
-                        ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10"
-                        ng-change="updateUrl()"></uib-pagination>
+        <ul uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems"
+                        ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10" boundary-link-numbers="true"
+                        ng-change="updateUrl()"></ul>
     </section>
 </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -348,7 +348,7 @@
             <div class="col-xs-12 no-side-padding">
 
                 <div ng-show="endpoint.messageTypesAvailable" class="alert alert-warning endpoint-data-changed">
-                    <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. <a ng-click="endpoint.messageTypesForceReload()">Click here to re-load the view</a>
+                    <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. <a ng-click="endpoint.messageTypesForceReload()">Click here to reload the view</a>
                 </div>
 
                 <!-- Breakdown by message type-->

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -348,7 +348,7 @@
             <div class="col-xs-12 no-side-padding">
 
                 <div ng-show="endpoint.messageTypesAvailable" class="alert alert-warning endpoint-data-changed">
-                    <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. <a ng-click="endpoint.messageTypesForceReload()">Click here to reload the view</a>
+                    <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. <a ng-click="endpoint.refreshMessageTypes()">Click here to reload the view</a>
                 </div>
 
                 <!-- Breakdown by message type-->

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -3,9 +3,10 @@
 <upgrade-protection-expired ng-if="isInvalidDueToUpgradeProtectionExpired"></upgrade-protection-expired>
 
 <div class="container" ng-if="!isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
-    <div ng-include="'modules/monitoring/views/monitoring_not_available.html'" ng-if="loading"></div>
+    <div class="sp-loader" ng-if="loading"></div>
+    <div ng-include="'modules/monitoring/views/monitoring_not_available.html'" ng-if="!loading && !loadedSuccessfuly"></div>
 
-    <div class="row monitoring-head" ng-if="!loading">
+    <div class="row monitoring-head" ng-if="loadedSuccessfuly">
         <div class="back-nav">
             <span class="fake-link" aria-hidden="true">&#9664;</span>
             <a href="/#/monitoring">All endpoints</a>
@@ -37,7 +38,7 @@
     </div>
 </div>
 
-<div class="container large-graphs" ng-if="!loading && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
+<div class="container large-graphs" ng-if="loadedSuccessfuly && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
     <div class="container">
         <div class="row">
             <div class="col-xs-4 no-side-padding list-section graph-area graph-queue-length">
@@ -201,8 +202,7 @@
     </div>
 </div>
 
-<div class="container" ng-if="!loading && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
-    <busy ng-show="loading" message="Loading details"></busy>
+<div class="container" ng-if="loadedSuccessfuly && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
     <div class="tabs">
         <h5 ng-class="{active: !showInstancesBreakdown}">
             <a ng-click="showInstancesBreakdownTab(false)" ng-href="{{buildUrl(selectedPeriod.value, showInstancesBreakdown, endpoint.messageTypesPage)}}" class="ng-binding">Message Types ({{endpoint.messageTypes.length}})</a>
@@ -216,10 +216,8 @@
         <div class="row">
             <div class="col-xs-12 no-side-padding">
 
-                <!-- Breakdown by instance -->
-                <busy ng-show="loading" message="Loading details"></busy>
-
-                <div ng-show="!loading" class="row box box-no-click table-head-row">
+                <!-- Breakdown by instance-->
+                <div ng-show="loadedSuccessfuly" class="row box box-no-click table-head-row">
                     <div class="col-xs-8">
                         <div class="row box-header">
                             <div class="col-xs-12">
@@ -350,10 +348,9 @@
         </div>
         <div class="row">
             <div class="col-xs-12 no-side-padding">
+                
                 <!-- Breakdown by message type-->
-                <busy ng-show="loading" message="Loading details"></busy>
-
-                <div ng-show="!loading" class="row box box-no-click table-head-row">
+                <div ng-show="loadedSuccessfuly" class="row box box-no-click table-head-row">
                     <div class="col-xs-4 col-xl-8">
                         <div class="row box-header">
                             <div class="col-xs-12">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -31,7 +31,7 @@
         <div class="col-xs-3 no-side-padding toolbar-menus">
             <ul class="nav nav-pills period-selector">
                 <li role="presentation" ng-repeat="period in periods" ng-class="(period.value == selectedPeriod.value ? 'active' : 'notselected')">
-                    <a ng-click="selectPeriod(period)" ng-href="{{buildUrl(period.value, showInstancesBreakdown, showInstacesBreakdown ? 1 : endpoint.messageTypesPage)}}" uib-tooltip="The data will be refreshed every {{period.refreshIntervalText}}.">{{period.text}}</a>
+                    <a ng-click="selectPeriod(period)" ng-href="{{buildUrl(period.value, showInstancesBreakdown, showInstacesBreakdown ? 1 : endpoint.messageTypesPage)}}" uib-tooltip="{{period.refreshIntervalText}}.">{{period.text}}</a>
                 </li>
             </ul>
         </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -205,10 +205,10 @@
     <busy ng-show="loading" message="Loading details"></busy>
     <div class="tabs">
         <h5 ng-class="{active: !showInstancesBreakdown}">
-            <a ng-click="showInstancesBreakdownTab(false)" ng-href="{{buildUrl(selectedPeriod.value, 'messageTypeBreakdown')}}" class="ng-binding">Message Types</a>
+            <a ng-click="showInstancesBreakdownTab(false)" ng-href="{{buildUrl(selectedPeriod.value, 'messageTypeBreakdown')}}" class="ng-binding">Message Types ({{endpoint.messageTypes.length}})</a>
         </h5>
         <h5 ng-class="{active: showInstancesBreakdown}">
-            <a ng-click="showInstancesBreakdownTab(true)" ng-href="{{buildUrl(selectedPeriod.value, 'instancesBreakdown')}}" class="ng-binding">Instances</a>
+            <a ng-click="showInstancesBreakdownTab(true)" ng-href="{{buildUrl(selectedPeriod.value, 'instancesBreakdown')}}" class="ng-binding">Instances ({{endpoint.instances.length}})</a>
         </h5>
     </div>
 

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -31,7 +31,7 @@
         <div class="col-xs-3 no-side-padding toolbar-menus">
             <ul class="nav nav-pills period-selector">
                 <li role="presentation" ng-repeat="period in periods" ng-class="(period.value == selectedPeriod.value ? 'active' : 'notselected')">
-                    <a ng-click="selectPeriod(period)" ng-href="{{buildUrl(period.value, showInstancesBreakdown, showInstacesBreakdown ? 1 : endpoint.messageTypesPage)}}">{{period.text}}</a>
+                    <a ng-click="selectPeriod(period)" ng-href="{{buildUrl(period.value, showInstancesBreakdown, showInstacesBreakdown ? 1 : endpoint.messageTypesPage)}}" uib-tooltip="The data will be refreshed every {{period.refreshIntervalText}}.">{{period.text}}</a>
                 </li>
             </ul>
         </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -392,7 +392,7 @@
 
                 <div class="row">
                     <div class="col-xs-12 no-side-padding">
-                        <div class="row box endpoint-row" ng-repeat="messageType in endpoint.messageTypes">
+                        <div class="row box endpoint-row" ng-repeat="messageType in endpoint.messageTypes | orderBy: 'typeName' | limitTo: endpoint.messageTypesItemsPerPage : (endpoint.messageTypesPage-1) * endpoint.messageTypesItemsPerPage">
                             <div class="col-xs-12 no-side-padding">
                                 <div class="row">
                                     <div class="col-xs-4 col-xl-8 endpoint-name" uib-tooltip-html="messageType.tooltipText">
@@ -479,5 +479,6 @@
                 </div>
             </div>
         </div>
+        <uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems" ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10"></uib-pagination>
     </section>
 </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -30,7 +30,7 @@
         <div class="col-xs-3 no-side-padding toolbar-menus">
             <ul class="nav nav-pills period-selector">
                 <li role="presentation" ng-repeat="period in periods" ng-class="(period.value == selectedPeriod.value ? 'active' : 'notselected')">
-                    <a ng-click="selectPeriod(period)" ng-href="{{buildUrl(period.value)}}">{{period.text}}</a>
+                    <a ng-click="selectPeriod(period)" ng-href="{{buildUrl(period.value, showInstancesBreakdown, showInstacesBreakdown ? 1 : endpoint.messageTypesPage)}}">{{period.text}}</a>
                 </li>
             </ul>
         </div>
@@ -205,10 +205,10 @@
     <busy ng-show="loading" message="Loading details"></busy>
     <div class="tabs">
         <h5 ng-class="{active: !showInstancesBreakdown}">
-            <a ng-click="showInstancesBreakdownTab(false)" ng-href="{{buildUrl(selectedPeriod.value, 'messageTypeBreakdown')}}" class="ng-binding">Message Types ({{endpoint.messageTypes.length}})</a>
+            <a ng-click="showInstancesBreakdownTab(false)" ng-href="{{buildUrl(selectedPeriod.value, showInstancesBreakdown, endpoint.messageTypesPage)}}" class="ng-binding">Message Types ({{endpoint.messageTypes.length}})</a>
         </h5>
         <h5 ng-class="{active: showInstancesBreakdown}">
-            <a ng-click="showInstancesBreakdownTab(true)" ng-href="{{buildUrl(selectedPeriod.value, 'instancesBreakdown')}}" class="ng-binding">Instances ({{endpoint.instances.length}})</a>
+            <a ng-click="showInstancesBreakdownTab(true)" ng-href="{{buildUrl(selectedPeriod.value, showInstancesBreakdown, 1)}}" class="ng-binding">Instances ({{endpoint.instances.length}})</a>
         </h5>
     </div>
 
@@ -482,6 +482,8 @@
                 </div>
             </div>
         </div>
-        <uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems" ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10"></uib-pagination>
+        <uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems" 
+                        ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10"
+                        ng-change="updateUrl()"></uib-pagination>
     </section>
 </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -218,35 +218,35 @@
 
                 <!-- Breakdown by instance-->
                 <div ng-show="loadedSuccessfuly" class="row box box-no-click table-head-row">
-                    <div class="col-xs-8">
+                    <div class="col-xs-4 col-xl-8">
                         <div class="row box-header">
                             <div class="col-xs-12">
                                 Instance Name
                             </div>
                         </div>
                     </div>
-                    <div class="col-xs-1 no-side-padding">
+                    <div class="col-xs-2 col-xl-1 no-side-padding">
                         <div class="row box-header">
                             <div class="col-xs-12 no-side-padding" uib-tooltip="Throughput: The number of messages per second successfully processed by a receiving endpoint.">
                                 Throughput <span class="table-header-unit">(msgs/s)</span>
                             </div>
                         </div>
                     </div>
-                    <div class="col-xs-1 no-side-padding">
+                    <div class="col-xs-2 col-xl-1 no-side-padding">
                         <div class="row box-header">
                             <div class="col-xs-12 no-side-padding" uib-tooltip="Scheduled retry rate: The number of messages per second scheduled for retries (immediate or delayed).">
                                 Scheduled retry rate <span class="table-header-unit">(msgs/s)</span>
                             </div>
                         </div>
                     </div>
-                    <div class="col-xs-1 no-side-padding">
+                    <div class="col-xs-2 col-xl-1 no-side-padding">
                         <div class="row box-header">
                             <div class="col-xs-12 no-side-padding" uib-tooltip="Processing time: The time taken for a receiving endpoint to successfully process a message.">
                                 Processing Time <span class="table-header-unit">(t)</span>
                             </div>
                         </div>
                     </div>
-                    <div class="col-xs-1 no-side-padding">
+                    <div class="col-xs-2 col-xl-1 no-side-padding">
                         <div class="row box-header">
                             <div class="col-xs-12 no-side-padding" uib-tooltip="Critical time: The elapsed time from when a message was sent, until it was successfully processed by a receiving endpoint.">
                                 Critical Time <span class="table-header-unit">(t)</span>
@@ -262,12 +262,12 @@
                         <div class="row box endpoint-row" ng-repeat="instance in endpoint.instances">
                             <div class="col-xs-12 no-side-padding">
                                 <div class="row">
-                                    <div class="col-xs-8 endpoint-name">
+                                    <div class="col-xs-4 col-xl-8 endpoint-name">
                                         <div class="row box-header">
                                             <div class="col-lg-max-9 no-side-padding lead righ-side-ellipsis" uib-tooltip="{{instance.name}}">
                                                 {{instance.name}}
                                             </div>
-                                            <div class="col-xs-4 endpoint-status">
+                                            <div class="col-lg-4 no-side-padding endpoint-status">
                                                 <span class="warning" ng-if="instance.isScMonitoringDisconnected">
                                                     <i class="fa pa-monitoring-lost endpoint-details" uib-tooltip="Unable to connect to monitoring server"></i>
                                                 </span>
@@ -283,7 +283,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-xs-1 no-side-padding">
+                                    <div class="col-xs-2 col-xl-1 no-side-padding">
                                         <div class="row box-header">
                                             <div class="no-side-padding">
                                                 <graph plot-data="instance.metrics.throughput" minimum-YAxis="{{smallGraphsMinimumYAxis.throughput}}" class="graph throughput pull-left"></graph>
@@ -294,7 +294,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-xs-2 col-xs-1 no-side-padding">
+                                    <div class="col-xs-2 col-xl-1 no-side-padding">
                                         <div class="row box-header">
                                             <div class="no-side-padding">
                                                 <graph plot-data="instance.metrics.retries" minimum-YAxis="{{smallGraphsMinimumYAxis.retries}}" class="graph retries pull-left"></graph>
@@ -305,7 +305,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-xs-1 no-side-padding">
+                                    <div class="col-xs-2 col-xl-1 no-side-padding">
                                         <div class="row box-header">
                                             <div class="no-side-padding">
                                                 <graph plot-data="instance.metrics.processingTime" minimum-YAxis="{{smallGraphsMinimumYAxis.processingTime}}" class="graph processing-time pull-left"></graph>
@@ -319,7 +319,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-xs-1 no-side-padding">
+                                    <div class="col-xs-2 col-xl-1 no-side-padding">
                                         <div class="row box-header">
                                             <div class="no-side-padding">
                                                 <graph plot-data="instance.metrics.criticalTime" minimum-YAxis="{{smallGraphsMinimumYAxis.criticalTime}}" class="graph critical-time pull-left"></graph>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -4,9 +4,9 @@
 
 <div class="container" ng-if="!isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
     <div class="sp-loader" ng-if="loading"></div>
-    <div ng-include="'modules/monitoring/views/monitoring_not_available.html'" ng-if="!loading && !loadedSuccessfuly"></div>
+    <div ng-include="'modules/monitoring/views/monitoring_not_available.html'" ng-if="!loading && !loadedSuccessfully"></div>
 
-    <div class="row monitoring-head" ng-if="loadedSuccessfuly">
+    <div class="row monitoring-head" ng-if="loadedSuccessfully">
         <div class="back-nav">
             <span class="fake-link" aria-hidden="true">&#9664;</span>
             <a href="/#/monitoring">All endpoints</a>
@@ -38,7 +38,7 @@
     </div>
 </div>
 
-<div class="container large-graphs" ng-if="loadedSuccessfuly && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
+<div class="container large-graphs" ng-if="loadedSuccessfully && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
     <div class="container">
         <div class="row">
             <div class="col-xs-4 no-side-padding list-section graph-area graph-queue-length">
@@ -202,7 +202,7 @@
     </div>
 </div>
 
-<div class="container" ng-if="loadedSuccessfuly && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
+<div class="container" ng-if="loadedSuccessfully && !isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
     <div class="tabs">
         <h5 ng-class="{active: !showInstancesBreakdown}">
             <a ng-click="showInstancesBreakdownTab(false)" ng-href="{{buildUrl(selectedPeriod.value, showInstancesBreakdown, endpoint.messageTypesPage)}}" class="ng-binding">Message Types ({{endpoint.messageTypes.length}})</a>
@@ -217,7 +217,7 @@
             <div class="col-xs-12 no-side-padding">
 
                 <!-- Breakdown by instance-->
-                <div ng-show="loadedSuccessfuly" class="row box box-no-click table-head-row">
+                <div ng-show="loadedSuccessfully" class="row box box-no-click table-head-row">
                     <div class="col-xs-4 col-xl-8">
                         <div class="row box-header">
                             <div class="col-xs-12">
@@ -352,7 +352,7 @@
                 </div>
 
                 <!-- Breakdown by message type-->
-                <div ng-show="loadedSuccessfuly" class="row box box-no-click table-head-row">
+                <div ng-show="loadedSuccessfully" class="row box box-no-click table-head-row">
                     <div class="col-xs-4 col-xl-8">
                         <div class="row box-header">
                             <div class="col-xs-12">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -345,6 +345,9 @@
     </section>
 
     <section ng-if="!showInstancesBreakdown" class="endpoint-message-types">
+        <div ng-show="endpoint.messageTypesAvailable" class="alert alert-warning">
+            <i class="fa fa-warning"></i> <strong>Warning:</strong> The number of available message types has changed. Click <a ng-click="endpoint.messageTypesForceReload()">here </a> to re-load the view
+        </div>
         <div class="row">
             <div class="col-xs-12 no-side-padding">
                 <!-- Breakdown by message type-->

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -477,10 +477,10 @@
                         </div>
                     </div>
                 </div>
+                <div class="row list-pagination">
+                        <ul uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems" ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10" boundary-link-numbers="true" ng-change="updateUrl()"></ul>
+                </div>
             </div>
         </div>
-        <ul uib-pagination ng-show="endpoint.messageTypesTotalItems >  endpoint.messageTypesItemsPerPage" total-items="endpoint.messageTypesTotalItems"
-                        ng-model="endpoint.messageTypesPage" items-per-page="endpoint.messageTypesItemsPerPage" max-size="10" boundary-link-numbers="true"
-                        ng-change="updateUrl()"></ul>
     </section>
 </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -72,7 +72,7 @@
                         <div class="row">
                             <div class="col-xs-2 col-xl-7 endpoint-name name-overview">
                                 <div class="row box-header">
-                                    <div class="col-lg-max-8 no-side-padding lead righ-side-ellipsis" uib-tooltip="{{endpoint.name}}">
+                                    <div class="col-lg-max-8 no-side-padding lead righ-side-ellipsis endpoint-details-link" uib-tooltip="{{endpoint.name}}">
                                         <a ng-click="endpoint.isExpanded = !endpoint.isExpanded" ng-href="{{getDetailsUrl(endpoint)}}">{{endpoint.name}}</a>
                                     </div>
                                     <div class="col-xs-5 no-side-padding endpoint-status">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -19,6 +19,7 @@
 
 <div class="container" ng-if="!isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
     <section ng-show="true">
+        <div class="sp-loader" ng-if="loading"></div>
         <div ng-include="'modules/monitoring/views/monitoring_not_available.html'" ng-show="!endpoints.length && !loading"></div>
         <div ng-show="endpoints.length" class="row box box-no-click table-head-row">
             <div class="col-xs-2 col-xl-7">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -19,7 +19,7 @@
 
 <div class="container" ng-if="!isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
     <section ng-show="true">
-        <div ng-include="'modules/monitoring/views/monitoring_not_available.html'" ng-show="!endpoints.length"></div>
+        <div ng-include="'modules/monitoring/views/monitoring_not_available.html'" ng-show="!endpoints.length && !loading"></div>
         <div ng-show="endpoints.length" class="row box box-no-click table-head-row">
             <div class="col-xs-2 col-xl-7">
                 <div class="row box-header">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -10,7 +10,7 @@
         <div class="col-xs-3 no-side-padding toolbar-menus">
             <ul class="nav nav-pills period-selector">
                 <li role="presentation" ng-repeat="period in periods" ng-class="(period.value == selectedPeriod.value ? 'active' : 'notselected')">
-                    <a ng-click="selectPeriod(period)" href="#/monitoring?historyPeriod={{period.value}}" uib-tooltip="The data will be refreshed every {{period.refreshIntervalText}}.">{{period.text}}</a>
+                    <a ng-click="selectPeriod(period)" href="#/monitoring?historyPeriod={{period.value}}" uib-tooltip="{{period.refreshIntervalText}}.">{{period.text}}</a>
                 </li>
             </ul>
         </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitored_endpoints.html
@@ -10,7 +10,7 @@
         <div class="col-xs-3 no-side-padding toolbar-menus">
             <ul class="nav nav-pills period-selector">
                 <li role="presentation" ng-repeat="period in periods" ng-class="(period.value == selectedPeriod.value ? 'active' : 'notselected')">
-                    <a ng-click="selectPeriod(period)" href="#/monitoring?historyPeriod={{period.value}}">{{period.text}}</a>
+                    <a ng-click="selectPeriod(period)" href="#/monitoring?historyPeriod={{period.value}}" uib-tooltip="The data will be refreshed every {{period.refreshIntervalText}}.">{{period.text}}</a>
                 </li>
             </ul>
         </div>

--- a/src/ServicePulse.Host/app/modules/shell/js/services/service.toast.js
+++ b/src/ServicePulse.Host/app/modules/shell/js/services/service.toast.js
@@ -2,7 +2,7 @@
     'use strict';
 
     function ToastService(toaster) {
-        this.showToast = function(text, type, title, sticky) {
+        this.showToast = function(text, type, title, sticky, onHide) {
             sticky = sticky || false;
             toaster.pop({
                 type: type || 'info',
@@ -10,12 +10,13 @@
                 body: text,
                 bodyOutputType: 'trustedHtml',
                 timeout: sticky ? 0 : 5000,
-                showCloseButton: sticky
-            });
+                showCloseButton: sticky,
+                onHideCallback: onHide
+        });
         };
 
-        this.showInfo = function(text, title, sticky) {
-            this.showToast(text, 'info', title || 'Info', sticky);
+        this.showInfo = function(text, title, sticky, onHide) {
+            this.showToast(text, 'info', title || 'Info', sticky, onHide);
         };
 
         this.showError = function(text, sticky) {

--- a/src/ServicePulse.Host/app/modules/shell/js/services/service.toast.js
+++ b/src/ServicePulse.Host/app/modules/shell/js/services/service.toast.js
@@ -2,7 +2,7 @@
     'use strict';
 
     function ToastService(toaster) {
-        this.showToast = function(text, type, title, sticky, onHide) {
+        this.showToast = function(text, type, title, sticky) {
             sticky = sticky || false;
             toaster.pop({
                 type: type || 'info',
@@ -10,13 +10,12 @@
                 body: text,
                 bodyOutputType: 'trustedHtml',
                 timeout: sticky ? 0 : 5000,
-                showCloseButton: sticky,
-                onHideCallback: onHide
-        });
+                showCloseButton: sticky
+            });
         };
 
-        this.showInfo = function(text, title, sticky, onHide) {
-            this.showToast(text, 'info', title || 'Info', sticky, onHide);
+        this.showInfo = function(text, title, sticky) {
+            this.showToast(text, 'info', title || 'Info', sticky);
         };
 
         this.showError = function(text, sticky) {

--- a/src/ServicePulse.Host/package.json
+++ b/src/ServicePulse.Host/package.json
@@ -10,7 +10,7 @@
     "angular-pretty-xml": "^0.1.1",
     "angular-route": "^1.6.9",
     "angular-sanitize": "^1.6.9",
-    "angular-ui-bootstrap": "0.14.3",
+    "angular-ui-bootstrap": "^2.5.6",
     "angularjs-toaster": "^1.1.0",
     "animate.css": "^3.4.0",
     "bootstrap": "3.3.5",


### PR DESCRIPTION
## Overview
This PR provides browser-side paging for the message types table in endpoint details view. Specifically, it adds:
  * Ordering on message types by message type name,
  * Paginator at the bottom of the table,
  * Deep linking for page number,
  * It does not reload the table automatically when new message types become available but prompt the user to force the view reload,
  * loader view for endpoint list and details - useful when there are larger sets of message types

NOTE: this includes updating angular-ui-bootstrap to 2.5.6 in order to get desired behavior of the pager. I've checked the other places we use the package (tooltips and modals) and they look fine after update.
