### PR TITLE
Replace description content

### DIFF
--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -14,7 +14,7 @@
     <page-title-from-route></page-title-from-route>
 
     <meta charset="utf-8">
-    <meta name="description" content="An Operations Manager’s Best Friend">
+    <meta name="description" content="ServicePulse Monitoring">
     <meta name="author" content="Particular Software">
     <meta name="viewport" content="width=1440, initial-scale=1">
 


### PR DESCRIPTION
Change ServicePulse pages' description from "An Operations Manager’s Best Friend" to "ServicePulse Monitoring", which is more useful when sharing links in places that show a page's content description instead of title.