### PR TITLE
Fix property names

### DIFF
--- a/src/ServicePulse.Host/app/modules/configuration/views/notificationsemailmodal.html
+++ b/src/ServicePulse.Host/app/modules/configuration/views/notificationsemailmodal.html
@@ -21,13 +21,13 @@
             <div class="form-group">
                 <label for="account">Authentication account</label>
                 <input type="text" id="account" name="account"
-                    ng-model="settings.authentication_account" class="form-control" />
+                    ng-model="settings.authorization_account" class="form-control" />
             </div>
             <div class="row"></div>
             <div class="form-group">
                 <label for="account">Authentication password</label>
                 <input type="password" id="password" name="password"
-                    ng-model="settings.authentication_password" class="form-control" />
+                    ng-model="settings.authorization_password" class="form-control" />
             </div>
             <div class="row"></div>
             <div class="form-group">


### PR DESCRIPTION
A customer raised a support ticket stating that account username and password are not saved when configuring email notifications. I can reproduce the issue locally on my machine.
Digging a bit into the entire thing it turns out that the ServiceControl [UpdateEmailNotificationsSettingsRequest](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControl/Notifications/Api/UpdateEmailNotificationsSettingsRequest.cs) expects those value to be in properties named `authorization_account` and `authorization_password`. ServicePulse was binding to `authentication_account` and `authentication_password` causing (if I get it right) the two values to not be stored in ServiceControl.