### PR TITLE
Restore nav in IE < 1440px

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2419,6 +2419,12 @@ div.alert.alert-warning strong {
     }
 }
 
+@media (max-width: 1439px) and screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    nav.navbar {
+        margin-top: 0;
+    }
+}
+
 @media (max-width: 1550px) {
 
     footer {


### PR DESCRIPTION
1.19 (or an earlier release) broke IE11 support. When the viewport size is smaller than 1400px width the top navbar disappears on IE.