### PR TITLE
Fix text alignment of Dismiss button

### DIFF
--- a/src/ServicePulse.Host/app/css/particular.css
+++ b/src/ServicePulse.Host/app/css/particular.css
@@ -1433,6 +1433,7 @@ span.metadata.danger, i.fa.fa-trash-o.danger, sp-moment.danger {
     width: 74px;
     top: -2px;
     left: 11px;
+    line-height: 1;
 }
 
 .table-header p {


### PR DESCRIPTION
The text is not properly aligned. Here's what it looks like in Chrome before the change:

<img width="846" alt="Screen Shot 2021-01-23 at 10 17 00 am" src="https://user-images.githubusercontent.com/132117/105559037-3b6c5400-5d64-11eb-8584-986cb5c6e0d6.png">
