### PR TITLE
Fix links in dashboard

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
@@ -106,7 +106,7 @@ function navigateToEvent(eventLogItem) {
 
       <div class="row text-center">
         <div class="col-12">
-          <a v-if="eventCount > 10" class="btn btn-default btn-secondary btn-all-events" href="/events">View all events</a>
+          <a v-if="eventCount > 10" class="btn btn-default btn-secondary btn-all-events" href="/a/#/events">View all events</a>
         </div>
       </div>
     </div>

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
@@ -85,10 +85,10 @@ function deleteNote(group) {
   showDeleteNoteModal.value = true;
 }
 
-function saveDeleteNote(groupId) {
+function saveDeleteNote(group) {
   showDeleteNoteModal.value = false;
 
-  useDeleteNote(groupId).then((result) => {
+    useDeleteNote(group.groupid).then((result) => {
     if (result.message === "success") {
       noteSaveSuccessful.value = true;
       useShowToast("info", "Info", "Note deleted succesfully");
@@ -474,7 +474,7 @@ defineExpose({
       @cancel="showDeleteNoteModal = false"
       @confirm="
         showDeleteNoteModal = false;
-        saveDeleteNote();
+        saveDeleteNote(selectedGroup);
       "
       :heading="'Are you sure you want to delete this note?'"
       :body="`Deleted note will not be available.`"

--- a/src/ServicePulse.Host/vue/src/views/DashboardView.vue
+++ b/src/ServicePulse.Host/vue/src/views/DashboardView.vue
@@ -30,7 +30,7 @@ import { licenseStatus } from "./../composables/serviceLicense.js";
                     <DashboardItem :counter="stats.number_of_failed_heartbeats" :url="'/a/#/endpoints'" :iconClass="'fa-heartbeat'">Heartbeats</DashboardItem>
                   </div>
                   <div class="col-4">
-                    <DashboardItem :counter="stats.number_of_failed_messages" :url="'/a/#/failed-messages/groups'" :iconClass="'fa-envelope'">Failed Messages</DashboardItem>
+                    <DashboardItem :counter="stats.number_of_failed_messages" :url="'/failed-messages'" :iconClass="'fa-envelope'">Failed Messages</DashboardItem>
                   </div>
                   <div class="col-4">
                     <DashboardItem :counter="stats.number_of_failed_checks" :url="'/a/#/custom-checks'" :iconClass="'fa-check'">Custom Checks</DashboardItem>


### PR DESCRIPTION
Fix the following links
- Link to angular version of "view all events " from dashboard
- Link to vue version of "Failed messages" from dashboard
- Delete comment note on failed messages group vue