### PR TITLE
Sparkline avg labels won't load css styles bug fix

### DIFF
--- a/src/ServicePulse.Host/app/index.html
+++ b/src/ServicePulse.Host/app/index.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" href="modules/dist/vendor.css">
 
     <!-- Particular Styles -->
-    <link rel="stylesheet" href="css/particular.css">
+    <link rel="stylesheet" href="css/particular.css?v=1660114036307">
     <!--[if lt IE 9 ]>
         <script type="text/javascript">
             window.location = 'NoIE.html';
@@ -144,7 +144,7 @@
     <script src="js/app.constants.js?v=1621602441174"></script>
 
     <script src="modules/dist/shell.dist.js?v=1621602441174"></script>
-    <script src="modules/dist/monitoring.dist.js?v=1621602441174"></script>
+    <script src="modules/dist/monitoring.dist.js?v=1660114036307"></script>
     <script src="modules/dist/configuration.dist.js?v=1621602441174"></script>
 
     <script src="lib/page-width-functions.js?v=1621602441174"></script>


### PR DESCRIPTION
Fixes #1267 1267