### PR TITLE
Make sure the built URI contains the endpoint name

### DIFF
--- a/src/ServicePulse.Host/app/js/views/message/controller.js
+++ b/src/ServicePulse.Host/app/js/views/message/controller.js
@@ -183,6 +183,7 @@
 
         vm.debugInServiceInsight = function () {
             var messageId = vm.message.message_id;
+            var endpointName = vm.message.receiving_endpoint.name;
             var dnsName = connectionsManager.getServiceControlUrl().toLowerCase();
 
             if (dnsName.indexOf("https") === 0) {
@@ -191,7 +192,7 @@
                 dnsName = dnsName.replace("http://", "");
             }
 
-            $window.open("si://" + dnsName + "?search=" + messageId);
+            $window.open("si://" + dnsName + "?search=" + messageId + "&endpointname=" + endpointName);
         };
 
         vm.loadMessage = function (messageId) {


### PR DESCRIPTION
This fixes a bug in the ServiceInsight command line search functionalities. If The command line doesn't contain an endpoint name, SI selects the ServiceControl node that causes the search to fail and instead all messages are displayed.