### PR TITLE
Add an endpoint disconnected count to the Monitoring navigation bar item

### DIFF
--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -51,7 +51,7 @@
                 if (routeData && routeData.redirectWhenNotConnected) {
                     $log.debug('not connected, and never connected once. Current route is a configuration route that requires redirect to: ', routeData.redirectWhenNotConnected);
                     event.preventDefault();
-                    $location.path(routeData.redirectWhenNotConnected); 
+                    $location.path(routeData.redirectWhenNotConnected);
                 }
             }
         });
@@ -68,7 +68,7 @@
         $scope.isPlatformExpired = licenseNotifierService.isPlatformExpired(license.license_status);
         $scope.isPlatformTrialExpired = licenseNotifierService.isPlatformTrialExpired(license.license_status);
         $scope.isInvalidDueToUpgradeProtectionExpired = licenseNotifierService.isInvalidDueToUpgradeProtectionExpired(license.license_status);
-          
+
         if ($scope.isPlatformExpired || $scope.isPlatformTrialExpired || $scope.isInvalidDueToUpgradeProtectionExpired) {
             $scope.licensewarning = "danger";
         }
@@ -81,7 +81,7 @@
             var active = $location.path().startsWith(viewLocation);
             return active;
         };
-       
+
         $($window.document).on('click', function (e) {
             if ($('.navbar-collapse.in').is(':visible')) {
                 $('.navbar-collapse.in').collapse('hide');
@@ -227,12 +227,12 @@
                 isSCConnecting: $scope.isSCConnecting,
                 scConnectedAtLeastOnce: $scope.scConnectedAtLeastOnce
             });
-       
+
         }, 'SignalREvent');
 
         notifier.subscribe($scope, function(event, data) {
             logit(event, data);
-            
+
             $scope.isSCConnected = false;
             $scope.isSCConnecting = false;
 
@@ -314,14 +314,14 @@
         listener.subscribe($scope, function (message) {
             notifier.notify('MessageFailureResolvedByRetry', message);
         }, 'MessageFailureResolvedByRetry');
-        
+
         listener.subscribe($scope, function (message) {
             logit(message);
-       
+
             notifier.notify('MessageFailuresUpdated', message.unresolved_total || message.total);
             notifier.notify('ArchivedMessagesUpdated', message.archived_total || 0);
 
-            
+
         }, 'MessageFailuresUpdated');
 
         listener.subscribe($scope, function(message) {
@@ -358,7 +358,7 @@
         listener.subscribe($scope, function (message) {
             notifier.notify('RetryOperationWaiting', message);
         }, 'RetryOperationWaiting');
-        
+
         listener.subscribe($scope, function (message) {
             notifier.notify('RetryOperationPreparing', message);
         }, 'RetryOperationPreparing');

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -98,7 +98,7 @@
         };
 
         function customChecksUpdated(event, data) {
-            $timeout(function() { //http://davidburgosonline.com/dev/2014/correctly-fix-angularjs-error-digest-already-in-progress/
+            $timeout(function() { //https://davidburgos.blog/correctly-fix-angularjs-error-digest-already-in-progress/
                 data = (data === 0 || data === '0') ? undefined : data;
                 $scope.failedcustomchecks = data;
                 logit(data);

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -23,7 +23,7 @@
         $route,
         configurationService,
         monitoringService,
-        disconnectedEndpointMonitor, //Keep this in so the monitor will run in the background
+        disconnectedEndpointMonitor,
     ) {
         var notifier = notifyService();
 
@@ -152,7 +152,10 @@
         notifier.subscribe($scope, customChecksUpdated, 'CustomChecksUpdated');
         notifier.subscribe($scope, messageFailuresUpdated, 'MessageFailuresUpdated');
         notifier.subscribe($scope, heartbeatsUpdated, 'HeartbeatsUpdated');
-        notifier.subscribe($scope, disconnectedEndpointsUpdated, 'DisconnectedEndpointsUpdated');
+
+        notifier.subscribe($scope, disconnectedEndpointsUpdated, disconnectedEndpointMonitor.updatedEvent);
+        disconnectedEndpointMonitor.startService();
+
         notifier.subscribe($scope, logit, 'ArchiveGroupRequestAccepted');
 
         notifier.subscribe($scope, function(event, data) {

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -120,6 +120,14 @@
             });
         }
 
+        function disconnectedEndpointsUpdated(event, data) {
+            $timeout(function () {
+                data = (data === 0 || data === '0') ? undefined : data;
+                $scope.disconnectedendpoints = data;
+                logit(data);
+            });
+        }
+
         function logit(event, data) {
             $log.debug(data);
         }
@@ -143,6 +151,7 @@
         notifier.subscribe($scope, customChecksUpdated, 'CustomChecksUpdated');
         notifier.subscribe($scope, messageFailuresUpdated, 'MessageFailuresUpdated');
         notifier.subscribe($scope, heartbeatsUpdated, 'HeartbeatsUpdated');
+        notifier.subscribe($scope, disconnectedEndpointsUpdated, 'DisconnectedEndpointsUpdated');
         notifier.subscribe($scope, logit, 'ArchiveGroupRequestAccepted');
 
         notifier.subscribe($scope, function(event, data) {

--- a/src/ServicePulse.Host/app/js/app.controller.js
+++ b/src/ServicePulse.Host/app/js/app.controller.js
@@ -22,7 +22,8 @@
         license,
         $route,
         configurationService,
-        monitoringService
+        monitoringService,
+        disconnectedEndpointMonitor, //Keep this in so the monitor will run in the background
     ) {
         var notifier = notifyService();
 
@@ -158,7 +159,7 @@
             $scope.SCVersion = data.sc_version;
             $scope.is_compatible_with_sc = data.is_compatible_with_sc;
             $rootScope.supportsArchiveGroups = data.supportsArchiveGroups;
-            
+
             if (!data.is_compatible_with_sc) {
                 var scNeedsUpgradeMessage = 'You are using Service Control version ' + data.sc_version + '. Please, upgrade to version ' + data.minimum_supported_sc_version + ' or higher to unlock new functionality in ServicePulse.';
                 toastService.showError(scNeedsUpgradeMessage);
@@ -399,7 +400,8 @@
         'license',
         '$route',
         'configurationService',
-        'monitoringService'
+        'monitoringService',
+        'disconnectedEndpointMonitor'
     ];
 
     angular.module('sc').controller('AppCtrl', controller);

--- a/src/ServicePulse.Host/app/js/app.js
+++ b/src/ServicePulse.Host/app/js/app.js
@@ -30,6 +30,7 @@
         'platformexpired',
         'configuration.license',
         'events.module',
+        'services.disconnectedEndpointMonitor',
     ]);
 
     angular.module('sc')

--- a/src/ServicePulse.Host/app/js/app.js
+++ b/src/ServicePulse.Host/app/js/app.js
@@ -34,7 +34,7 @@
 
     angular.module('sc')
         .run(['$rootScope', '$location', '$log', function ($rootScope, $location, $log) {
-            $rootScope.$log = $log; 
+            $rootScope.$log = $log;
         }]);
 
     angular.module('sc')

--- a/src/ServicePulse.Host/app/js/services/services.module.js
+++ b/src/ServicePulse.Host/app/js/services/services.module.js
@@ -12,7 +12,8 @@
         'services.exceptionHandler',
         'services.uri',
         'services.endpoints',
-        'services.messageTypeParser'
+        'services.messageTypeParser',
+        'services.disconnectedEndpointMonitor',
     ]);
 
 } (window, window.angular));

--- a/src/ServicePulse.Host/app/layout/navbar.html
+++ b/src/ServicePulse.Host/app/layout/navbar.html
@@ -26,6 +26,7 @@
                     <a href="#/monitoring">
                         <i class="fa fa-heartbeat icon-white"></i>
                         <span class="navbar-label">Monitoring</span>
+                        <span ng-show="disconnectedendpoints > 0" class="badge badge-important ">{{disconnectedendpoints | largeNumber:0}}</span>
                     </a>
                 </li>
                 <li ng-class="{ active: isActive('/failed-messages/groups') || isActive('/failed-messages/all') || isActive('/failed-messages/archived') || isActive('/failed-messages/pending-retries') }">

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
@@ -19,19 +19,22 @@
 
         var isConnected = false;
 
-        notifier.subscribe($rootScope, (event, data) => {
-            if (data.isMonitoringConnected && isConnected == false) {
-                checkDisconnectedCount();
-                checkInterval = setInterval(checkDisconnectedCount, 20000);
-                isConnected = true;
-            } else if (!data.isMonitoringConnected && isConnected) {
-                isConnected = false;
-                clearInterval(checkInterval);
-            }
-        }, "MonitoringConnectionStatusChanged")
+        var startService = function () {
+            notifier.subscribe($rootScope, (event, data) => {
+                if (data.isMonitoringConnected && isConnected == false) {
+                    checkDisconnectedCount();
+                    checkInterval = setInterval(checkDisconnectedCount, 20000);
+                    isConnected = true;
+                } else if (!data.isMonitoringConnected && isConnected) {
+                    isConnected = false;
+                    clearInterval(checkInterval);
+                }
+            }, "MonitoringConnectionStatusChanged");
+        };
 
         var service = {
-            eventPublished: disconnectedEndpointsUpdatedEvent
+            updatedEvent: disconnectedEndpointsUpdatedEvent,
+            startService: startService
         };
 
         return service;

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
@@ -1,0 +1,43 @@
+﻿(function (window, angular, $, Rx) {
+    'use strict';
+
+    function Service(notifyService, monitoringService, $log, $rootScope) {
+        var disconnectedEndpointsUpdatedEvent = "DisconnectedEndpointsUpdated";
+
+        var notifier = notifyService();
+
+        var checkDisconnectedCount = function ()
+        {
+            monitoringService.getDisconnectedCount().then(result => {
+                notifier.notify(disconnectedEndpointsUpdatedEvent, result.data);
+            }, e => {
+                $log.debug('Error while getting disconnected endpoints count from monitoring:' + e);
+            });
+        };
+
+        var checkInterval;
+        var isConnected = false;
+
+        notifier.subscribe($rootScope, (event, data) => {
+            if (data.isMonitoringConnected && isConnected == false) {
+                checkDisconnectedCount();
+                checkInterval = setInterval(checkDisconnectedCount, 20000);
+                isConnected = true;
+            } else if (!data.isMonitoringConnected && isConnected) {
+                isConnected = false;
+                clearInterval(checkInterval);
+            }
+        }, "MonitoringConnectionStatusChanged")
+
+        var service = {
+            EventPublished: disconnectedEndpointsUpdatedEvent
+        };
+
+        return service;
+    }
+
+    Service.$inject = ['notifyService', 'monitoringService', '$log', '$rootScope'];
+
+    angular.module('services.disconnectedEndpointMonitor', ['sc'])
+        .service('disconnectedEndpointMonitor', Service);
+}(window, window.angular, window.jQuery, window.Rx));

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
@@ -8,8 +8,7 @@
 
         var checkInterval;
 
-        var checkDisconnectedCount = function ()
-        {
+        var checkDisconnectedCount = function () {
             monitoringService.getDisconnectedCount().then(result => {
                 notifier.notify(disconnectedEndpointsUpdatedEvent, result.data);
             }, e => {
@@ -32,7 +31,7 @@
         }, "MonitoringConnectionStatusChanged")
 
         var service = {
-            EventPublished: disconnectedEndpointsUpdatedEvent
+            eventPublished: disconnectedEndpointsUpdatedEvent
         };
 
         return service;

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.disconnectedEndpointMonitor.js
@@ -6,16 +6,18 @@
 
         var notifier = notifyService();
 
+        var checkInterval;
+
         var checkDisconnectedCount = function ()
         {
             monitoringService.getDisconnectedCount().then(result => {
                 notifier.notify(disconnectedEndpointsUpdatedEvent, result.data);
             }, e => {
                 $log.debug('Error while getting disconnected endpoints count from monitoring:' + e);
+                clearInterval(checkInterval); //Stop checking, probably an old version of Monitoring
             });
         };
 
-        var checkInterval;
         var isConnected = false;
 
         notifier.subscribe($rootScope, (event, data) => {

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -80,13 +80,18 @@
             });
         }
 
+       function getDisconnectedCount() {
+            return $http.get(uri.join(mu, 'monitored-endpoints', 'disconnected'));
+        }
+
         var service = {
             createEndpointsSource,
             createEndpointDetailsSource,
             getMonitoredEndpoints,
             getServiceControlMonitoringVersion,
             removeEndpointInstance,
-            isRemovingEndpointEnabled
+            isRemovingEndpointEnabled,
+            getDisconnectedCount: getDisconnectedCount
         };
 
         return service;

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.monitoring.js
@@ -91,7 +91,7 @@
             getServiceControlMonitoringVersion,
             removeEndpointInstance,
             isRemovingEndpointEnabled,
-            getDisconnectedCount: getDisconnectedCount
+            getDisconnectedCount
         };
 
         return service;

--- a/src/ServicePulse.Host/app/modules/monitoring/monitoring.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/monitoring.js
@@ -1,2 +1,3 @@
 ﻿require('./js/monitored_endpoints.module');
 require('./js/endpoint_details.module');
+require('./js/services/services.disconnectedEndpointMonitor');


### PR DESCRIPTION
This PR adds support for periodically checking the disconnected endpoint count as reported by Monitoring and displaying a badge on the `Monitoring` top navigation menu item.

![image](https://user-images.githubusercontent.com/2546913/88341227-11bd6c00-ccf2-11ea-8621-0e041094e8da.png)