### PR TITLE
Only refresh page if first connection attempt

### DIFF
--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControl.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControl.js
@@ -345,8 +345,11 @@ function fetchWithErrorHandling(fetchFunction, connectionState, action) {
       });
   }
   try {
-    connectionState.connecting = true;
-    connectionState.connected = false;
+    if (!connectionState.connected) {
+      connectionState.connecting = true;
+      connectionState.connected = false;
+    }
+
     return fetchFunction()
       .then((response) => action(response))
       .then((response) => {


### PR DESCRIPTION
Checks if connected is already true. If it is true, it means it has successfully connected previously and we don't need to show the loading icon.

Once a connection drops, the connected field is set to false so the next attempt will show the loading icon again.