### PR TITLE
Allow to control (again) the showPendingRetry setting

### DIFF
--- a/src/ServicePulse.Host.Tests/ApprovalFiles/APIApprovals.PlatformSampleApprovals.approved.txt
+++ b/src/ServicePulse.Host.Tests/ApprovalFiles/APIApprovals.PlatformSampleApprovals.approved.txt
@@ -2,5 +2,6 @@ window.defaultConfig = {
     default_route: '/dashboard',
     version: '1.2.0',
     service_control_url: 'http://localhost:33333/api/',
-    monitoring_urls: ['http://localhost:33633/']
+    monitoring_urls: ['http://localhost:33633/'],
+    showPendingRetry: false
 };

--- a/src/ServicePulse.Host.Tests/ApprovalFiles/APIApprovals.PlatformSampleApprovals.approved.txt
+++ b/src/ServicePulse.Host.Tests/ApprovalFiles/APIApprovals.PlatformSampleApprovals.approved.txt
@@ -2,6 +2,5 @@ window.defaultConfig = {
     default_route: '/dashboard',
     version: '1.2.0',
     service_control_url: 'http://localhost:33333/api/',
-    monitoring_urls: ['http://localhost:33633/'],
-    showPendingRetry: false
+    monitoring_urls: ['http://localhost:33633/']
 };

--- a/src/ServicePulse.Host/app/js/app.constants.js
+++ b/src/ServicePulse.Host/app/js/app.constants.js
@@ -2,5 +2,6 @@ window.defaultConfig = {
     default_route: '/dashboard',
     version: '1.2.0',
     service_control_url: 'http://localhost:33333/api/',
-    monitoring_urls: ['http://localhost:33633/']
+    monitoring_urls: ['http://localhost:33633/'],
+    showPendingRetry: false
 };

--- a/src/ServicePulse.Host/app/js/app.constants.js
+++ b/src/ServicePulse.Host/app/js/app.constants.js
@@ -2,6 +2,5 @@ window.defaultConfig = {
     default_route: '/dashboard',
     version: '1.2.0',
     service_control_url: 'http://localhost:33333/api/',
-    monitoring_urls: ['http://localhost:33633/'],
-    showPendingRetry: false
+    monitoring_urls: ['http://localhost:33633/']
 };

--- a/src/ServicePulse.Host/app/js/app.js
+++ b/src/ServicePulse.Host/app/js/app.js
@@ -39,7 +39,7 @@
     angular.module('sc')
         .value('$jquery', $)
         .constant('version', window.defaultConfig.version)
-        .constant('showPendingRetry', window.defaultConfig.showPendingRetry)
+        .constant('showPendingRetry', (window.defaultConfig.showPendingRetry || false))
         .constant('scConfig', window.defaultConfig);
 
     angular.module('sc').config(['$locationProvider', function ($locationProvider) {

--- a/src/ServicePulse.Host/app/js/app.js
+++ b/src/ServicePulse.Host/app/js/app.js
@@ -39,7 +39,7 @@
     angular.module('sc')
         .value('$jquery', $)
         .constant('version', window.defaultConfig.version)
-        .constant('showPendingRetry', (window.defaultConfig.showPendingRetry || false))
+        .constant('showPendingRetry', window.defaultConfig.showPendingRetry)
         .constant('scConfig', window.defaultConfig);
 
     angular.module('sc').config(['$locationProvider', function ($locationProvider) {

--- a/src/ServicePulse.Host/app/js/app.js
+++ b/src/ServicePulse.Host/app/js/app.js
@@ -39,7 +39,7 @@
     angular.module('sc')
         .value('$jquery', $)
         .constant('version', window.defaultConfig.version)
-        .constant('showPendingRetry', false)
+        .constant('showPendingRetry', window.defaultConfig.showPendingRetry)
         .constant('scConfig', window.defaultConfig);
 
     angular.module('sc').config(['$locationProvider', function ($locationProvider) {


### PR DESCRIPTION
As [stated in the documentation](https://docs.particular.net/servicepulse/intro-pending-retries) by tweaking the `app.constants.js` it should be possible to enable the "show pending retry" feature in ServicePulse. This was broken due to way Pulse was changed to introduce the ability to control che ServiceControl connection. This PR fixes the regression by re-enabling the ability to turn-on the "show pending retry" feature.

## PoA

- [x] test that Pulse and the feature work as expected when using the installer
- [ ] update documentation to reflect the change https://github.com/Particular/docs.particular.net/pull/4443
- [ ] release and announce