### PR TITLE
Refresh the failed group data every 5 seconds

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
@@ -28,10 +28,9 @@ const selectedGroup = ref({
 const noteSaveSuccessful = ref(null);
 const groupDeleteSuccessful = ref(null);
 const groupRetrySuccessful = ref(null);
+let refreshInterval = null;
 
 function getExceptionGroups() {
-  exceptionGroups.value = [];
-
   return useGetExceptionGroups().then((result) => {
     exceptionGroups.value = result;
     if (result.length > 0) {
@@ -221,6 +220,10 @@ function isBeingRetried(group) {
 
 onMounted(() => {
   initialLoad();
+
+  refreshInterval = setInterval(() => {
+    initialLoad();
+  }, 5000);
 });
 </script>
 

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
@@ -28,7 +28,6 @@ const selectedGroup = ref({
 const noteSaveSuccessful = ref(null);
 const groupDeleteSuccessful = ref(null);
 const groupRetrySuccessful = ref(null);
-let refreshInterval = null;
 
 function getExceptionGroups() {
   return useGetExceptionGroups().then((result) => {
@@ -221,7 +220,7 @@ function isBeingRetried(group) {
 onMounted(() => {
   initialLoad();
 
-  refreshInterval = setInterval(() => {
+  setInterval(() => {
     initialLoad();
   }, 5000);
 });


### PR DESCRIPTION
Refreshes the failed group data every 5 seconds.

We might want to consider decreasing that duration to every 1 second when we detect that a retry is ongoing so that the progress bar responds sooner, but we can improve that as a second step.