### PR TITLE
Allow removal of stale endpoints

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2970,7 +2970,10 @@ ul.dropdown-menu li a span {
 }
 
 .endpoint-row:hover a.remove-endpoint {
-    display: inline;
+    display: block;
+    position: absolute;
+    top: 17px;
+    right: 22px;
 }
 
 a.remove-endpoint {
@@ -2991,7 +2994,6 @@ a.remove-endpoint:hover i {
 .filter-group {
     display: inline-block;
     width: 50%;
-    float: right;
     position: relative;
     top: -3px;
     margin-top: -26px;

--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -2965,6 +2965,29 @@ ul.dropdown-menu li a span {
     color: #aaa;
 }
 
+.endpoint-row a.remove-endpoint {
+    display: none;
+}
+
+.endpoint-row:hover a.remove-endpoint {
+    display: inline;
+}
+
+a.remove-endpoint {
+    margin-left: 7px;
+}
+
+a.remove-endpoint:hover {
+    cursor: pointer;
+}
+
+a.remove-endpoint i {
+    color: #00a3c4;
+}
+
+a.remove-endpoint:hover i {
+    color: #00729c;
+}
 .filter-group {
     display: inline-block;
     width: 50%;

--- a/src/ServicePulse.Host/app/modules/modules.webpackconfig.builder.js
+++ b/src/ServicePulse.Host/app/modules/modules.webpackconfig.builder.js
@@ -1,6 +1,25 @@
-﻿var config = require('./modules.webpackconfig.js');
+﻿const fs = require('fs');
+
+var config = require('./modules.webpackconfig.js');
 
 delete config.watch;
 delete config.watchOptions;
+// function to replace src="modules/dist/*.js" with the hash appended
+config.plugins.push(function() {
+    this.plugin('done', function (statsData) {
+        const stats = statsData.toJson();
+
+        if (!stats.errors.length) {
+            const html = fs.readFileSync('./app/index.html', 'utf8');
+            const now = Date.now();
+
+            let tokenizedMarkup = html.split('.js?v=').map(token => token.split('"></script>'));
+            let flattenedTokens = tokenizedMarkup.reduce((acc, val) => acc.concat(val), []);
+            let htmlOutput = flattenedTokens.filter((token, index) => index % 2 == 0).join('.js?v=' + now + '"></script>');
+
+            fs.writeFileSync('./app/index.html', htmlOutput);
+        }
+    });
+})
 
 module.exports = config;

--- a/src/ServicePulse.Host/app/modules/modules.webpackconfig.js
+++ b/src/ServicePulse.Host/app/modules/modules.webpackconfig.js
@@ -2,7 +2,6 @@
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const fs = require('fs');
 
 module.exports = {
     entry: {
@@ -25,23 +24,6 @@ module.exports = {
             moment: 'moment'
         }),
         new ExtractTextPlugin("vendor.css"),
-        // function to replace src="modules/dist/*.js" with the hash appended
-        function() {
-            this.plugin('done', function (statsData) {
-                const stats = statsData.toJson();
-
-                if (!stats.errors.length) {
-                    const html = fs.readFileSync('./app/index.html', 'utf8');
-                    const now = Date.now();
-
-                    let tokenizedMarkup = html.split('.js?v=').map(token => token.split('"></script>'));
-                    let flattenedTokens = tokenizedMarkup.reduce((acc, val) => acc.concat(val), []);
-                    let htmlOutput = flattenedTokens.filter((token, index) => index % 2 == 0).join('.js?v=' + now + '"></script>');
-
-                    fs.writeFileSync('./app/index.html', htmlOutput);
-                }
-            });
-        }
     ],
     module: {
         rules: [{

--- a/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.largeGraph.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/directives/ui.particular.largeGraph.js
@@ -131,7 +131,7 @@
                                 max = Math.max(max, secondSeries.average, d3.max(secondSeries.points));
                             }
 
-                            var max = padToWholeValue(max);
+                            max = padToWholeValue(max);
 
                             var scaleY = d3.scaleLinear()
                                 .domain([0, max])

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -74,7 +74,7 @@
             monitoringService.removeEndpointInstance(endpointName, instance.id).then(() => {
                 $scope.endpoint.instances.splice($scope.endpoint.instances.indexOf(instance), 1);
             }, () => {
-                instance.busy = false
+                instance.busy = false;
             });
         };
 

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -73,6 +73,10 @@
             instance.busy = true;
             monitoringService.removeEndpointInstance(endpointName, instance.id).then(() => {
                 $scope.endpoint.instances.splice($scope.endpoint.instances.indexOf(instance), 1);
+
+                if ($scope.endpoint.instances.length === 0) {
+                    $window.location.hash = '#/monitoring';
+                }
             }, () => {
                 instance.busy = false;
             });

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -65,6 +65,15 @@
             $scope.endpoint.refreshMessageTypes();
         };
 
+        $scope.removeEndpoint = (instance) => {
+            instance.busy = true;
+            monitoringService.removeEndpointInstance(instance.id).then(() => {
+                $scope.endpoint.instances.splice($scope.endpoint.instances.indexOf(instance), 1);
+            }, () => {
+                instance.busy = false
+            });
+        };
+
         $scope.endpoint = {
             messageTypesPage: !$scope.showInstancesBreakdown ? $routeParams.pageNo : 1,
             messageTypesTotalItems: 0,

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -41,7 +41,7 @@
 
         function mergeIn(destination, source, propertiesToSkip) {
             for (var propName in source) {
-                if (source.hasOwnProperty(propName)) {
+                if (Object.prototype.hasOwnProperty.call(source, propName)) {
                     if(!propertiesToSkip || !propertiesToSkip.includes(propName)) {
                         destination[propName] = source[propName];
                     }

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -35,6 +35,10 @@
             updateUI();
         };
 
+        monitoringService.isRemovingEndpointEnabled().then(enabled => {
+            $scope.isRemovingEndpointEnabled = enabled;
+        });
+
         function mergeIn(destination, source, propertiesToSkip) {
             for (var propName in source) {
                 if (source.hasOwnProperty(propName)) {

--- a/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/endpoint_details.controller.js
@@ -69,9 +69,9 @@
             $scope.endpoint.refreshMessageTypes();
         };
 
-        $scope.removeEndpoint = (instance) => {
+        $scope.removeEndpoint = (endpointName, instance) => {
             instance.busy = true;
-            monitoringService.removeEndpointInstance(instance.id).then(() => {
+            monitoringService.removeEndpointInstance(endpointName, instance.id).then(() => {
                 $scope.endpoint.instances.splice($scope.endpoint.instances.indexOf(instance), 1);
             }, () => {
                 instance.busy = false

--- a/src/ServicePulse.Host/app/modules/monitoring/js/monitored_endpoints.controller.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/monitored_endpoints.controller.js
@@ -51,7 +51,7 @@
 
         function mergeIn(destination, source) {
             for (var propName in source) {
-                if (source.hasOwnProperty(propName)) {
+                if (Object.prototype.hasOwnProperty.call(source, propName)) {
                     destination[propName] = source[propName];
                 }
             }

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -60,11 +60,16 @@
             });
         }
 
+        function removeEndpointInstance(instanceId) {
+            return $http.delete(uri.join(mu, 'monitored-instance', instanceId));
+        }
+
         var service = {
-            createEndpointsSource: createEndpointsSource,
-            createEndpointDetailsSource: createEndpointDetailsSource,
-            getMonitoredEndpoints: getMonitoredEndpoints,
-            getServiceControlMonitoringVersion: getServiceControlMonitoringVersion
+            createEndpointsSource,
+            createEndpointDetailsSource,
+            getMonitoredEndpoints,
+            getServiceControlMonitoringVersion,
+            removeEndpointInstance
         };
 
         return service;

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -64,8 +64,6 @@
             });
         }
 
-        }
-
         function isRemovingEndpointEnabled() {
             return $http({
                 method: 'OPTIONS',

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -64,12 +64,30 @@
             return $http.delete(uri.join(mu, 'monitored-instance', instanceId));
         }
 
+        function isRemovingEndpointEnabled() {
+            return $http({
+                method: 'OPTIONS',
+                url: mu
+            }).then((response) => {
+                const headers = response.headers();
+
+                const allow = headers.allow;
+                const deleteAllowed = allow.indexOf(`DELETE`) >= 0;
+
+                return deleteAllowed;
+            }, function() {
+                debugger;
+                return false;
+            });
+        }
+
         var service = {
             createEndpointsSource,
             createEndpointDetailsSource,
             getMonitoredEndpoints,
             getServiceControlMonitoringVersion,
-            removeEndpointInstance
+            removeEndpointInstance,
+            isRemovingEndpointEnabled
         };
 
         return service;

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -54,14 +54,16 @@
             return $http.get(uri.join(mu, 'monitored-endpoints') + '?history=1');
         }
 
+        function removeEndpointInstance(endpointName, instanceId) {
+            return $http.delete(uri.join(mu, 'monitored-instance', endpointName, instanceId));
+        }
+
         function getServiceControlMonitoringVersion() {
             return $http.get(mu).then(function(response) {
                 return response.headers('X-Particular-Version');
             });
         }
 
-        function removeEndpointInstance(instanceId) {
-            return $http.delete(uri.join(mu, 'monitored-instance', instanceId));
         }
 
         function isRemovingEndpointEnabled() {
@@ -76,7 +78,6 @@
 
                 return deleteAllowed;
             }, function() {
-                debugger;
                 return false;
             });
         }

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -74,7 +74,7 @@
                 const headers = response.headers();
 
                 const allow = headers.allow;
-                const deleteAllowed = allow.indexOf(`DELETE`) >= 0;
+                const deleteAllowed = allow.indexOf('DELETE') >= 0;
 
                 return deleteAllowed;
             }, function() {

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -403,9 +403,6 @@
                                                 <span class="warning" ng-if="endpoint.isScMonitoringDisconnected">
                                                     <i class="fa pa-monitoring-lost endpoint-details" uib-tooltip="Unable to connect to monitoring server"></i>
                                                 </span>
-                                                <span class="warning" ng-if="endpoint.isStale">
-                                                    <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
-                                                </span>
                                             </div>
                                         </div>
                                         <div class="row message-type-properties">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -269,7 +269,6 @@
                                                 </span>
                                                 <span class="warning" ng-if="instance.isStale">
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
-                                                    <a ng-if="isRemovingEndpointEnabled" class="remove-endpoint" ng-click="removeEndpoint(endpointName, instance)"><i class="fa fa-trash" uib-tooltip="Remove endpoint"></i></a>
                                                 </span>
                                                 <span class="warning" ng-if="instance.errorCount">
                                                     <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{instance.serviceControlId}}">
@@ -330,6 +329,7 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <a ng-if="isRemovingEndpointEnabled" ng-show="instance.isStale" class="remove-endpoint" ng-click="removeEndpoint(endpointName, instance)"><i class="fa fa-trash" uib-tooltip="Remove endpoint"></i></a>
                                 </div>
                             </div>
                         </div>

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -269,6 +269,7 @@
                                                 </span>
                                                 <span class="warning" ng-if="instance.isStale">
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
+                                                    <a class="remove-endpoint" ng-click="removeEndpoint(instance)"><i class="fa fa-trash" uib-tooltip="Remove endpoint"></i></a>
                                                 </span>
                                                 <span class="warning" ng-if="instance.errorCount">
                                                     <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{instance.serviceControlId}}">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -269,7 +269,7 @@
                                                 </span>
                                                 <span class="warning" ng-if="instance.isStale">
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
-                                                    <a class="remove-endpoint" ng-click="removeEndpoint(instance)"><i class="fa fa-trash" uib-tooltip="Remove endpoint"></i></a>
+                                                    <a ng-if="isRemovingEndpointEnabled" class="remove-endpoint" ng-click="removeEndpoint(instance)"><i class="fa fa-trash" uib-tooltip="Remove endpoint"></i></a>
                                                 </span>
                                                 <span class="warning" ng-if="instance.errorCount">
                                                     <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{instance.serviceControlId}}">

--- a/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/endpoint_details.html
@@ -269,7 +269,7 @@
                                                 </span>
                                                 <span class="warning" ng-if="instance.isStale">
                                                     <i class="fa pa-endpoint-lost endpoint-details" uib-tooltip="Unable to connect to instance"></i>
-                                                    <a ng-if="isRemovingEndpointEnabled" class="remove-endpoint" ng-click="removeEndpoint(instance)"><i class="fa fa-trash" uib-tooltip="Remove endpoint"></i></a>
+                                                    <a ng-if="isRemovingEndpointEnabled" class="remove-endpoint" ng-click="removeEndpoint(endpointName, instance)"><i class="fa fa-trash" uib-tooltip="Remove endpoint"></i></a>
                                                 </span>
                                                 <span class="warning" ng-if="instance.errorCount">
                                                     <a ng-if="instance.errorCount" class="warning btn" href="#/failed-messages/groups/{{instance.serviceControlId}}">


### PR DESCRIPTION
Fixes https://github.com/Particular/ServicePulse/issues/840

Introduces a delete option for stale endpoints.

Sends a HTTP DELETE request to ServiceControl Monitoring to remove the instance from the endpoint registry.

* It first does a Cors OPTIONS check to see if ServiceControl monitoring supports deleting the instances.
* If it returns a header supporting DELETE, then a delete icon will appear when hovering over a stale endpoint instance.
* Clicking on the delete icon will result in the endpoint instance being removed from the Monitoring page.
* If ServiceControl monitoring does not support deleting endpoints, then the behaviour will be exactly as it is now. No changes.


![image](https://user-images.githubusercontent.com/1060960/80477854-f0e0b700-894c-11ea-9d4b-0fab980f5d4d.png)
