### PR TITLE
Provide shortened type names on message hierarchies

### DIFF
--- a/src/ServicePulse.Host.Tests/tests/js/services/services.messageTypeParser.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/services/services.messageTypeParser.spec.js
@@ -70,6 +70,16 @@ describe('messageTypeParser', function () {
         expect(sut.assemblyName).toEqual('Shared');
     });
 
+    it('should parse messageTypes as well as shortNames without an unknown result', function() {
+        var sut = {};
+        Object.assign(sut, twoTypeMessageType);
+
+        messageTypeParser.parseTheMessageTypeData(sut);
+
+        expect(sut.typeName).toEqual('Some.Very.Long.Shared.Namespace.Is.Found.Here.EventMessage, IMyEvent');
+        expect(sut.shortName).toEqual('EventMessage, IMyEvent');
+    });
+
     it('should parse message type if there is more than one class in', function () {
         var sut = {};
         Object.assign(sut, twoTypeMessageType);

--- a/src/ServicePulse.Host/app/modules/monitoring/js/services/services.messageTypeParser.js
+++ b/src/ServicePulse.Host/app/modules/monitoring/js/services/services.messageTypeParser.js
@@ -24,14 +24,15 @@
                 });
                 messageType.messageTypeHierarchy = messageTypeHierarchy;
                 messageType.typeName =
-                    messageTypeHierarchy.reduce((sum, item) => (sum ? `${sum}, ` : '') + item.typeName, '');
+                    messageTypeHierarchy.map(item => item.typeName).join(", ");
+                messageType.shortName = messageTypeHierarchy.map(item => shortenTypeName(item.typeName)).join(", ");
                 messageType.containsTypeHierarchy = true;
                 messageType.tooltipText = messageTypeHierarchy.reduce((sum, item) => (sum ? `${sum}<br> ` : '') +
                     `${item.typeName} |${item.assemblyName}-${item.assemblyVersion}` + (item.culture ? ` |${item.culture}` : '') + (item.publicKeyToken ? ` |${item.publicKeyToken}` : ''),
                     '');
             } else {
                 //Get the name without the namespace
-                messageType.shortName = messageType.typeName.split('.').pop();
+                messageType.shortName = shortenTypeName(messageType.typeName);
 
                 var tooltip = `${messageType.typeName} | ${messageType.assemblyName}-${messageType.assemblyVersion}`;
                 if (messageType.culture && messageType.culture != 'null') {
@@ -44,6 +45,10 @@
 
                 messageType.tooltipText = tooltip;
             }
+        }
+
+        function shortenTypeName(typeName) {
+            return typeName.split('.').pop();
         }
     
         var service = {


### PR DESCRIPTION
fixes #970 

"unknown" is shown as messages with a hierarchy don't have a `shortName` property at the moment. Instead of checking for the shortName to exist and fallback to the typeName, it seems more appropriate to also shorten type names on hierarchies too. Replaced the more complex fold with a map/join combination.