### PR TITLE
Add a new "Archive Groups" screen to show groups of archived messages

### DIFF
--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -228,6 +228,11 @@
     <script src="js/views/archive/controller.js?v=1587640065850"></script>
     <script src="js/views/archive/service.js?v=1587640065850"></script>
 
+    <!-- Archive Groups -->
+    <script src="js/views/archivedgroups/archivedgroups.route.js"></script>
+    <script src="js/views/archivedgroups/archivedgroups.controller.js"></script>
+    <script src="js/views/archivedgroups/archivedgroups.service.js"></script>
+
     <!-- Pending Retries -->
     <script src="js/views/pending_retries/route.js?v=1587640065850"></script>
     <script src="js/views/pending_retries/controller.js?v=1587640065850"></script>

--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -229,9 +229,9 @@
     <script src="js/views/archive/service.js?v=1587640065850"></script>
 
     <!-- Archive Groups -->
-    <script src="js/views/archivedgroups/archivedgroups.route.js"></script>
-    <script src="js/views/archivedgroups/archivedgroups.controller.js"></script>
-    <script src="js/views/archivedgroups/archivedgroups.service.js"></script>
+    <script src="js/views/archivedgroups/archivedgroups.route.js?v=1587640065850"></script>
+    <script src="js/views/archivedgroups/archivedgroups.controller.js?v=1587640065850"></script>
+    <script src="js/views/archivedgroups/archivedgroups.service.js?v=1587640065850"></script>
 
     <!-- Pending Retries -->
     <script src="js/views/pending_retries/route.js?v=1587640065850"></script>

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -148,6 +148,8 @@
         notifier.subscribe($scope, function(event, data) {
             $scope.SCVersion = data.sc_version;
             $scope.is_compatible_with_sc = data.is_compatible_with_sc;
+            $rootScope.supportsArchiveGroups = data.supportsArchiveGroups;
+            
             if (!data.is_compatible_with_sc) {
                 var scNeedsUpgradeMessage = 'You are using Service Control version ' + data.sc_version + '. Please, upgrade to version ' + data.minimum_supported_sc_version + ' or higher to unlock new functionality in ServicePulse.';
                 toastService.showError(scNeedsUpgradeMessage);

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.js
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.js
@@ -1,14 +1,15 @@
 ﻿(function(window, angular, $) {
     'use strict';
 
-
-    function controller($scope, $interval, $location, sharedDataService, notifyService, serviceControlService, showPendingRetry) {
+    function controller($scope, $rootScope, $interval, $location, sharedDataService, notifyService, serviceControlService, showPendingRetry) {
 
         var notifier = notifyService();
 
         $scope.isActive = function(viewLocation) {
             return (viewLocation === $location.path());
         };
+
+        $scope.supportsArchiveGroups = $rootScope.supportsArchiveGroups;
 
         var stats = sharedDataService.getstats();
         var allFailedMessagesGroup = { 'id': undefined, 'title': 'All Failed Messages', 'count': stats.number_of_failed_messages }
@@ -21,7 +22,7 @@
 
         $scope.viewExceptionGroup = function() {
             sharedDataService.set(allFailedMessagesGroup);
-            $location.path('/failed-messages/all');
+            $location.url('/failed-messages/all');
         }
 
         var archiveMessagesUpdatedTimer = $interval(function() {
@@ -72,7 +73,7 @@
         }, 'PendingRetriesTotalUpdated');
     }
 
-    controller.$inject = ['$scope', '$interval', '$location', 'sharedDataService', 'notifyService', 'serviceControlService', 'showPendingRetry'];
+    controller.$inject = ['$scope', '$rootScope', '$interval', '$location', 'sharedDataService', 'notifyService', 'serviceControlService', 'showPendingRetry'];
 
     function directive() {
         return {

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
@@ -7,7 +7,7 @@
                 </span>
             </h5>
             <h5 ng-class="{ active: isActive('/failed-messages/all') }"><a ng-click="viewExceptionGroup()">All failed messages<span ng-show="counters.message == 0"> (0)</span></a> <span ng-show="counters.message > 0" class="badge badge-important">{{counters.message | largeNumber:0}}</span></h5>
-            <h5 ng-class="{ active: isActive('/archivedgroups/groups') }">
+            <h5 ng-if="supportsArchiveGroups" ng-class="{ active: isActive('/archivedgroups/groups') }">
                 <a href="#/archivedgroups">Archived message groups<span ng-show="counters.archived == 0"> (0)</span></a> <span ng-hide="counters.archived == 0" class="badge badge-important">
                     <span tooltip="There's varying numbers of archived message groups depending on group type">!</span>
                 </span>

--- a/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
+++ b/src/ServicePulse.Host/app/js/directives/ui.particular.failedMessageTabs.tpl.html
@@ -7,6 +7,11 @@
                 </span>
             </h5>
             <h5 ng-class="{ active: isActive('/failed-messages/all') }"><a ng-click="viewExceptionGroup()">All failed messages<span ng-show="counters.message == 0"> (0)</span></a> <span ng-show="counters.message > 0" class="badge badge-important">{{counters.message | largeNumber:0}}</span></h5>
+            <h5 ng-class="{ active: isActive('/archivedgroups/groups') }">
+                <a href="#/archivedgroups">Archived message groups<span ng-show="counters.archived == 0"> (0)</span></a> <span ng-hide="counters.archived == 0" class="badge badge-important">
+                    <span tooltip="There's varying numbers of archived message groups depending on group type">!</span>
+                </span>
+            </h5>
             <h5 ng-class="{ active: isActive('/failed-messages/archived') }"><a href="#/failed-messages/archived">Archived messages ({{counters.archived | largeNumber:0}})</a></h5>
             <h5 ng-show="{{showPendingRetry}}" ng-class="{ active: isActive('/failed-messages/pending-retries') }"><a href="#/failed-messages/pending-retries">Pending retries ({{counters.pendingRetries | largeNumber:0}})</a></h5>
         </div>

--- a/src/ServicePulse.Host/app/js/services/factory.shareddata.js
+++ b/src/ServicePulse.Host/app/js/services/factory.shareddata.js
@@ -38,10 +38,12 @@
             sp_version: spVersion
         };
 
-        serviceControlService.getVersion()
-        .then(function (scVersion) {
-            environment.sc_version = scVersion;
-            if (!semverService.isSupported(scVersion, environment.minimum_supported_sc_version)) {
+        serviceControlService.getServiceControlMetadata()
+        .then(function (metaData) {
+            environment.sc_version = metaData.version;
+            environment.supportsArchiveGroups = metaData.archivedGroupsUrl && metaData.archivedGroupsUrl.length > 0;
+
+            if (!semverService.isSupported(metaData.version, environment.minimum_supported_sc_version)) {
                 environment.is_compatible_with_sc = false;
             }
             notifier.notify('EnvironmentUpdated', environment);

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -5,10 +5,13 @@
 
         var scu = connectionsManager.getServiceControlUrl();
 
-        function getVersion() {
+        function getServiceControlMetadata() {
             var url = uri.join(scu);
             return $http.get(url).then(function(response) {
-                return response.headers('X-Particular-Version');
+                return {
+                    version: response.headers('X-Particular-Version'),
+                    archivedGroupsUrl: response.data.archived_groups_url
+                };
             });
         }
 
@@ -313,7 +316,7 @@
         }
 
         var service = {
-            getVersion: getVersion,
+            getServiceControlMetadata: getServiceControlMetadata,
             checkLicense: checkLicense,
             getConfiguration: getConfiguration,
             getEventLogItems: getEventLogItems,

--- a/src/ServicePulse.Host/app/js/views/archive/archive-view.html
+++ b/src/ServicePulse.Host/app/js/views/archive/archive-view.html
@@ -9,7 +9,20 @@
 
     <section name="failed_messages" ng-show="isSCConnected || scConnectedAtLeastOnce">
 
-        <failed-message-tabs></failed-message-tabs>
+        <div>
+            <failed-message-tabs></failed-message-tabs>
+        </div>
+
+        
+        <div class="row" ng-show="vm.selectedArchiveGroup.id && vm.archives.length > 0">
+            <div class="col-sm-12">
+                <div ng-show="!vm.selectedArchiveGroup.id" class="active">All archived messages ({{vm.archives.length}} / {{vm.selectedExceptionGroup.count}} | number)</div>
+                <h1 ng-show="vm.selectedArchiveGroup.id" class="active break group-title">
+                    {{vm.selectedArchiveGroup.title}}
+                </h1>
+                <h3 class="active group-title group-message-count">{{vm.total | number}} messages in group</h3>
+            </div>
+        </div>
 
         <div class="row" ng-show="!vm.loadingData">
             <div class="col-sm-12">

--- a/src/ServicePulse.Host/app/js/views/archive/controller.js
+++ b/src/ServicePulse.Host/app/js/views/archive/controller.js
@@ -255,7 +255,7 @@
 
         var loadGroupDetails = function() {
             if (vm.selectedArchiveGroup.initialLoad && vm.selectedArchiveGroup.id) {
-                    serviceControlService.getExceptionGroup(vm.selectedArchiveGroup.id).then(function (result) {
+                    archivedMessageService.getArchiveGroup(vm.selectedArchiveGroup.id).then(function (result) {
                         vm.selectedArchiveGroup.title = result.data.title;
                 });
             }

--- a/src/ServicePulse.Host/app/js/views/archive/controller.js
+++ b/src/ServicePulse.Host/app/js/views/archive/controller.js
@@ -1,12 +1,12 @@
 ﻿(function (window, angular) {
-    "use strict";
+    'use strict';
 
     function controller(
         $scope,
         $log,
         $timeout,
         moment,
-        $location,
+        $routeParams,
         $cookies,
         sharedDataService,
         notifyService,
@@ -24,6 +24,8 @@
 
         vm.stats = sharedDataService.getstats();
 
+        vm.selectedArchiveGroup = { 'id': $routeParams.groupId ? $routeParams.groupId : undefined, 'title': 'All Archived Messages', 'count': 0, 'initialLoad': true };
+
         vm.sort = {
             sortby: 'modified',
             direction: 'desc',
@@ -31,7 +33,7 @@
             start: undefined,
             end: undefined,
             buttonText: function () {
-                return (vm.sort.sortby === 'message_type' ? "Message Type" : "Time Archived") + " " + (vm.sort.direction === 'asc' ? "ASC" : "DESC");
+                return (vm.sort.sortby === 'message_type' ? 'Message Type' : 'Time Archived') + ' ' + (vm.sort.direction === 'asc' ? 'ASC' : 'DESC');
             }
         };
 
@@ -47,7 +49,7 @@
         vm.allMessagesLoaded = false;
         vm.loadingData = false;
         vm.archives = [{}];
-        vm.error_retention_period = moment.duration("10.00:00:00").asHours();
+        vm.error_retention_period = moment.duration('10.00:00:00').asHours();
         vm.allFailedMessagesGroup = { 'id': undefined, 'title': 'All Failed Messages', 'count': 0 };
         
         var processLoadedMessages = function (data) {
@@ -78,8 +80,8 @@
         };
 
         var getSelectedArchiveGroup = function () {
-            var amount = $cookies.get("archive_amount");
-            var unit = $cookies.get("archive_unit");
+            var amount = $cookies.get('archive_amount');
+            var unit = $cookies.get('archive_unit');
 
             return {
                 amount: amount,
@@ -99,6 +101,7 @@
 
             vm.selectTimeGroup(selectedArchiveGroup.amount, selectedArchiveGroup.unit);
             vm.allFailedMessagesGroup.count = vm.stats.number_of_failed_messages;
+            loadGroupDetails();
             vm.loadMoreResults();
         };
 
@@ -129,7 +132,7 @@
                 serviceControlService.getMessageBody(message.message_id).then(function (msg) {
                     message.messageBody = msg.data;
                 }, function () {
-                    message.bodyUnavailable = "message body unavailable";
+                    message.bodyUnavailable = 'message body unavailable';
                 });
             }
 
@@ -137,7 +140,7 @@
                 serviceControlService.getMessageHeaders(message.message_id).then(function (response) {
                     message.messageHeaders = response.headers;
                 }, function () {
-                    message.headersUnavailable = "message headers unavailable";
+                    message.headersUnavailable = 'message headers unavailable';
                 });
             }
             message.panel = panelnum;
@@ -250,6 +253,14 @@
             selectGroupInternal();
         };
 
+        var loadGroupDetails = function() {
+            if (vm.selectedArchiveGroup.initialLoad && vm.selectedArchiveGroup.id) {
+                    serviceControlService.getExceptionGroup(vm.selectedArchiveGroup.id).then(function (result) {
+                        vm.selectedArchiveGroup.title = result.data.title;
+                });
+            }
+        };
+
         vm.loadMoreResults = function () {
             vm.allMessagesLoaded = vm.archives.length >= vm.total;
 
@@ -260,6 +271,7 @@
             vm.loadingData = true;
 
             archivedMessageService.getArchivedMessages(
+                vm.selectedArchiveGroup.id,
                 vm.sort.sortby,
                 vm.sort.page,
                 vm.sort.direction,
@@ -276,20 +288,20 @@
     }
 
     controller.$inject = [
-        "$scope",
-        "$log",
-        "$timeout",
-        "moment",
-        "$location",
-        "$cookies",
-        "sharedDataService",
-        "notifyService",
-        "serviceControlService",
-        "failedMessageGroupsService",
-        "archivedMessageService"
+        '$scope',
+        '$log',
+        '$timeout',
+        'moment',
+        '$routeParams',
+        '$cookies',
+        'sharedDataService',
+        'notifyService',
+        'serviceControlService',
+        'failedMessageGroupsService',
+        'archivedMessageService'
     ];
 
-    angular.module("sc")
-        .controller("archivedMessageController", controller);
+    angular.module('sc')
+        .controller('archivedMessageController', controller);
 
 })(window, window.angular);

--- a/src/ServicePulse.Host/app/js/views/archive/service.js
+++ b/src/ServicePulse.Host/app/js/views/archive/service.js
@@ -31,13 +31,17 @@
 
         return {
 
-            getArchivedMessages: function (sort, page, direction, start, end) {
+            getArchivedMessages: function (groupId, sort, page, direction, start, end) {
                 var url = '';
-                if (start && end) {
-                    url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction + '&modified=' + start + '...' + end);
+                if (groupId) {
+                    url = uri.join(scu, 'recoverability', 'groups', groupId, 'errors?page=' + page + '&sort=' + sort + '&status=unresolved');
                 } else {
-                    url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction);
-                } 
+                    if (start && end) {
+                        url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction + '&modified=' + start + '...' + end);
+                    } else {
+                        url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction);
+                    }
+                }
 
                 return $http.get(url).then(function (response) {
                     return {
@@ -45,7 +49,6 @@
                         total: response.headers('Total-Count')
                     };
                 });
-
             },
 
             getArchivedCount: function () {

--- a/src/ServicePulse.Host/app/js/views/archive/service.js
+++ b/src/ServicePulse.Host/app/js/views/archive/service.js
@@ -29,12 +29,13 @@
             return defer.promise;
         }
 
-        return {
+        var previousArchiveGroupEtag;
 
+        return {
             getArchivedMessages: function (groupId, sort, page, direction, start, end) {
                 var url = '';
                 if (groupId) {
-                    url = uri.join(scu, 'recoverability', 'groups', groupId, 'errors?page=' + page + '&sort=' + sort + '&status=unresolved');
+                    url = uri.join(scu, 'recoverability', 'groups', groupId, 'errors?page=' + page + '&sort=' + sort + '&status=archived');
                 } else {
                     if (start && end) {
                         url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction + '&modified=' + start + '...' + end);
@@ -52,7 +53,6 @@
             },
 
             getArchivedCount: function () {
-
                 var url = uri.join(scu, 'errors?status=archived');
 
                 return $http.head(url).then(function (response) {
@@ -62,21 +62,34 @@
             },
 
             restoreFromArchive: function (startdate, enddate, success, error) {
-
                 var url = uri.join(scu, 'errors', startdate.format('YYYY-MM-DDTHH:mm:ss') + '...' + enddate.format('YYYY-MM-DDTHH:mm:ss'), 'unarchive');
                 return patchPromise(url, success, error);
             },
 
             restoreMessageFromArchive: function (id, success, error) {
-
                 var url = uri.join(scu, 'errors', 'unarchive');
                 return patchPromise(url, success, error, [id]);
             },
 
             restoreMessagesFromArchive: function (ids, success, error) {
-
                 var url = uri.join(scu, 'errors', 'unarchive');
                 return patchPromise(url, success, error, ids);
+            },
+
+            getArchiveGroup: function(groupId) {
+                var url = uri.join(scu, 'archive', 'groups', 'id', groupId);
+                return $http.get(url).then(function (response) {
+                    var status = 200;
+                    if (previousArchiveGroupEtag === response.headers('etag')) {
+                        status = 304;
+                    } else {
+                        previousArchiveGroupEtag = response.headers('etag');
+                    }
+                    return {
+                        data: response.data,
+                        status: status
+                    };
+                });
             }
         };
     }

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.controller.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.controller.js
@@ -25,13 +25,12 @@
         vm.selectedClassification = '';
         vm.stats = sharedDataService.getstats();
 
-        vm.viewExceptionGroup = function (group) {
-            sharedDataService.set(group);
-            $location.path('/failed-messages/groups/' + group.id);
-        };
-
         vm.unarchiveGroup = function (group) {
             debugger;
+        };
+
+        vm.viewArchiveGroup = function (group) {
+            $location.url('/failed-messages/archived?groupId=' + group.id);
         };
 
         var getClasses = function (stepStatus, currentStatus, statusArray) {
@@ -63,7 +62,6 @@
             vm.archiveGroups = [];
             return archivedMessageGroupsService.getArchivedGroups(vm.selectedClassification)
                 .then(function (response) {
-                    debugger;
                     if (response.status === 304 && vm.archiveGroups.length > 0) {
                         return true;
                     }
@@ -119,15 +117,15 @@
             archivedMessageGroupsService.getArchivedGroupClassifiers().then(function (classifiers) {
                 vm.availableClassifiers = classifiers;
                 vm.selectedClassification = getDefaultClassification(classifiers);
-            });
 
-            getArchivedGroups().then(function () {
-                vm.loadingData = false;
-                vm.initialLoadComplete = true;
-                
-                notifier.notify('InitialLoadComplete');
-
-                return true;
+                return getArchivedGroups().then(function () {
+                    vm.loadingData = false;
+                    vm.initialLoadComplete = true;
+                    
+                    notifier.notify('InitialLoadComplete');
+    
+                    return true;
+                });
             });
         };
 

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.controller.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.controller.js
@@ -1,0 +1,350 @@
+﻿(function (window, angular) {
+    'use strict';
+
+    function createWorkflowState(optionalStatus, optionalTotal, optionalFailed) {
+        if (optionalTotal && optionalTotal <= 1) {
+            optionalTotal = optionalTotal * 100;
+        }
+        return {
+            status: optionalStatus || 'working',
+            total: optionalTotal || 0,
+            failed: optionalFailed || false
+        };
+    }
+
+    function controller(
+        $scope,
+        $timeout,
+        $interval,
+        $location,
+        $cookies,
+        sharedDataService,
+        notifyService,
+        serviceControlService,
+        archivedMessageGroupsService,
+        toastService,
+        $routeParams) {
+
+        var vm = this;
+        var notifier = notifyService();
+
+        serviceControlService.performingDataLoadInitially = true;
+       
+        vm.loadingData = false;
+        vm.archiveGroups = [];
+        vm.availableClassifiers = [];
+        vm.selectedExceptionGroup = {};
+        vm.stats = sharedDataService.getstats();
+
+        vm.viewExceptionGroup = function (group) {
+            if (vm.isBeingArchived(group.operation_status) || vm.isBeingRetried(group)) {
+                return;
+            }
+            sharedDataService.set(group);
+            $location.path('/failed-messages/groups/' + group.id);
+        };
+
+        vm.unarchiveGroup = function (group) {
+            debugger;
+        };
+
+        var getClasses = function (stepStatus, currentStatus, statusArray) {
+            var indexOfStep = statusArray.indexOf(stepStatus);
+            var indexOfCurrent = statusArray.indexOf(currentStatus);
+            if (indexOfStep > indexOfCurrent) {
+                return 'left-to-do';
+            } else if (indexOfStep === indexOfCurrent) {
+                return 'active';
+            } else {
+                return 'completed';
+            }
+        };
+
+        var statusesForRetryOperation = ['waiting', 'preparing', 'queued', 'forwarding'];
+        vm.getClassesForRetryOperation = function(stepStatus, currentStatus) {
+            if (currentStatus === 'queued') {
+                currentStatus = 'forwarding';
+            }
+            return getClasses(stepStatus, currentStatus, statusesForRetryOperation);
+        };
+
+        var statusesForArchiveOperation = ['archivestarted', 'archiveprogressing', 'archivefinalizing', 'archivecompleted'];
+        vm.getClassesForArchiveOperation = function(stepStatus, currentStatus) {
+            return getClasses(stepStatus, currentStatus, statusesForArchiveOperation);
+        };
+
+        vm.isBeingRetried = function(group) {
+            return group.workflow_state.status !== 'none' && (group.workflow_state.status !== 'completed' || group.need_user_acknowledgement === true) && !vm.isBeingArchived(group.workflow_state.status);
+        };
+
+        vm.isBeingArchived = function (status) {
+            return status === 'archivestarted' || status === 'archiveprogressing' || status === 'archivefinalizing' || status === 'archivecompleted';
+        };
+
+        var initializeGroupState = function (group) {
+            var operationStatus = (group.operation_status ? group.operation_status.toLowerCase() : null) ||
+                'none';
+            if (operationStatus === 'preparing' && group.operation_progress === 1) {
+                operationStatus = 'queued';
+            }
+
+            group.workflow_state = createWorkflowState(operationStatus, group.operation_progress, group.operation_failed);
+
+            return group;
+        };
+
+        var getExceptionGroups = function () {
+            vm.archiveGroups = [];
+            return archivedMessageGroupsService.getArchivedGroups(vm.selectedClassification)
+                .then(function (response) {
+                    if (response.status === 304 && vm.exceptionGroups.length > 0) {
+                        return true;
+                    }
+
+                    if (response.data.length > 0) {
+
+                        // need a map in some ui state for controlling animations
+                        vm.exceptionGroups = response.data.map(initializeGroupState);
+
+                        if (vm.exceptionGroups.length !== vm.stats.number_of_exception_groups) {
+                            vm.stats.number_of_exception_groups = vm.exceptionGroups.length;
+                            notifier.notify('ExceptionGroupCountUpdated', vm.stats.number_of_exception_groups);
+                        }
+                    }
+                    return true;
+                });
+        };
+
+        var saveSelectedClassification = function(classification) {
+            $cookies.put('archived_groups_classification', classification);
+        };
+
+        var getDefaultClassification = function (classifiers) {
+            if ($routeParams.groupBy) {
+                saveSelectedClassification($routeParams.groupBy);
+                return $routeParams.groupBy;
+            }
+
+            var storedClassification = $cookies.get('archived_groups_classification');
+
+            if (typeof storedClassification === 'undefined') {
+                return classifiers[0];
+            }
+
+            return storedClassification;
+        };
+
+        vm.selectClassification = function (newClassification) {
+            vm.loadingData = true;
+            vm.selectedClassification = newClassification;
+
+            saveSelectedClassification(newClassification);
+
+            return autoGetExceptionGroups().then(function () {
+                vm.loadingData = false;
+
+                return true;
+            });
+        };
+
+        var initialLoad = function () {
+            vm.loadingData = true;
+
+            archivedMessageGroupsService.getArchivedGroupClassifiers().then(function (classifiers) {
+                vm.availableClassifiers = classifiers;
+                vm.selectedClassification = getDefaultClassification(classifiers);
+
+                autoGetExceptionGroups().then(function () {
+                    vm.loadingData = false;
+                    vm.initialLoadComplete = true;
+                    
+                    notifier.notify('InitialLoadComplete');
+
+                    return true;
+                });
+            });
+        };
+
+        vm.updateExceptionGroups = function() {
+            return serviceControlService.getExceptionGroups(vm.selectedClassification)
+                .then(function(response) {
+                    if (response.status === 304) {
+                        return true;
+                    }
+                    var exceptionGroupsToBeRemoved = vm.exceptionGroups.filter(function(item) {
+                        return !response.data.some(function(d) {
+                            return d.id === item.id;
+                        });
+                    });
+                    exceptionGroupsToBeRemoved.forEach(function(item) {
+                        vm.exceptionGroups.splice(vm.exceptionGroups.indexOf(item), 1);
+                    });
+
+                    vm.exceptionGroups.forEach(function(group) {
+                        var d = response.data.filter(function(item) {
+                            return item.id === group.id;
+                        })[0];
+
+                        for (var prop in d) {
+                            group[prop] = d[prop];
+                        }
+                        initializeGroupState(group);
+                    });
+
+                    response.data.filter(function(group) {
+                            return !vm.exceptionGroups.some(function(item) {
+                                return item.id === group.id;
+                            });
+                        })
+                        .forEach(function(group) {
+                            vm.exceptionGroups.push(group);
+                            initializeGroupState(group);
+                        });
+
+                    if (vm.exceptionGroups.length !== vm.stats.number_of_exception_groups) {
+                        vm.stats.number_of_exception_groups = vm.exceptionGroups.length;
+                        notifier.notify('ExceptionGroupCountUpdated', vm.stats.number_of_exception_groups);
+                    }
+
+                    return true;
+                });
+        };
+
+        var historicGroupsEtag;
+
+        var getHistoricGroups = function() {
+            serviceControlService.getHistoricGroups()
+                .then(function (response) {
+                    if (historicGroupsEtag === response.etag) {
+                        return true;
+                    }
+                    historicGroupsEtag = response.etag;
+                    vm.historicGroups = response.data.historic_operations;
+                });
+        };
+
+        var groupUpdatedInterval = $interval(function () {
+            getHistoricGroups();
+            vm.updateExceptionGroups();
+        }, 5000);
+
+        $scope.$on('$destroy', function () {
+            if (angular.isDefined(groupUpdatedInterval)) {
+                $interval.cancel(groupUpdatedInterval);
+                groupUpdatedInterval = undefined;
+            }
+        });
+
+        var archiveOperationEventHandler = function (data, status) {
+            var group = vm.exceptionGroups.filter(function (item) { return item.id === data.request_id });
+
+            group.forEach(function (item) {
+                item
+                    .workflow_state =
+                    createWorkflowState(status,
+                        data.progress.percentage);
+
+                item.operation_remaining_count = data.progress.messages_remaining;
+                item.operation_messages_completed_count = data.progress.number_of_messages_archived;
+                item.operation_start_time = data.start_time;
+
+                if (status === 'archivecompleted') {
+                    item.operation_completion_time = data.completion_time;
+                    item.need_user_acknowledgement = true;
+                }
+            });
+        };
+
+        var retryOperationEventHandler = function (data, status) {
+            var group = vm.exceptionGroups.filter(function (item) { return item.id === data.request_id });
+            
+            group.forEach(function (item) {
+                    if (status === 'preparing' && data.progress.percentage === 1) {
+                        status = 'queued';
+                    }
+                    item
+                        .workflow_state =
+                        createWorkflowState(status,
+                            data.progress.percentage,
+                            data.failed || false);
+
+                    item.operation_remaining_count = data.progress.messages_remaining;
+                    item.operation_start_time = data.start_time;
+
+                if (status === 'completed') {
+                    item.need_user_acknowledgement = true;
+                    item.operation_completion_time = data.completion_time;
+                }
+            });
+        };
+
+        notifier.subscribe($scope, function (event, data) {
+            archiveOperationEventHandler(data, 'archivestarted');
+        }, 'ArchiveOperationStarting');
+
+        notifier.subscribe($scope, function (event, data) {
+            archiveOperationEventHandler(data, 'archiveprogressing');
+        }, 'ArchiveOperationBatchCompleted');
+
+        notifier.subscribe($scope, function (event, data) {
+            archiveOperationEventHandler(data, 'archivefinalizing');
+        }, 'ArchiveOperationFinalizing');
+
+        notifier.subscribe($scope, function (event, data) {
+            archiveOperationEventHandler(data, 'archivecompleted');
+            getHistoricGroups();
+            
+            toastService.showInfo('Group ' + data.group_name + ' was archived succesfully.', 'Archive operation completed', true);
+            
+        }, 'ArchiveOperationCompleted');
+
+
+        notifier.subscribe($scope, function (event, data) {
+            retryOperationEventHandler(data, 'waiting');
+        }, 'RetryOperationWaiting');
+
+        notifier.subscribe($scope, function (event, data) {
+            retryOperationEventHandler(data, 'preparing');
+        }, 'RetryOperationPreparing');
+
+        notifier.subscribe($scope, function (event, data) {
+            retryOperationEventHandler(data, 'forwarding');
+        }, 'RetryOperationForwarding');
+        
+        notifier.subscribe($scope, function (event, data) {
+            retryOperationEventHandler(data, 'forwarding');
+        }, 'RetryOperationForwarded');
+
+        notifier.subscribe($scope, function (event, data) {
+            retryOperationEventHandler(data, 'completed');
+            getHistoricGroups();
+            if (data.failed) {
+                toastService.showInfo('Group ' + data.originator + ' was retried however and error have occured and not all messages were retried. Retry the remaining messages afterwards.', 'Retry operation completed', true);
+            } else {
+                toastService.showInfo('Group ' + data.originator + ' was retried succesfully.', 'Retry operation completed', true);
+            }
+        }, 'RetryOperationCompleted');
+
+        // INIT
+        initialLoad();
+        getHistoricGroups();
+    }
+
+    controller.$inject = [
+        '$scope',
+        '$timeout',
+        '$interval',
+        '$location',
+        '$cookies',
+        'sharedDataService',
+        'notifyService',
+        'serviceControlService',
+        'archivedMessageGroupsService',
+        'toastService',
+        '$routeParams'
+    ];
+
+    angular.module('sc')
+        .controller('archivedMessageGroupsController', controller);
+
+})(window, window.angular);

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.controller.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.controller.js
@@ -3,15 +3,12 @@
 
     function controller(
         $scope,
-        $timeout,
-        $interval,
         $location,
         $cookies,
         sharedDataService,
         notifyService,
         serviceControlService,
         archivedMessageGroupsService,
-        toastService,
         $routeParams) {
 
         var vm = this;
@@ -25,37 +22,8 @@
         vm.selectedClassification = '';
         vm.stats = sharedDataService.getstats();
 
-        vm.unarchiveGroup = function (group) {
-            debugger;
-        };
-
         vm.viewArchiveGroup = function (group) {
             $location.url('/failed-messages/archived?groupId=' + group.id);
-        };
-
-        var getClasses = function (stepStatus, currentStatus, statusArray) {
-            var indexOfStep = statusArray.indexOf(stepStatus);
-            var indexOfCurrent = statusArray.indexOf(currentStatus);
-            if (indexOfStep > indexOfCurrent) {
-                return 'left-to-do';
-            } else if (indexOfStep === indexOfCurrent) {
-                return 'active';
-            } else {
-                return 'completed';
-            }
-        };
-
-        var statusesForRetryOperation = ['waiting', 'preparing', 'queued', 'forwarding'];
-        vm.getClassesForRetryOperation = function(stepStatus, currentStatus) {
-            if (currentStatus === 'queued') {
-                currentStatus = 'forwarding';
-            }
-            return getClasses(stepStatus, currentStatus, statusesForRetryOperation);
-        };
-
-        var statusesForArchiveOperation = ['archivestarted', 'archiveprogressing', 'archivefinalizing', 'archivecompleted'];
-        vm.getClassesForArchiveOperation = function(stepStatus, currentStatus) {
-            return getClasses(stepStatus, currentStatus, statusesForArchiveOperation);
         };
 
         var getArchivedGroups = function () {
@@ -129,182 +97,17 @@
             });
         };
 
-        vm.updateExceptionGroups = function() {
-            return serviceControlService.getExceptionGroups(vm.selectedClassification)
-                .then(function(response) {
-                    if (response.status === 304) {
-                        return true;
-                    }
-                    var exceptionGroupsToBeRemoved = vm.exceptionGroups.filter(function(item) {
-                        return !response.data.some(function(d) {
-                            return d.id === item.id;
-                        });
-                    });
-                    exceptionGroupsToBeRemoved.forEach(function(item) {
-                        vm.exceptionGroups.splice(vm.exceptionGroups.indexOf(item), 1);
-                    });
-
-                    vm.exceptionGroups.forEach(function(group) {
-                        var d = response.data.filter(function(item) {
-                            return item.id === group.id;
-                        })[0];
-
-                        for (var prop in d) {
-                            group[prop] = d[prop];
-                        }
-                        initializeGroupState(group);
-                    });
-
-                    response.data.filter(function(group) {
-                            return !vm.exceptionGroups.some(function(item) {
-                                return item.id === group.id;
-                            });
-                        })
-                        .forEach(function(group) {
-                            vm.exceptionGroups.push(group);
-                            initializeGroupState(group);
-                        });
-
-                    if (vm.exceptionGroups.length !== vm.stats.number_of_exception_groups) {
-                        vm.stats.number_of_exception_groups = vm.exceptionGroups.length;
-                        notifier.notify('ExceptionGroupCountUpdated', vm.stats.number_of_exception_groups);
-                    }
-
-                    return true;
-                });
-        };
-
-        var historicGroupsEtag;
-
-        var getHistoricGroups = function() {
-            serviceControlService.getHistoricGroups()
-                .then(function (response) {
-                    if (historicGroupsEtag === response.etag) {
-                        return true;
-                    }
-                    historicGroupsEtag = response.etag;
-                    vm.historicGroups = response.data.historic_operations;
-                });
-        };
-
-        var groupUpdatedInterval = $interval(function () {
-            getHistoricGroups();
-            vm.updateExceptionGroups();
-        }, 5000);
-
-        $scope.$on('$destroy', function () {
-            if (angular.isDefined(groupUpdatedInterval)) {
-                $interval.cancel(groupUpdatedInterval);
-                groupUpdatedInterval = undefined;
-            }
-        });
-
-        var archiveOperationEventHandler = function (data, status) {
-            var group = vm.exceptionGroups.filter(function (item) { return item.id === data.request_id });
-
-            group.forEach(function (item) {
-                item
-                    .workflow_state =
-                    createWorkflowState(status,
-                        data.progress.percentage);
-
-                item.operation_remaining_count = data.progress.messages_remaining;
-                item.operation_messages_completed_count = data.progress.number_of_messages_archived;
-                item.operation_start_time = data.start_time;
-
-                if (status === 'archivecompleted') {
-                    item.operation_completion_time = data.completion_time;
-                    item.need_user_acknowledgement = true;
-                }
-            });
-        };
-
-        var retryOperationEventHandler = function (data, status) {
-            var group = vm.exceptionGroups.filter(function (item) { return item.id === data.request_id });
-            
-            group.forEach(function (item) {
-                    if (status === 'preparing' && data.progress.percentage === 1) {
-                        status = 'queued';
-                    }
-                    item
-                        .workflow_state =
-                        createWorkflowState(status,
-                            data.progress.percentage,
-                            data.failed || false);
-
-                    item.operation_remaining_count = data.progress.messages_remaining;
-                    item.operation_start_time = data.start_time;
-
-                if (status === 'completed') {
-                    item.need_user_acknowledgement = true;
-                    item.operation_completion_time = data.completion_time;
-                }
-            });
-        };
-
-        notifier.subscribe($scope, function (event, data) {
-            archiveOperationEventHandler(data, 'archivestarted');
-        }, 'ArchiveOperationStarting');
-
-        notifier.subscribe($scope, function (event, data) {
-            archiveOperationEventHandler(data, 'archiveprogressing');
-        }, 'ArchiveOperationBatchCompleted');
-
-        notifier.subscribe($scope, function (event, data) {
-            archiveOperationEventHandler(data, 'archivefinalizing');
-        }, 'ArchiveOperationFinalizing');
-
-        notifier.subscribe($scope, function (event, data) {
-            archiveOperationEventHandler(data, 'archivecompleted');
-            getHistoricGroups();
-            
-            toastService.showInfo('Group ' + data.group_name + ' was archived succesfully.', 'Archive operation completed', true);
-            
-        }, 'ArchiveOperationCompleted');
-
-
-        notifier.subscribe($scope, function (event, data) {
-            retryOperationEventHandler(data, 'waiting');
-        }, 'RetryOperationWaiting');
-
-        notifier.subscribe($scope, function (event, data) {
-            retryOperationEventHandler(data, 'preparing');
-        }, 'RetryOperationPreparing');
-
-        notifier.subscribe($scope, function (event, data) {
-            retryOperationEventHandler(data, 'forwarding');
-        }, 'RetryOperationForwarding');
-        
-        notifier.subscribe($scope, function (event, data) {
-            retryOperationEventHandler(data, 'forwarding');
-        }, 'RetryOperationForwarded');
-
-        notifier.subscribe($scope, function (event, data) {
-            retryOperationEventHandler(data, 'completed');
-            getHistoricGroups();
-            if (data.failed) {
-                toastService.showInfo('Group ' + data.originator + ' was retried however and error have occured and not all messages were retried. Retry the remaining messages afterwards.', 'Retry operation completed', true);
-            } else {
-                toastService.showInfo('Group ' + data.originator + ' was retried succesfully.', 'Retry operation completed', true);
-            }
-        }, 'RetryOperationCompleted');
-
-        // INIT
         initialLoad();
-        getHistoricGroups();
     }
 
     controller.$inject = [
         '$scope',
-        '$timeout',
-        '$interval',
         '$location',
         '$cookies',
         'sharedDataService',
         'notifyService',
         'serviceControlService',
         'archivedMessageGroupsService',
-        'toastService',
         '$routeParams'
     ];
 

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
@@ -66,13 +66,6 @@
                                                 </p>
                                             </div>
                                         </div>
-                                        <div class="row">
-                                            <div class="col-sm-12 no-side-padding">
-                                                <button type="button" class="btn btn-link btn-sm" confirm-click="vm.unarchiveGroup(group, $event)" ng-mouseenter="group.hover3 = true" ng-mouseleave="group.hover3 = false" confirm-title="Are you sure you want to archive this group?" confirm-message="Messages that are archived will be cleaned up according to the ServiceControl retention policy, and aren't available for retrying unless they're unarchived.">
-                                                    <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Unarchive Group
-                                                </button>
-                                            </div>
-                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
@@ -35,11 +35,10 @@
                 </div>
             </div>
 
-
             <div class="row">
                 <div class="col-sm-12">
                     <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
-                    <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
+                    <no-data ng-show="vm.archiveGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
                 </div>
             </div>
 
@@ -47,16 +46,16 @@
             <div class="row">
                 <div class="col-sm-12 no-mobile-side-padding">
 
-                    <div ng-show="vm.exceptionGroups.length > 0">
+                    <div ng-show="vm.archiveGroups.length > 0">
 
-                        <div class="row box box-group wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0" ng-mouseenter="group.hover2 = true" ng-mouseleave="group.hover2 = false">
+                        <div class="row box box-group wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.archiveGroups" ng-click="vm.viewArchiveGroup(group)" ng-disabled="group.count == 0" ng-mouseenter="group.hover2 = true" ng-mouseleave="group.hover2 = false">
                             <div class="col-sm-12 no-mobile-side-padding">
                                 <div class="row">
                                     <div class="col-sm-12 no-side-padding">
                                         <div class="row box-header">
                                             <div class="col-sm-12 no-side-padding">
                                                 <p class="lead break" ng-class="{'msg-type-hover': group.hover2, 'msg-type-hover-off': group.hover3}"> {{group.title}}</p>
-                                                <p class="metadata" ng-show="!vm.isBeingRetried(group) && !vm.isBeingArchived(group.workflow_state.status)">
+                                                <p class="metadata">
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.operation_remaining_count > 0">(currently retrying {{group.operation_remaining_count | number}})</span></span>
 
                                                     <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
@@ -67,106 +66,11 @@
                                                 </p>
                                             </div>
                                         </div>
-                                        <div class="row" ng-show="!vm.isBeingRetried(group) && !vm.isBeingArchived(group.workflow_state.status)">
+                                        <div class="row">
                                             <div class="col-sm-12 no-side-padding">
-                                                <button type="button" class="btn btn-link btn-sm" confirm-click="vm.unarchiveGroup(group, $event)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" ng-mouseenter="group.hover3 = true" ng-mouseleave="group.hover3 = false" confirm-title="Are you sure you want to archive this group?" confirm-message="Messages that are archived will be cleaned up according to the ServiceControl retention policy, and aren't available for retrying unless they're unarchived.">
+                                                <button type="button" class="btn btn-link btn-sm" confirm-click="vm.unarchiveGroup(group, $event)" ng-mouseenter="group.hover3 = true" ng-mouseleave="group.hover3 = false" confirm-title="Are you sure you want to archive this group?" confirm-message="Messages that are archived will be cleaned up according to the ServiceControl retention policy, and aren't available for retrying unless they're unarchived.">
                                                     <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Unarchive Group
                                                 </button>
-                                            </div>
-                                        </div>
-                                        <div class="row" ng-show="vm.isBeingRetried(group)">
-                                            <div class="col-sm-12 no-side-padding">
-                                                <div class="panel panel-default panel-retry">
-                                                    <div class="panel-body">
-                                                        <ul class="retry-request-progress">
-                                                            <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClassesForRetryOperation('waiting', group.workflow_state.status)">
-                                                                <div class="bulk-retry-progress-status">Initialize retry request...</div>
-                                                            </li>
-                                                            <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClassesForRetryOperation('preparing', group.workflow_state.status)">
-
-                                                                <div class="row">
-                                                                    <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
-                                                                        <div class="bulk-retry-progress-status">Prepare messages...</div>
-                                                                    </div>
-
-                                                                    <div class="col-xs-12 col-sm-6">
-                                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
-                                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" ng-style="{'min-width': '2em', 'width': group.workflow_state.total + '%'}">
-                                                                                {{group.workflow_state.total | number : 0}}%
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </li>
-                                                            <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClassesForRetryOperation('forwarding', group.workflow_state.status)">
-
-                                                                <div class="row">
-                                                                    <div class="col-xs-9 col-sm-4 col-md-3 no-side-padding">
-                                                                        <div class="bulk-retry-progress-status">Send messages to retry...</div>
-                                                                    </div>
-                                                                    <div class="col-xs-3 col-sm-3 retry-op-queued" ng-show="group.workflow_state.status === 'queued'">
-                                                                        (Queued)
-                                                                    </div>
-                                                                    <div class="col-xs-12 col-sm-6">
-
-                                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
-                                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" ng-style="{'min-width': '2em', 'width': group.workflow_state.total + '%'}">
-                                                                                {{group.workflow_state.total | number : 0}}%
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </li>
-                                                        </ul>
-
-                                                        <div class="op-metadata">
-                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.workflow_state.status === 'completed' ? 'Messages sent:' : 'Messages to send:'}} {{(group.operation_remaining_count || group.count) | number}}</span>
-                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.operation_start_time}}"></sp-moment></span>
-                                                            <span class="metadata" ng-show="group.workflow_state.status === 'completed'"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.operation_completion_time}}"></sp-moment></span>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="row" ng-show="vm.isBeingArchived(group.workflow_state.status)">
-                                            <div class="col-sm-12 no-side-padding">
-                                                <div class="panel panel-default panel-retry">
-                                                    <div class="panel-body">
-                                                        <ul class="retry-request-progress">
-                                                            <li ng-hide="group.workflow_state.status === 'archivecompleted'" ng-class="vm.getClassesForArchiveOperation('archivestarted', group.workflow_state.status)">
-                                                                <div class="bulk-retry-progress-status">Initialize archive request...</div>
-                                                            </li>
-                                                            <li ng-hide="group.workflow_state.status === 'archivecompleted'" ng-class="vm.getClassesForArchiveOperation('archiveprogressing', group.workflow_state.status)">
-                                                                <div class="row">
-                                                                    <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
-                                                                        <div class="bulk-retry-progress-status">Archive request in progress...</div>
-                                                                    </div>
-
-                                                                    <div class="col-xs-12 col-sm-6">
-                                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'archiveprogressing'">
-                                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" ng-style="{'min-width': '2em', 'width': group.workflow_state.total + '%'}">
-                                                                                {{group.workflow_state.total | number : 0}}%
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </li>
-                                                            <li ng-hide="group.workflow_state.status === 'archivecompleted'" ng-class="vm.getClassesForArchiveOperation('archivefinalizing', group.workflow_state.status)">
-                                                                <div class="row">
-                                                                    <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
-                                                                        <div class="bulk-retry-progress-status">Cleaning up...</div>
-                                                                    </div>
-                                                                </div>
-                                                            </li>
-                                                        </ul>
-
-                                                        <div class="op-metadata">
-                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Archive request started: <sp-moment date="{{group.operation_start_time}}"></sp-moment></span>
-                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to archive: {{(group.operation_remaining_count || 0) | number}}</span>
-                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages archived: {{(group.operation_messages_completed_count || 0) | number}}</span>
-                                                        </div>
-                                                    </div>
-                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
@@ -1,0 +1,182 @@
+﻿<platform-trial-expired ng-if="isPlatformTrialExpired"></platform-trial-expired>
+<platform-expired ng-if="isPlatformExpired"></platform-expired>
+<upgrade-protection-expired ng-if="isInvalidDueToUpgradeProtectionExpired"></upgrade-protection-expired>
+
+<div class="container" ng-if="!isPlatformTrialExpired && !isPlatformExpired && !isInvalidDueToUpgradeProtectionExpired">
+    <div class="sp-loader" ng-if="isSCConnecting"></div>
+    <div ng-include="'js/views/sc_not_available.html'" ng-show="!isSCConnected && !isSCConnecting && !scConnectedAtLeastOnce"></div>
+
+    <section ng-show="isSCConnected || scConnectedAtLeastOnce">
+        <reindexingstatus></reindexingstatus>
+
+        <section name="message_groups">
+
+            <failed-message-tabs></failed-message-tabs>
+
+            <div class="row">
+                <div class="col-xs-6 list-section">
+                    <h6>Archived message groups</h6>
+                </div>
+
+                <div class="col-xs-6 toolbar-menus no-side-padding">
+
+                    <div class="msg-group-menu dropdown">
+                        <label class="control-label">Group by:</label>
+                        <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            {{vm.selectedClassification}}
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li ng-repeat="classifier in vm.availableClassifiers">
+                                <a href="/#/archivedgroups/groups?groupBy={{classifier}}">{{classifier}}</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="row">
+                <div class="col-sm-12">
+                    <busy ng-show="vm.loadingData" message="fetching more messages"></busy>
+                    <no-data ng-show="vm.exceptionGroups.length === 0 && !vm.loadingData" title="message groups" message="There are currently no grouped message failures"></no-data>
+                </div>
+            </div>
+
+
+            <div class="row">
+                <div class="col-sm-12 no-mobile-side-padding">
+
+                    <div ng-show="vm.exceptionGroups.length > 0">
+
+                        <div class="row box box-group wf-{{group.workflow_state.status}} repeat-modify" ng-repeat="group in vm.exceptionGroups" ng-click="vm.viewExceptionGroup(group)" ng-disabled="group.count == 0" ng-mouseenter="group.hover2 = true" ng-mouseleave="group.hover2 = false">
+                            <div class="col-sm-12 no-mobile-side-padding">
+                                <div class="row">
+                                    <div class="col-sm-12 no-side-padding">
+                                        <div class="row box-header">
+                                            <div class="col-sm-12 no-side-padding">
+                                                <p class="lead break" ng-class="{'msg-type-hover': group.hover2, 'msg-type-hover-off': group.hover3}"> {{group.title}}</p>
+                                                <p class="metadata" ng-show="!vm.isBeingRetried(group) && !vm.isBeingArchived(group.workflow_state.status)">
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.count | number}} message<span ng-show="group.count >1">s</span><span ng-show="group.operation_remaining_count > 0">(currently retrying {{group.operation_remaining_count | number}})</span></span>
+
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> First failed: <sp-moment date="{{group.first}}"></sp-moment></span>
+
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Last failed: <sp-moment date="{{group.last}}"></sp-moment></span>
+
+                                                    <span class="metadata"><i aria-hidden="true" class="fa fa-repeat"></i> Last retried: <sp-moment empty-message="never" date="{{group.last_operation_completion_time}}"></sp-moment></span>
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <div class="row" ng-show="!vm.isBeingRetried(group) && !vm.isBeingArchived(group.workflow_state.status)">
+                                            <div class="col-sm-12 no-side-padding">
+                                                <button type="button" class="btn btn-link btn-sm" confirm-click="vm.unarchiveGroup(group, $event)" ng-disabled="group.count == 0 || vm.isBeingRetried(group)" ng-mouseenter="group.hover3 = true" ng-mouseleave="group.hover3 = false" confirm-title="Are you sure you want to archive this group?" confirm-message="Messages that are archived will be cleaned up according to the ServiceControl retention policy, and aren't available for retrying unless they're unarchived.">
+                                                    <i aria-hidden="true" class="fa fa-archive no-link-underline">&nbsp</i>Unarchive Group
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div class="row" ng-show="vm.isBeingRetried(group)">
+                                            <div class="col-sm-12 no-side-padding">
+                                                <div class="panel panel-default panel-retry">
+                                                    <div class="panel-body">
+                                                        <ul class="retry-request-progress">
+                                                            <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClassesForRetryOperation('waiting', group.workflow_state.status)">
+                                                                <div class="bulk-retry-progress-status">Initialize retry request...</div>
+                                                            </li>
+                                                            <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClassesForRetryOperation('preparing', group.workflow_state.status)">
+
+                                                                <div class="row">
+                                                                    <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
+                                                                        <div class="bulk-retry-progress-status">Prepare messages...</div>
+                                                                    </div>
+
+                                                                    <div class="col-xs-12 col-sm-6">
+                                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'preparing'">
+                                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" ng-style="{'min-width': '2em', 'width': group.workflow_state.total + '%'}">
+                                                                                {{group.workflow_state.total | number : 0}}%
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </li>
+                                                            <li ng-hide="group.workflow_state.status === 'completed'" ng-class="vm.getClassesForRetryOperation('forwarding', group.workflow_state.status)">
+
+                                                                <div class="row">
+                                                                    <div class="col-xs-9 col-sm-4 col-md-3 no-side-padding">
+                                                                        <div class="bulk-retry-progress-status">Send messages to retry...</div>
+                                                                    </div>
+                                                                    <div class="col-xs-3 col-sm-3 retry-op-queued" ng-show="group.workflow_state.status === 'queued'">
+                                                                        (Queued)
+                                                                    </div>
+                                                                    <div class="col-xs-12 col-sm-6">
+
+                                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'forwarding'">
+                                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" ng-style="{'min-width': '2em', 'width': group.workflow_state.total + '%'}">
+                                                                                {{group.workflow_state.total | number : 0}}%
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </li>
+                                                        </ul>
+
+                                                        <div class="op-metadata">
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> {{group.workflow_state.status === 'completed' ? 'Messages sent:' : 'Messages to send:'}} {{(group.operation_remaining_count || group.count) | number}}</span>
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request started: <sp-moment date="{{group.operation_start_time}}"></sp-moment></span>
+                                                            <span class="metadata" ng-show="group.workflow_state.status === 'completed'"><i aria-hidden="true" class="fa fa-clock-o"></i> Retry request completed: <sp-moment date="{{group.operation_completion_time}}"></sp-moment></span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="row" ng-show="vm.isBeingArchived(group.workflow_state.status)">
+                                            <div class="col-sm-12 no-side-padding">
+                                                <div class="panel panel-default panel-retry">
+                                                    <div class="panel-body">
+                                                        <ul class="retry-request-progress">
+                                                            <li ng-hide="group.workflow_state.status === 'archivecompleted'" ng-class="vm.getClassesForArchiveOperation('archivestarted', group.workflow_state.status)">
+                                                                <div class="bulk-retry-progress-status">Initialize archive request...</div>
+                                                            </li>
+                                                            <li ng-hide="group.workflow_state.status === 'archivecompleted'" ng-class="vm.getClassesForArchiveOperation('archiveprogressing', group.workflow_state.status)">
+                                                                <div class="row">
+                                                                    <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
+                                                                        <div class="bulk-retry-progress-status">Archive request in progress...</div>
+                                                                    </div>
+
+                                                                    <div class="col-xs-12 col-sm-6">
+                                                                        <div class="progress bulk-retry-progress" ng-show="group.workflow_state.status === 'archiveprogressing'">
+                                                                            <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="{{group.workflow_state.total}}" aria-valuemin="0" aria-valuemax="100" ng-style="{'min-width': '2em', 'width': group.workflow_state.total + '%'}">
+                                                                                {{group.workflow_state.total | number : 0}}%
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </li>
+                                                            <li ng-hide="group.workflow_state.status === 'archivecompleted'" ng-class="vm.getClassesForArchiveOperation('archivefinalizing', group.workflow_state.status)">
+                                                                <div class="row">
+                                                                    <div class="col-xs-12 col-sm-4 col-md-3 no-side-padding">
+                                                                        <div class="bulk-retry-progress-status">Cleaning up...</div>
+                                                                    </div>
+                                                                </div>
+                                                            </li>
+                                                        </ul>
+
+                                                        <div class="op-metadata">
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Archive request started: <sp-moment date="{{group.operation_start_time}}"></sp-moment></span>
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages left to archive: {{(group.operation_remaining_count || 0) | number}}</span>
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-envelope"></i> Messages archived: {{(group.operation_messages_completed_count || 0) | number}}</span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+    </section>
+</div>

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.route.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.route.js
@@ -1,0 +1,24 @@
+﻿(function (window, angular) {
+    'use strict';
+
+    function routeProvider($routeProvider) {
+        $routeProvider.when('/archivedgroups', {
+            redirectTo: '/archivedgroups/groups'
+        }).when('/archivedgroups/groups', {
+            data: {
+                pageTitle: 'Archived Message Groups'
+            },
+            templateUrl: 'js/views/archivedgroups/archivedgroups.html',
+            controller: 'archivedMessageGroupsController',
+            controllerAs: 'vm'
+        });
+    }
+
+    routeProvider.$inject = [
+        '$routeProvider'
+    ];
+
+    angular.module('sc')
+        .config(routeProvider);
+
+}(window, window.angular));

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
@@ -1,0 +1,107 @@
+﻿(function (window, angular) {
+    'use strict';
+
+    function service(
+            $http,
+            $log,
+            $timeout,
+            $q,
+            notifyService,
+            connectionsManager,
+            uri
+        ) {
+
+        var notifier = notifyService();
+        var scu = connectionsManager.getServiceControlUrl();
+
+        function patchPromise(url, success, error, ids) {
+
+            var defer = $q.defer();
+
+            success = success || 'success';
+            error = error || 'error';
+
+            $http.patch(url, ids)
+                .then(function (response) {
+                    defer.resolve(success + ':' + response);
+                }, function (response) {
+                    defer.reject(error + ':' + response);
+                });
+
+            return defer.promise;
+        }
+
+        return {
+            getArchivedGroupClassifiers: function() {
+                var url = uri.join(scu, 'recoverability', 'classifiers');
+                return $http.get(url).then(function (response) {
+                    return response.data;
+                });
+            },
+
+            getArchivedGroups: function(classifier) {
+
+            },
+
+            getArchivedMessages: function (sort, page, direction, start, end) {
+                var url = '';
+                if (start && end) {
+                    url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction + '&modified=' + start + '...' + end);
+                } else {
+                    url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction);
+                } 
+
+                return $http.get(url).then(function (response) {
+                    debugger;
+                    return {
+                        data: response.data,
+                        total: response.headers('Total-Count')
+                    };
+                });
+
+            },
+
+            getArchivedCount: function () {
+
+                var url = uri.join(scu, 'errors?status=archived');
+
+                return $http.head(url).then(function (response) {
+                   
+                    return response.headers('Total-Count');
+                });
+            },
+
+            restoreFromArchive: function (startdate, enddate, success, error) {
+
+                var url = uri.join(scu, 'errors', startdate.format('YYYY-MM-DDTHH:mm:ss') + '...' + enddate.format('YYYY-MM-DDTHH:mm:ss'), 'unarchive');
+                return patchPromise(url, success, error);
+            },
+
+            restoreMessageFromArchive: function (id, success, error) {
+
+                var url = uri.join(scu, 'errors', 'unarchive');
+                return patchPromise(url, success, error, [id]);
+            },
+
+            restoreMessagesFromArchive: function (ids, success, error) {
+
+                var url = uri.join(scu, 'errors', 'unarchive');
+                return patchPromise(url, success, error, ids);
+            }
+        };
+    }
+
+    service.$inject = [
+        '$http',
+        '$log',
+        '$timeout',
+        '$q',
+        'notifyService',
+        'connectionsManager',
+        'uri'
+    ];
+
+    angular.module('sc')
+        .service('archivedMessageGroupsService', service);
+
+})(window, window.angular);

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
@@ -31,6 +31,7 @@
             return defer.promise;
         }
 
+        var previousArchiveGroupEtag;
         return {
             getArchivedGroupClassifiers: function() {
                 var url = uri.join(scu, 'recoverability', 'classifiers');
@@ -40,7 +41,19 @@
             },
 
             getArchivedGroups: function(classifier) {
-
+                var url = uri.join(scu, 'errors', 'groups', classifier);
+                return $http.get(url).then(function (response) {
+                    var status = 200;
+                    if (previousArchiveGroupEtag === response.headers('etag')) {
+                        status = 304;
+                    } else {
+                        previousArchiveGroupEtag = response.headers('etag');
+                    }
+                    return {
+                        data: response.data,
+                        status: status
+                    };
+                });
             },
 
             getArchivedMessages: function (sort, page, direction, start, end) {

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
@@ -56,22 +56,24 @@
                 });
             },
 
-            getArchivedMessages: function (sort, page, direction, start, end) {
+            getArchivedMessages: function (groupId, sort, page, direction, start, end) {
                 var url = '';
-                if (start && end) {
-                    url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction + '&modified=' + start + '...' + end);
+                if (groupId) {
+                    url = uri.join(scu, 'recoverability', 'groups', groupId, 'errors?page=' + page + '&sort=' + sort + '&status=unresolved');
                 } else {
-                    url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction);
-                } 
+                    if (start && end) {
+                        url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction + '&modified=' + start + '...' + end);
+                    } else {
+                        url = uri.join(scu, 'errors?status=archived&page=' + page + '&sort=' + sort + '&direction=' + direction);
+                    }
+                }
 
                 return $http.get(url).then(function (response) {
-                    debugger;
                     return {
                         data: response.data,
                         total: response.headers('Total-Count')
                     };
                 });
-
             },
 
             getArchivedCount: function () {

--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.service.js
@@ -86,6 +86,10 @@
                 });
             },
 
+            unArchiveGroup: function (groupId) {
+                return $http.patch(uri.join(scu, 'errors', 'unarchive', 'group', groupId));
+            },
+
             restoreFromArchive: function (startdate, enddate, success, error) {
 
                 var url = uri.join(scu, 'errors', startdate.format('YYYY-MM-DDTHH:mm:ss') + '...' + enddate.format('YYYY-MM-DDTHH:mm:ss'), 'unarchive');

--- a/src/ServicePulse.Host/package-lock.json
+++ b/src/ServicePulse.Host/package-lock.json
@@ -3134,8 +3134,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3156,14 +3155,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3178,20 +3175,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3308,8 +3302,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3321,7 +3314,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3336,7 +3328,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3344,14 +3335,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3370,7 +3359,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3432,8 +3420,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3461,8 +3448,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3474,7 +3460,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3552,8 +3537,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3589,7 +3573,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3609,7 +3592,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3653,14 +3635,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
Fixes https://github.com/Particular/ServicePulse/issues/318
Fixes https://github.com/Particular/ServicePulse/issues/801

Requires: https://github.com/Particular/ServiceControl/pull/1987 for the functionality to be seen

Adds an Archive Groups screen.

The screen links to the archived messages screen for that group only.
If ServiceControl does not support Archived Groups, the behaviour is the same as it is now and the user does not notice a difference.

![image](https://user-images.githubusercontent.com/1060960/80601464-23aeac00-8a2e-11ea-98a4-d3bc15275b73.png)


