### PR TITLE
Adds forward slash to the connection strings if they are missing

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
@@ -52,7 +52,7 @@ function testMonitoringUrl(event) {
 
 function saveConnections(event) {
   if (event) {
-    updateServiceControlUrls(serviceControlUrl.value, monitoringUrl.value);
+    updateServiceControlUrls(serviceControlUrl, monitoringUrl);
     connectionSaved.value = true;
   }
 }

--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
@@ -92,7 +92,7 @@ export function updateServiceControlUrls(newServiceControlUrl, newMonitoringUrl)
   if (newServiceControlUrl.value.match(regex) === null){
     newServiceControlUrl.value += "/";
   }
-  if (newMonitoringUrl.value.match(regex) === null){
+  if (newMonitoringUrl.value.match(regex) === null && newMonitoringUrl.value !== '!'){
     newMonitoringUrl.value += "/";
   }
 

--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
@@ -80,17 +80,15 @@ export function useServiceControlUrls() {
 }
 
 export function updateServiceControlUrls(newServiceControlUrl, newMonitoringUrl) {
-  const regex = /\/$/gm;  // checks for a trailing forward slash
-
   if (!newServiceControlUrl.value) {
     throw "ServiceControl URL is mandatory";
-  } else if (newServiceControlUrl.value.match(regex) === null) {
+  } else if (!newServiceControlUrl.value.endsWith('/')) {
     newServiceControlUrl.value += "/";
   }
 
   if (!newMonitoringUrl.value) {
     newMonitoringUrl.value = "!"; //disabled
-  } else if (newMonitoringUrl.value.match(regex) === null){
+  } else if (!newMonitoringUrl.value.endsWith('/')){
     newMonitoringUrl.value += "/";
   }
 

--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
@@ -80,19 +80,27 @@ export function useServiceControlUrls() {
 }
 
 export function updateServiceControlUrls(newServiceControlUrl, newMonitoringUrl) {
-  if (!newServiceControlUrl) {
+  if (!newServiceControlUrl.value) {
     throw "ServiceControl URL is mandatory";
   }
 
-  if (!newMonitoringUrl) {
-    newMonitoringUrl = "!"; //disabled
+  if (!newMonitoringUrl.value) {
+    newMonitoringUrl.value = "!"; //disabled
+  }
+
+  const regex = /\/$/gm;
+  if (newServiceControlUrl.value.match(regex) === null){
+    newServiceControlUrl.value += "/";
+  }
+  if (newMonitoringUrl.value.match(regex) === null){
+    newMonitoringUrl.value += "/";
   }
 
   //values have changed. They'll be reset after page reloads
   window.localStorage.removeItem("scu");
   window.localStorage.removeItem("mu");
 
-  let newSearch = "?scu=" + newServiceControlUrl + "&mu=" + newMonitoringUrl;
+  let newSearch = "?scu=" + newServiceControlUrl.value + "&mu=" + newMonitoringUrl.value;
   console.debug("updateConnections - new query string: ", newSearch);
   window.location.search = newSearch;
 }

--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.js
@@ -80,19 +80,17 @@ export function useServiceControlUrls() {
 }
 
 export function updateServiceControlUrls(newServiceControlUrl, newMonitoringUrl) {
+  const regex = /\/$/gm;  // checks for a trailing forward slash
+
   if (!newServiceControlUrl.value) {
     throw "ServiceControl URL is mandatory";
+  } else if (newServiceControlUrl.value.match(regex) === null) {
+    newServiceControlUrl.value += "/";
   }
 
   if (!newMonitoringUrl.value) {
     newMonitoringUrl.value = "!"; //disabled
-  }
-
-  const regex = /\/$/gm;
-  if (newServiceControlUrl.value.match(regex) === null){
-    newServiceControlUrl.value += "/";
-  }
-  if (newMonitoringUrl.value.match(regex) === null && newMonitoringUrl.value !== '!'){
+  } else if (newMonitoringUrl.value.match(regex) === null){
     newMonitoringUrl.value += "/";
   }
 


### PR DESCRIPTION
This is related to a support case that was raised about getting a 404 error on the connection and dashboard screens if a trailing `/` is not at the end of the connection strings in the configuration page.

Here is the issue [[2.0] ServicePulse unable to connect to ServiceControl if connection URL lacks a trailing forward slash](https://github.com/Particular/KeepTheLightsOn/issues/1188)