### PR TITLE
Timespan sparkline values are incorrectly formatted when displaying minute timespans in "hour" unit values  bug fix

### DIFF
--- a/src/ServicePulse.Host.Tests/tests/js/services/service.formatter.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/services/service.formatter.spec.js
@@ -7,23 +7,26 @@
         formatter = _formatter_;
     }));
 
-    it('should apply hour format to timespans between 60 seconds (1 minute) and 23 hours and 59 seconds ', () => {  
+    it('should apply hour format to timespans between 60 seconds (1 minute) and 23 hours and 59 minutes ', () => {  
         const nineteenHoursAndFortyMinutesInMs = 70800000;
         const twentyFourMinutesInMs = 24 * 60 * 1000;
         const twoMinutesInMs = 2 * 60 * 1000;
-        const twentyThreeHoursFiftyNineMinutesAndTenSeconds = (((23 * 60 * 60) + (59 * 60) + 10)  * 1000) + 10;
+        const twentyThreeHoursFiftyNineMinutesTenSecondsAnd10MsInMs = (((23 * 60 * 60) + (59 * 60) + 10)  * 1000) + 10;
          
         expect(formatter.formatTime(nineteenHoursAndFortyMinutesInMs)).toEqual({value: '19:40', unit: 'hr'});
         expect(formatter.formatTime(twentyFourMinutesInMs)).toEqual({value: '00:24', unit: 'hr'});
         expect(formatter.formatTime(twoMinutesInMs)).toEqual({value: '00:02', unit: 'hr'});
-        expect(formatter.formatTime(twentyThreeHoursFiftyNineMinutesAndTenSeconds)).toEqual({value: '23:59', unit: 'hr'});
+        expect(formatter.formatTime(twentyThreeHoursFiftyNineMinutesTenSecondsAnd10MsInMs)).toEqual({value: '23:59', unit: 'hr'});
     });  
 
     it('should apply day and hours format to day timespans', () => {  
         const oneDayAndTwelveMinutes = (24 * 60 * 60 + 12 * 60) * 1000;
         const oneDayAndTwelveHours = (24 * 60 * 60 + 12 * 60 * 60) * 1000;
-        expect(formatter.formatTime(oneDayAndTwelveMinutes)).toEqual({value: '1 d 0 hr', unit: ''});
-        expect(formatter.formatTime(oneDayAndTwelveHours)).toEqual({value: '1 d 12 hr', unit: ''});
+
+        var result = formatter.formatTime(oneDayAndTwelveMinutes); 
+        expect(result.value).toMatch(/1 d 0 hr.*/)
+        result = formatter.formatTime(oneDayAndTwelveHours);
+        expect(result.value).toMatch(/1 d 12 hr.*/)
     });
     
     it('should format seconds timespans with seconds format', () => {  

--- a/src/ServicePulse.Host.Tests/tests/js/services/service.formatter.spec.js
+++ b/src/ServicePulse.Host.Tests/tests/js/services/service.formatter.spec.js
@@ -7,7 +7,29 @@
         formatter = _formatter_;
     }));
 
-    it('should format time value with hour format', () => {        
-        expect(formatter.formatTime(70825325).value).toEqual('19:40');        
-    });   
+    it('should apply hour format to timespans between 60 seconds (1 minute) and 23 hours and 59 seconds ', () => {  
+        const nineteenHoursAndFortyMinutesInMs = 70800000;
+        const twentyFourMinutesInMs = 24 * 60 * 1000;
+        const twoMinutesInMs = 2 * 60 * 1000;
+        const twentyThreeHoursFiftyNineMinutesAndTenSeconds = (((23 * 60 * 60) + (59 * 60) + 10)  * 1000) + 10;
+         
+        expect(formatter.formatTime(nineteenHoursAndFortyMinutesInMs)).toEqual({value: '19:40', unit: 'hr'});
+        expect(formatter.formatTime(twentyFourMinutesInMs)).toEqual({value: '00:24', unit: 'hr'});
+        expect(formatter.formatTime(twoMinutesInMs)).toEqual({value: '00:02', unit: 'hr'});
+        expect(formatter.formatTime(twentyThreeHoursFiftyNineMinutesAndTenSeconds)).toEqual({value: '23:59', unit: 'hr'});
+    });  
+
+    it('should apply day and hours format to day timespans', () => {  
+        const oneDayAndTwelveMinutes = (24 * 60 * 60 + 12 * 60) * 1000;
+        const oneDayAndTwelveHours = (24 * 60 * 60 + 12 * 60 * 60) * 1000;
+        expect(formatter.formatTime(oneDayAndTwelveMinutes)).toEqual({value: '1 d 0 hr', unit: ''});
+        expect(formatter.formatTime(oneDayAndTwelveHours)).toEqual({value: '1 d 12 hr', unit: ''});
+    });
+    
+    it('should format seconds timespans with seconds format', () => {  
+        
+        const fiftyNineSecondsInMs =  59 * 1000 + 1;
+        
+        expect(formatter.formatTime(fiftyNineSecondsInMs)).toEqual({value: '59', unit: 'sec'});     
+    }); 
 });

--- a/src/ServicePulse.Host/app/js/services/service.formatter.js
+++ b/src/ServicePulse.Host/app/js/services/service.formatter.js
@@ -15,7 +15,7 @@
                 time.value = duration.format('D [d] h [hr]');
                 return time;
             } else if (duration >= hourDuration) {
-                time.value = duration.format('HH:mm');
+                time.value = moment.utc(duration.asMilliseconds()).format('HH:mm');
                 time.unit = 'hr';
                 return time;
             } else if (duration >= minuteDuration) {


### PR DESCRIPTION
Fixes bug #1271 