### PR TITLE
Fix issue with unarchiving more than 50 items at a time

### DIFF
--- a/src/ServicePulse.Host/app/js/views/archive/controller.js
+++ b/src/ServicePulse.Host/app/js/views/archive/controller.js
@@ -68,7 +68,7 @@
 
                 vm.archives = vm.archives.concat(exgroups);
                 vm.allMessagesLoaded = (vm.archives.length >= vm.total);
-                vm.page++;
+                vm.sort.page++;
             }
 
             vm.loadingData = false;
@@ -156,6 +156,7 @@
                     // We are going to have to wait for service control to tell us the job has been done
                     // group.workflow_state = createWorkflowState('success', message);
                     notifier.notify('RestoreFromArchiveRequestAccepted');
+                    $scope.$emit('list:updated');
 
                 }, function (message) {
                     // group.workflow_state = createWorkflowState('error', message);

--- a/src/ServicePulse.Host/app/js/views/archive/view.html
+++ b/src/ServicePulse.Host/app/js/views/archive/view.html
@@ -45,7 +45,7 @@
 
         <no-data ng-show="vm.archives.length === 0 && !vm.loadingData" title="message failures" message="There are currently no archived messages"></no-data>
 
-        <div class="row" ng-show="vm.archives.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup)" infinite-scroll-distance="0" infinite-scroll-disabled="vm.disableLoadingData" class="clearfix">
+        <div class="row" ng-show="vm.archives.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup)" infinite-scroll-distance="0" infinite-scroll-listen-for-event="list:updated" infinite-scroll-disabled="vm.disableLoadingData" class="clearfix">
 
             <div class="col-sm-12 no-mobile-side-padding" ng-repeat="message in vm.archives">
 

--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -153,6 +153,7 @@
                     vm.failedMessages = vm.failedMessages.filter(function(item) {
                         return !item.selected;
                     });
+
                     $scope.$emit("list:updated");
                 });
         };

--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -153,6 +153,7 @@
                     vm.failedMessages = vm.failedMessages.filter(function(item) {
                         return !item.selected;
                     });
+                    $scope.$emit("list:updated");
                 });
         };
 

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -68,7 +68,7 @@
                 </div>
             </div>
 
-            <div ng-show="vm.failedMessages.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup, true)" infinite-scroll-distance="0" infinite-scroll-disabled="vm.disableLoadingData" class="clearfix">
+            <div ng-show="vm.failedMessages.length > 0" infinite-scroll="vm.loadMoreResults(vm.selectedExceptionGroup, true)" infinite-scroll-distance="0" infinite-scroll-listen-for-event="list:updated" infinite-scroll-disabled="vm.disableLoadingData" class="clearfix">
                 <div class="col-sm-12 no-mobile-side-padding">
                     <div class="row box repeat-item failed-message" ng-repeat="message in vm.failedMessages">
 


### PR DESCRIPTION
Fixes #664 
Fixes #665 

This also addresses another issue where the failed messages and archived messages pages would not load more search results if you managed to remove all displayed items from the list.