### PR TITLE
Replace ng-page-title with custom directive

### DIFF
--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -10,7 +10,8 @@
         }
     </style>
 
-    <title page-title pattern="%s • ServicePulse"></title>
+    <title>ServicePulse</title>
+    <page-title-from-route></page-title-from-route>
 
     <meta charset="utf-8">
     <meta name="description" content="An Operations Manager’s Best Friend">
@@ -177,7 +178,6 @@
     <!-- Directives -->
     <script src="js/directives/ngClip.js"></script>
     <script src="js/directives/moment.js"></script>
-    <script src="js/directives/ui.particular.js"></script>
     <script src="js/directives/ui.particular.hud.js"></script>
     <script src="js/directives/ui.particular.productVersion.js"></script>
     <script src="js/directives/ui.particular.busy.js"></script>
@@ -190,6 +190,8 @@
     <script src="js/directives/ui.particular.failedMessageTabs.js"></script>
     <script src="js/directives/ui.particular.largenumber.js"></script>
     <script src="js/directives/ui.particular.multi-checkboxlist.js"></script>
+    <script src="js/directives/ui.particular.pageTitleFromRoute.js"></script>
+    <script src="js/directives/ui.particular.js"></script>
 
     <!-- Mystery -->
     <script src="js/views/event_log_items/eventLogItems.js"></script>

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.js
@@ -21,7 +21,8 @@
         'ui.particular.multicheckboxList',
         'ui.particular.monitoringConnectivityStatus',
         'ui.particular.exclamation',
-        'ui.particular.messageTypesChangeIndicator'
+        'ui.particular.messageTypesChangeIndicator',
+        'ui.particular.pageTitleFromRoute',
     ]);
 
 } (window, window.angular));

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.pageTitleFromRoute.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.pageTitleFromRoute.js
@@ -1,0 +1,24 @@
+(function (window, angular) {
+    'use strict';
+
+    function directive($route, $rootScope, $window) {
+        return {
+            scope: {
+                type: '@'
+            },
+            restrict: 'E',
+            replace: true,
+            link: function (scope, element) {
+                $rootScope.$on('$routeChangeSuccess', function() {
+                    $window.document.title = $route.current.$$route.data.pageTitle + ' • ServicePulse';
+                });
+             }
+        };
+    };
+    
+    directive.$inject = ['$route', '$rootScope', '$window'];
+    
+    angular.module('ui.particular.pageTitleFromRoute', ['ngRoute'])
+        .directive('pageTitleFromRoute', directive);
+
+}(window, window.angular));

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.pageTitleFromRoute.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.pageTitleFromRoute.js
@@ -4,7 +4,6 @@
     function directive($route, $rootScope, $window) {
         return {
             scope: {
-                type: '@'
             },
             restrict: 'E',
             replace: true,

--- a/src/ServicePulse.Host/package.json
+++ b/src/ServicePulse.Host/package.json
@@ -19,7 +19,6 @@
     "moment": "^2.19.3",
     "moment-duration-format": "^1.3.0",
     "ng-infinite-scroll": "^1.3.0",
-    "ng-page-title": "^1.1.1",
     "ngstorage": "git://github.com/gsklee/ngStorage#0.3.10",
     "npm": "^6.1.0",
     "rx": "^4.1.0",


### PR DESCRIPTION
Fixes https://github.com/Particular/ServicePulse/issues/717

Replaces `ng-page-title` with a custom directive.

Added @WojcikMike as a reviewer in case he want's to look over our work.