### PR TITLE
Displaying a static text for a retries consisting of selection or a s…

### DIFF
--- a/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
@@ -29,7 +29,7 @@
                                 <div class="col-sm-12 no-side-padding">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <p class="lead break"> {{group.originator}}</p>
+                                            <p class="lead break"> {{group.originator || 'A retry of selection of messages.'}}</p>
                                         </div>
                                     </div>
 


### PR DESCRIPTION
…ingle message

Solves: https://github.com/Particular/ServicePulse/issues/744

![image](https://user-images.githubusercontent.com/604826/80382668-d3efa980-88a2-11ea-805e-8bbbd22b630e.png)

The group name is empty when retry is related to a selection of messages. And this is what I tried to represent here. 
I am waiting for a good name for such scenario: 
