### PR TITLE
Enter node in the correct place already

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/FlowDiagram.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/FlowDiagram.vue
@@ -104,7 +104,18 @@ function drawTree(treeData) {
       svg.attr("transform", event.transform);
     });
 
-  svg.append("defs").append("marker").attr("id", "end-arrow").attr("viewBox", "0 -5 10 10").attr("refX", 0).attr("refY", 0).attr("markerWidth", 6).attr("markerHeight", 6).attr("orient", "auto").attr("class", "arrow").append("path").attr("d", "M10,-5L0,0L10,5");
+  svg.append("defs")
+    .append("marker")
+    .attr("id", "end-arrow")
+    .attr("viewBox", "0 -5 10 10")
+    .attr("refX", 0)
+    .attr("refY", 0)
+    .attr("markerWidth", 6)
+    .attr("markerHeight", 6)
+    .attr("orient", "auto")
+    .attr("class", "arrow")
+    .append("path")
+    .attr("d", "M10,-5L0,0L10,5");
 
   // declares a tree layout and assigns the size
   treemap = tree().nodeSize([rectNode.width + 20, rectNode.height]);
@@ -143,9 +154,6 @@ function update(source) {
     .append("g")
     .attr("class", (d) => {
       return "node " + d.data.type.toLowerCase() + " " + (d.data.isError ? "error" : "") + " " + (d.data.id === props.messageId ? "current-message" : "");
-    })
-    .attr("transform", () => {
-      return "translate(" + source.x0 + "," + source.y0 + ")";
     })
     .on("click", click);
 


### PR DESCRIPTION
Takes away the fly in thing, it seems this was intentional but it doesn't actually work in the angular version