### PR TITLE
Open docs link in new browser tab

### DIFF
--- a/src/ServicePulse.Host/app/modules/monitoring/views/monitoring_no_data.html
+++ b/src/ServicePulse.Host/app/modules/monitoring/views/monitoring_no_data.html
@@ -8,6 +8,6 @@
         <li>Endpoints sending data to incorrect queue or monitoring server listening.</li>
     </ul>
     <div class="action-toolbar">
-        <a class="btn btn-default btn-primary" href="https://docs.particular.net/monitoring/metrics/">Learn how to enable endpoint monitoring</a>
+        <a class="btn btn-default btn-primary" href="https://docs.particular.net/monitoring/metrics/" target="_blank">Learn how to enable endpoint monitoring</a>
     </div>
 </div>


### PR DESCRIPTION
Opens the link of the button on this page on a dedicated browser tab instead of leaving the SP app

![image](https://user-images.githubusercontent.com/3524870/94683585-0f494500-0327-11eb-899a-71847d6411eb.png)
