### PR TITLE
Strip comments from message body payloads

### DIFF
--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -146,7 +146,7 @@
                 method: 'GET',
                 transformResponse: function(defaults, transform) {
                     // Remove any comments from the body before deserializing
-                    return defaults.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => g ? "" : m);
+                    return defaults.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, function (m, g) { return g ? "" : m });
                 }
               });
         }

--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -141,11 +141,14 @@
                 url = uri.join(scu, message.bodyUrl);
             }
 
-            return $http.get(url).then(function(response) {
-                return {
-                    data: response.data
-                };
-            });
+            return $http({
+                url: url,
+                method: 'GET',
+                transformResponse: function(defaults, transform) {
+                    // Remove any comments from the body before deserializing
+                    return defaults.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => g ? "" : m);
+                }
+              });
         }
 
         function getMessage(messageId) {


### PR DESCRIPTION
Fixes #1184

Removes comments of the style:

`// comment`
`/* comment */`

from the body of messages that are received from ServiceControl so that they can be rendered correctly.

This will also remove comments from XML messages as they are sent to SP as JSON anyway and will be subject to the same problems.

I don't know that this is testable given the reliance on angularjs as the `$http` wrapper.