### PR TITLE
Fix JSON payloads not being prettyfied

### DIFF
--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -146,7 +146,7 @@
                 method: 'GET',
                 transformResponse: function(defaults, transform) {
                     // Remove any comments from the body before deserializing
-                    return defaults.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, function (m, g) { return g ? "" : m });
+                    return JSON.parse(defaults.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, function (m, g) { return g ? "" : m }));
                 }
               });
         }


### PR DESCRIPTION
Fixes https://github.com/Particular/ServicePulse/issues/1194

[Removing the comments from JSON](https://github.com/Particular/ServicePulse/pull/1185) returned by ServiceControl resulted in the result no longer being an object but being text. This PR re-parses the content from the server.

**Before:**

![image](https://user-images.githubusercontent.com/1060960/168783636-73761c5b-1ece-4bf6-815f-a6a0ad0a9d28.png)

**After:**

![image](https://user-images.githubusercontent.com/1060960/168783453-26ff5cb5-c0f7-4436-98bb-ac30818fd271.png)

_Note that this is parsing data directly from a server. It shouldn't be any more dangerous that what the underlying $http API does_