### PR TITLE
CustomChecks view - infinite scroll and initial load race condition fix

### DIFF
--- a/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.controller.js
+++ b/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.controller.js
@@ -10,6 +10,7 @@
         $scope.model = { data: [], total: 0 };
         $scope.loadingData = false;
         $scope.disableLoadingData = false;
+        $scope.reloadCount = 0;
 
         var page = 1;
 
@@ -19,7 +20,7 @@
             }
 
             $scope.loadingData = true;
-            load(page++);
+            load(page++, $scope.reloadCount);
         };
 
         $scope.dismiss = function (row) {
@@ -34,11 +35,18 @@
             $scope.loadingData = true;
             $scope.model = { data: [], total: 0 };
             $scope.disableLoadingData = false;
-            load(page);
+            $scope.reloadCount++;
+
+            load(page, $scope.reloadCount);
         }
 
-        function load(page) {
+        function load(page, reloadCount) {
             serviceControlService.getFailingCustomChecks(page).then(function (response) {
+
+                //If the load was called before last result reload it should be discarded
+                if (reloadCount < $scope.reloadCount) {
+                    return;
+                }
 
                 $scope.loadingData = false;
 


### PR DESCRIPTION
Connected to https://github.com/Particular/ServiceControl/issues/2086

### Problem

```javascript
var page = 1;

$scope.loadMoreResults = function () {
    if ($scope.loadingData) {
        return;
    }

    $scope.loadingData = true;
    load(page++);
};

$scope.dismiss = function (row) {
    serviceControlService.dismissCustomChecks(row);
};

var notifier = notifyService();
notifier.subscribe($scope, reloadData, 'CustomChecksUpdated');

function reloadData() {
    page = 1;
    $scope.loadingData = true;
    $scope.model = { data: [], total: 0 };
    $scope.disableLoadingData = false;
    load(page);
}
```

It is possible for `loadMoreResults` to be triggered by the UI (by the infinite scroll) just before the `reloadData` is called via the notification service. In such a case, there are 2 outstanding requests that will both update the list of custom checks. If that happens during the initial page load the first page will be duplicated. If it happens further in the lifecycle of the page the view will end up showing the data from the first page and some further page (depending on how far a user scrolled and how much data was available).

### Solution

This PR introduces `reloadCount` that is incremented before each reload request. The `load` function will apply the data returned from the backend only if the `reloadCount` did not change between the request was made and the response was returned.