### PR TITLE
Make the link to the previous version of the edited message explicit

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -612,7 +612,9 @@ span.metadata {
     color: #777f7f;
 }
 
-
+span.metadata.metadata-link i.fa {
+    color: #00a3c4;
+}
 
 .metadata:first-child {
     padding-left: 0;
@@ -2933,4 +2935,8 @@ table[ng-show="vm.message.panel === 2 && vm.message.messageHeaders"] td[nowrap="
 
 .modal-msg-editor .row.alert.alert-danger i.fa.fa-exclamation-triangle {
     color: #ce4844;
+}
+
+span.label {
+    background-image: none;
 }

--- a/src/ServicePulse.Host/app/js/views/message/messages-view.html
+++ b/src/ServicePulse.Host/app/js/views/message/messages-view.html
@@ -29,11 +29,8 @@
                             <span ng-if="vm.message.archived" tooltip="Message is being archived" class="label sidebar-label label-warning metadata-label">Archived</span>
                             <span ng-if="vm.message.resolved" tooltip="Message was processed successfully" class="label sidebar-label label-warning metadata-label">Processed</span>
                             <span ng-if="vm.message.number_of_processing_attempts > 1" tooltip="This message has already failed {{vm.message.number_of_processing_attempts}} times" class="label sidebar-label label-important metadata-label">{{vm.message.number_of_processing_attempts}} Retry Failures</span>
-                            <span ng-if="vm.message.edited">
-                                <span tooltip="Message was edited" class="label sidebar-label label-info metadata-label">Edited</span>
-                                <a ng-href="#/failed-messages/message/{{vm.message.edit_of}}" tooltip="Click to load the original message"> View original message</a>
-                            </span>
-
+                            <span ng-if="vm.message.edited" tooltip="Message was edited" class="label sidebar-label label-info metadata-label">Edited</span>
+                            <span class="metadata metadata-link" ng-if="vm.message.edited"><i class="fa fa-history" aria-hidden="true"></i> <a ng-href="#/failed-messages/message/{{vm.message.edit_of}}">View previous version</a></span>
                             <span class="metadata"><i class="fa fa-clock-o"></i> Failed: <sp-moment date="{{vm.message.time_of_failure}}"></sp-moment></span>
                             <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{vm.message.receiving_endpoint.name}}</span>
                             <span class="metadata"><i class="fa fa-laptop"></i> Machine: {{vm.message.receiving_endpoint.host}}</span>

--- a/src/ServicePulse.Host/app/js/views/message/messages-view.html
+++ b/src/ServicePulse.Host/app/js/views/message/messages-view.html
@@ -29,7 +29,10 @@
                             <span ng-if="vm.message.archived" tooltip="Message is being archived" class="label sidebar-label label-warning metadata-label">Archived</span>
                             <span ng-if="vm.message.resolved" tooltip="Message was processed successfully" class="label sidebar-label label-warning metadata-label">Processed</span>
                             <span ng-if="vm.message.number_of_processing_attempts > 1" tooltip="This message has already failed {{vm.message.number_of_processing_attempts}} times" class="label sidebar-label label-important metadata-label">{{vm.message.number_of_processing_attempts}} Retry Failures</span>
-                            <a ng-if="vm.message.edited" ng-href="#/failed-messages/message/{{vm.message.edit_of}}" tooltip="Message was edited, click to load the original message" class="label sidebar-label label-info metadata-label">Edited</a>
+                            <span ng-if="vm.message.edited">
+                                <span tooltip="Message was edited" class="label sidebar-label label-info metadata-label">Edited</span>
+                                <a ng-href="#/failed-messages/message/{{vm.message.edit_of}}" tooltip="Click to load the original message"> View original message</a>
+                            </span>
 
                             <span class="metadata"><i class="fa fa-clock-o"></i> Failed: <sp-moment date="{{vm.message.time_of_failure}}"></sp-moment></span>
                             <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{vm.message.receiving_endpoint.name}}</span>


### PR DESCRIPTION
Based on feedback this PR adds an explicit link to the original message instead of relying to a link on the `Edited` badge.