### PR TITLE
Replacing text/json to application/json

### DIFF
--- a/src/ServicePulse.Host/app/js/services/services.service-control.js
+++ b/src/ServicePulse.Host/app/js/services/services.service-control.js
@@ -146,7 +146,7 @@
                 method: 'GET',
                 transformResponse: function(defaults, transform) {
                     // Remove any comments from the body before deserializing
-                    return transform()['content-type'] === 'text/json' ? JSON.parse(defaults.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, function (m, g) { return g ? "" : m })) : defaults;
+                    return transform()['content-type'] === 'application/json' ? JSON.parse(defaults.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, function (m, g) { return g ? "" : m })) : defaults;
                 }
               });
         }


### PR DESCRIPTION
In the last release we added an if, to only prettify json messages when they are in fact json. But we made a mistake by using text/json instead of application/json

Fixes #1272