### PR TITLE
Use replaceAll instead of replace

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
@@ -50,7 +50,7 @@ function sortGroups(sort) {
 }
 
 function loadMessages() {
-  loadPagedMessages(groupId.value, pageNumber.value, sortMethod.description.replace(" ", "_").toLowerCase(), sortMethod.dir);
+  loadPagedMessages(groupId.value, pageNumber.value, sortMethod.description.replaceAll(" ", "_").toLowerCase(), sortMethod.dir);
 }
 
 function loadPagedMessages(groupId, page, sortBy, direction) {

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/PendingRetries.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/PendingRetries.vue
@@ -86,7 +86,7 @@ function loadPendingRetryMessages() {
       break;
   }
 
-  return loadPagedPendingRetryMessages(pageNumber.value, sortMethod.description.replace(" ", "_").toLowerCase(), sortMethod.dir, selectedQueue.value, startDate.toISOString(), endDate.toISOString());
+  return loadPagedPendingRetryMessages(pageNumber.value, sortMethod.description.replaceAll(" ", "_").toLowerCase(), sortMethod.dir, selectedQueue.value, startDate.toISOString(), endDate.toISOString());
 }
 
 function loadPagedPendingRetryMessages(page, sortBy, direction, searchPhrase, startDate, endDate) {


### PR DESCRIPTION
`.replace()` only replaces the first instance, not all 🤦 