### PR TITLE
Chunk display of metadata for custom checks

### DIFF
--- a/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
+++ b/src/ServicePulse.Host/app/js/views/custom_checks/customChecks.html
@@ -29,11 +29,18 @@
                                     <div class="col-xs-10">
                                         <div class="row box-header">
                                             <div class="col-sm-12 no-side-padding">
-                                                <p class="lead pre-wrap">{{item.failure_reason}}</p>
-                                                <p>{{item.custom_check_id}} </p>
-                                                <p>
-                                                    {{item.category}} reported by {{item.originating_endpoint.name}} on {{item.originating_endpoint.host}} <sp-moment date="{{item.reported_at}}"></sp-moment>
-                                                </p>
+                                                <p class="lead pre-wrap">{{item.failure_reason}}</p>                                                
+                                                <div class="row">
+                                                    <div class="col-sm-12 no-side-padding">
+                                                        <p class="metadata">
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-check"></i> Check: {{item.custom_check_id}}</span>
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-list"></i> Category: {{item.category}}</span>
+                                                            <span class="metadata"><i aria-hidden="true" class="fa pa-endpoint"></i> Endpoint: {{item.originating_endpoint.name}}</span>
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-server"></i> Host: {{item.originating_endpoint.host}}</span>
+                                                            <span class="metadata"><i aria-hidden="true" class="fa fa-clock-o"></i> Last checked: <sp-moment date="{{item.reported_at}}"></sp-moment></span>
+                                                        </p>
+                                                    </div>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Fixes #1169 and #1170

<img width="840" alt="image" src="https://user-images.githubusercontent.com/493451/176404132-02aebadf-59b8-41d4-a368-1ce7762612a5.png">
