### PR TITLE
Add sort on failed message groups

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2960,3 +2960,7 @@ a.remove-item i {
 a.remove-item:hover i {
     color: #00729c;
 }
+
+ul.dropdown-menu li a span {
+    color: #aaa;
+}

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -676,8 +676,8 @@ div.btn-toolbar, div.form-inline {
 
 .control-label {
     float: left;
-    padding-top: 6px;
-    margin-right: 6px;
+    padding-top: 7.5px;
+    margin-right: -10px;
 }
 
 .row.filter-toolbar, .row.action-toolbar {

--- a/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
@@ -57,7 +57,6 @@
                 </div>
 
                 <div class="col-xs-6 toolbar-menus no-side-padding">
-
                     <div class="msg-group-menu dropdown">
                         <label class="control-label">Group by:</label>
                         <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -68,6 +67,18 @@
                             <li ng-repeat="classifier in vm.availableClassifiers">
                                 <a href="/#/failed-messages/groups?groupBy={{classifier}}">{{classifier}}</a>
                             </li>
+                        </ul>
+                    </div>
+
+                    <div class="msg-group-menu dropdown">
+                        <label class="control-label">Sort by:</label>
+                        <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            {{vm.selectedSort}}
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li ng-repeat-start="sort in vm.sortSelectors"><a href="/#/failed-messages/groups?sortBy={{sort.description}}">{{sort.description}}</a></li>
+                            <li ng-repeat-end><a href="/#/failed-messages/groups?sortBy={{sort.description}}&sortdir=desc">{{sort.description}} (Desc)</a></li>
                         </ul>
                     </div>
                 </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
@@ -78,7 +78,7 @@
                         </button>
                         <ul class="dropdown-menu">
                             <li ng-repeat-start="sort in vm.sortSelectors"><a href="/#/failed-messages/groups?sortBy={{sort.description}}">{{sort.description}}</a></li>
-                            <li ng-repeat-end><a href="/#/failed-messages/groups?sortBy={{sort.description}}&sortdir=desc">{{sort.description}} (Desc)</a></li>
+                            <li ng-repeat-end><a href="/#/failed-messages/groups?sortBy={{sort.description}}&sortdir=desc">{{sort.description}} <span>(Descending)</span></a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Closes https://github.com/Particular/ServicePulse/issues/266

Adds a sort option on the failed message groups.

Adds sort for all the main fields on the group:

* Name
* First failure
* Last failure
* Last retry
* Number of messages

![image](https://user-images.githubusercontent.com/1060960/79872499-2a15a600-83e6-11ea-95fd-4b886b98d0f4.png)

It also saves the sort so that the next time the user views the page it restores the previously selected sort.