### PR TITLE
Differentiate between infinite scroll loads

### DIFF
--- a/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
+++ b/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
@@ -89,6 +89,7 @@
     <Content Include="tests\js\services\services.messageTypeParser.spec.js" />
     <Content Include="tests\js\services\services.monitoring.spec.js" />
     <Content Include="tests\js\views\failed_groups\controller.spec.js" />
+    <Content Include="tests\js\views\failed_messages\controller.spec.js" />
     <Content Include="tests\js\views\license\license.controller.spec.js" />
     <Content Include="tests\js\views\message\controller.spec.js" />
     <Content Include="tests\js\views\monitored_endpoints\controller.spec.js" />

--- a/src/ServicePulse.Host.Tests/package.json
+++ b/src/ServicePulse.Host.Tests/package.json
@@ -5,7 +5,8 @@
     
   },  
   "devDependencies": {
-    "karma-chrome-launcher": "^2.2.0",    
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "^2.0.1",
     "karma": "^3.1.4",
     "karma-cli": "^2.0.0",
@@ -13,6 +14,7 @@
   },
   "scripts": {
     "test": "karma start --browsers Chrome",    
-    "test-teamcity": "karma start --browsers Chrome --reporters teamcity --single-run"
+    "test-chrome-teamcity": "karma start --browsers Chrome --reporters teamcity --single-run",
+    "test-firefox-teamcity": "karma start --browsers Firefox --reporters teamcity --single-run"
   }
 }

--- a/src/ServicePulse.Host.Tests/package.json
+++ b/src/ServicePulse.Host.Tests/package.json
@@ -5,7 +5,6 @@
     
   },  
   "devDependencies": {
-    "karma-phantomjs-launcher": "^1.0.4",
     "karma-chrome-launcher": "^2.2.0",    
     "karma-jasmine": "^2.0.1",
     "karma": "^3.1.4",
@@ -13,8 +12,7 @@
     "karma-teamcity-reporter": "^1.1.0"
   },
   "scripts": {
-    "test": "karma start --browsers PhantomJS",    
-    "test-chrome": "karma start --browsers Chrome",
-    "test-teamcity": "karma start --browsers PhantomJS --reporters teamcity --single-run"
+    "test": "karma start --browsers Chrome",    
+    "test-teamcity": "karma start --browsers Chrome --reporters teamcity --single-run"
   }
 }

--- a/src/ServicePulse.Host.Tests/tests/js/views/failed_messages/controller.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/views/failed_messages/controller.spec.js
@@ -1,0 +1,62 @@
+﻿describe('failedMessagesController',
+    function() {
+        beforeEach(module('sc'));
+
+        var $controller;
+
+        beforeEach(inject(function(_$controller_) {
+            $controller = _$controller_;
+        }));
+
+        describe('when loading the data with infinite scroll',
+            function() {
+                var controller, serviceControlService, root, deferred, getFailedMessageSpy;
+
+                beforeEach(inject(function ($rootScope, notifyService, $q) {
+                    root = $rootScope;
+                    this.notifyService = notifyService;
+                    serviceControlService = { getExceptionGroups: function () { }, getFailedMessages: function(){ } };
+                    deferred = $q.defer();
+                    spyOn(serviceControlService, 'getExceptionGroups').and.callFake(function () {
+                        
+                        return deferred.promise;
+                    });
+                    
+                    getFailedMessageSpy = spyOn(serviceControlService, 'getFailedMessages').and.callFake(function () {
+                        return deferred.promise;
+                    });
+
+                    controller = $controller('failedMessagesController',
+                    {
+                        $scope: root,
+                        $timeout: null,
+                        $interval: function(){},
+                        $location: null,
+                        sharedDataService: { getstats: function() { return { number_of_pending_retries: 0 }; } },
+                        notifyService: notifyService,
+                        serviceControlService: serviceControlService,
+                        failedMessageGroupsService: null
+                    });
+                }));
+
+                it('no load happens when initial load is in progress',
+                    function () {
+                        expect(getFailedMessageSpy).toHaveBeenCalledTimes(1);
+                        
+                        controller.loadMoreResults(controller.selectedExceptionGroup, true);
+
+                        expect(getFailedMessageSpy).toHaveBeenCalledTimes(1);                        
+                    });
+
+                it('load happens when initial load is done',
+                    function () {
+                        root.$apply(function () { deferred.resolve({data: []}) });
+                        expect(getFailedMessageSpy).toHaveBeenCalledTimes(1);
+
+                        controller.loadMoreResults(controller.selectedExceptionGroup, true);
+
+                        expect(getFailedMessageSpy).toHaveBeenCalledTimes(2);
+                    });
+
+            });       
+    });

--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -218,10 +218,14 @@
             selectGroupInternal(group, sort, direction, true);
         };
 
-        vm.loadMoreResults = function(group) {
+        vm.loadMoreResults = function(group, isInfiniteScrolling) {
             vm.allMessagesLoaded = vm.failedMessages.length >= group.count;
 
             if (!group.initialLoad && (vm.allMessagesLoaded || vm.loadingData)) {
+                return;
+            }
+
+            if (group.initialLoad && isInfiniteScrolling) {
                 return;
             }
 

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -64,7 +64,7 @@
             </div>
         </div>
 
-        <div ng-show="vm.failedMessages.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup)" infinite-scroll-distance="0" infinite-scroll-disabled="vm.disableLoadingData">
+        <div ng-show="vm.failedMessages.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup, true)" infinite-scroll-distance="0" infinite-scroll-disabled="vm.disableLoadingData">
             <div class="col-sm-12 no-mobile-side-padding">
                 <div class="row box repeat-item failed-message" ng-repeat="message in vm.failedMessages">
 


### PR DESCRIPTION
Fixes #726 

Adds a flag that can be used to differentiate between an infinite scroll request or a normal request. If the initial load is still being performed and an infinite scroll load happens at the same time, the infinite scroll request is abandoned.