### PR TITLE
replace absolute paths with relative

### DIFF
--- a/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
+++ b/src/ServicePulse.Host/app/js/views/archivedgroups/archivedgroups.html
@@ -28,7 +28,7 @@
                         </button>
                         <ul class="dropdown-menu">
                             <li ng-repeat="classifier in vm.availableClassifiers">
-                                <a href="/#/archivedgroups/groups?groupBy={{classifier}}">{{classifier}}</a>
+                                <a href="#/archivedgroups/groups?groupBy={{classifier}}">{{classifier}}</a>
                             </li>
                         </ul>
                     </div>

--- a/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
+++ b/src/ServicePulse.Host/app/js/views/failed_groups/failed-groups-view.html
@@ -65,7 +65,7 @@
                         </button>
                         <ul class="dropdown-menu">
                             <li ng-repeat="classifier in vm.availableClassifiers">
-                                <a href="/#/failed-messages/groups?groupBy={{classifier}}">{{classifier}}</a>
+                                <a href="#/failed-messages/groups?groupBy={{classifier}}">{{classifier}}</a>
                             </li>
                         </ul>
                     </div>
@@ -77,8 +77,8 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu">
-                            <li ng-repeat-start="sort in vm.sortSelectors"><a href="/#/failed-messages/groups?sortBy={{sort.description}}">{{sort.description}}</a></li>
-                            <li ng-repeat-end><a href="/#/failed-messages/groups?sortBy={{sort.description}}&sortdir=desc">{{sort.description}} <span>(Descending)</span></a></li>
+                            <li ng-repeat-start="sort in vm.sortSelectors"><a href="#/failed-messages/groups?sortBy={{sort.description}}">{{sort.description}}</a></li>
+                            <li ng-repeat-end><a href="#/failed-messages/groups?sortBy={{sort.description}}&sortdir=desc">{{sort.description}} <span>(Descending)</span></a></li>
                         </ul>
                     </div>
                 </div>

--- a/src/ServicePulse.Host/app/modules/shell/views/events-view.html
+++ b/src/ServicePulse.Host/app/modules/shell/views/events-view.html
@@ -55,10 +55,10 @@
                         <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu">
-                        <li><a href="/#/events?pageSize=20">20</a></li>
-                        <li><a href="/#/events?pageSize=35">35</a></li>
-                        <li><a href="/#/events?pageSize=50">50</a></li>
-                        <li><a href="/#/events?pageSize=75">75</a></li>
+                        <li><a href="#/events?pageSize=20">20</a></li>
+                        <li><a href="#/events?pageSize=35">35</a></li>
+                        <li><a href="#/events?pageSize=50">50</a></li>
+                        <li><a href="#/events?pageSize=75">75</a></li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
There are absolute path references in links that stop the UI from working if hosted in IIS at a non-root location.
