### PR TITLE
Fix broken link in monitoring endpoint details

### DIFF
--- a/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/controller.js
@@ -19,8 +19,6 @@
         var notifier = notifyService();
         
         vm.selectedExceptionGroup = { 'id': $routeParams.groupId ? $routeParams.groupId : undefined, 'title': 'All Failed Messages', 'count': 0, 'initialLoad': true };
-        vm.selectedExceptionGroup.parentTitle = $routeParams.parentGroupId;
-        vm.selectedExceptionGroup.parentGroupIndex = $routeParams.parentGroupIndex;
 
         if (!vm.selectedExceptionGroup.hasOwnProperty('title')) {
             $location.path('/failed-messages/groups');

--- a/src/ServicePulse.Host/app/js/views/failed_messages/route.js
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/route.js
@@ -8,14 +8,6 @@
             {
                 redirectTo: '/failed-messages/groups/:groupId'
             })
-            .when('/failed-messages/groups/:parentGroupId/:parentGroupIndex/:groupId', {
-                data: {
-                    pageTitle: 'Failed Messages'
-                },
-                templateUrl: 'js/views/failed_messages/view.html',
-                controller: 'failedMessagesController',
-                controllerAs: 'vm'
-            })
             .when('/failed-messages/groups/:groupId', {
                 data: {
                     pageTitle: 'Failed Messages'

--- a/src/ServicePulse.Host/app/js/views/failed_messages/view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_messages/view.html
@@ -18,7 +18,6 @@
                 <div class="col-sm-12">
                     <div ng-show="!vm.selectedExceptionGroup.id" class="active">All failed messages ({{vm.failedMessages.length}} / {{vm.selectedExceptionGroup.count}} | number)</div>
                     <h1 ng-show="vm.selectedExceptionGroup.id" class="active break group-title">
-                        <span ng-if="vm.selectedExceptionGroup.parentTitle">{{vm.selectedExceptionGroup.parentTitle}} - </span>
                         {{vm.selectedExceptionGroup.title}}
                     </h1>
                     <h3 class="active group-title group-message-count">{{vm.selectedExceptionGroup.count | number}} messages in group</h3>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -18,7 +18,7 @@
                 <span class="warning" ng-if="endpoint.isScMonitoringDisconnected">
                     <i class="fa pa-monitoring-lost endpoint-details" uib-tooltip="Unable to connect to monitoring server"></i>
                 </span>
-                <a ng-if="endpoint.errorCount" class="warning" href="#/failed-messages/groups/{{endpointName}}/{{endpoint.serviceControlId}}">
+                <a ng-if="endpoint.errorCount" class="warning" href="#/failed-messages/groups/{{endpoint.serviceControlId}}">
                     <i class="fa fa-envelope" uib-tooltip="{{endpoint.errorCount | metricslargenumber}} failed messages associated with this endpoint. Click to see list."></i>
                     <span class="badge badge-important ng-binding">{{endpoint.errorCount | metricslargenumber}}</span>
                 </a>
@@ -271,7 +271,7 @@
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
                                                 </span>
                                                 <span class="warning" ng-if="instance.errorCount">
-                                                    <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{endpointName}}/{{instance.serviceControlId}}">
+                                                    <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{instance.serviceControlId}}">
                                                         <i class="fa fa-envelope" uib-tooltip="{{instance.errorCount | metricslargenumber}} failed messages associated with this endpoint. Click to see list."></i>
                                                         <span class="badge badge-important ng-binding">{{instance.errorCount | metricslargenumber}}</span>
                                                     </a>


### PR DESCRIPTION
Fixes #789 

Not part of the ServicePulse maintenance release but noticed this broken link during testing. The route code I removed because it doesn't appear to be used anywhere else now that the link has been fixed.