### PR TITLE
Show ServiceControlUrl in error message when unable to connect

### DIFF
--- a/src/ServicePulse.Host/app/js/views/sc_not_available.html
+++ b/src/ServicePulse.Host/app/js/views/sc_not_available.html
@@ -1,7 +1,7 @@
 ﻿<div class="text-center monitoring-no-data">
     <h1>Cannot connect to ServiceControl</h1>
     <p>
-        ServicePulse is unable to connect to the ServiceControl instance <span id="serviceControlUrl">{{serviceControlUrl}}</span>. Please ensure that ServiceControl is running and accessible from your machine.
+        ServicePulse is unable to connect to the ServiceControl instance at <span id="serviceControlUrl">{{serviceControlUrl}}</span>. Please ensure that ServiceControl is running and accessible from your machine.
     </p>
     <div class="action-toolbar">
         <a href="#/configuration/connections" class="btn btn-default btn-primary">View Connection Details</a> <a class="btn btn-default btn-secondary" href="https://docs.particular.net/monitoring/metrics/">Learn more</a>

--- a/src/ServicePulse.Host/app/js/views/sc_not_available.html
+++ b/src/ServicePulse.Host/app/js/views/sc_not_available.html
@@ -1,7 +1,7 @@
 ﻿<div class="text-center monitoring-no-data">
     <h1>Cannot connect to ServiceControl</h1>
     <p>
-        ServicePulse is unable to connect to the ServiceControl instance<span id="serviceControlUrl">put here the url we tried to connect to</span>. Please ensure that ServiceControl is running and accessible from your machine.
+        ServicePulse is unable to connect to the ServiceControl instance <span id="serviceControlUrl">{{serviceControlUrl}}</span>. Please ensure that ServiceControl is running and accessible from your machine.
     </p>
     <div class="action-toolbar">
         <a href="#/configuration/connections" class="btn btn-default btn-primary">View Connection Details</a> <a class="btn btn-default btn-secondary" href="https://docs.particular.net/monitoring/metrics/">Learn more</a>


### PR DESCRIPTION
Currently, the string "put here the url we tried to connect to" is displayed as part of the error message that is shown when unable to connect to ServiceControl. This change shows the actual ServiceControlUrl