### PR TITLE
Remove a duplicated fetching of message headers

### DIFF
--- a/src/ServicePulse.Host/app/js/views/message/controller.js
+++ b/src/ServicePulse.Host/app/js/views/message/controller.js
@@ -171,13 +171,6 @@
                 message.retried = message.status === 'retryIssued';
                 updateMessageDeleteDate(message, vm.error_retention_period);
                 vm.message = message;
-
-                serviceControlService.getMessage(vm.message.message_id).then(function (response) {
-                    vm.message.headers = response.message.headers;
-                    vm.message.bodyUrl = response.message.body_url;
-                }, function () {
-                    vm.message.headersUnavailable = 'message headers unavailable';
-                });
             },
                 function (response) {
                     if (response.status === 404) {


### PR DESCRIPTION
From version 1.28 SP is fetching the message body from the Audit instance. If the amount of Audits is big it slows down ServicePulse by doing an expensive calls. This PR is reverting the change.

With this change the message body will once again be pulled from ServiceControl instance