### PR TITLE
Fix badge spacing and disable checkbox on message action

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/AllDeletedMessages.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/AllDeletedMessages.vue
@@ -165,6 +165,7 @@ function restoreSelectedMessages() {
   const selectedMessages = messageList.value.getSelectedMessages();
   selectedMessages.forEach((m) => m.restoreInProgress = true);
 
+    selectedMessages.forEach((m) => (m.restoreInProgress = true));
   useShowToast("info", "Info", "restoring " + selectedMessages.length + " messages...");
 
   usePatchToServiceControl(
@@ -237,7 +238,7 @@ onMounted(() => {
   if (typeof cookiePeriod === "undefined" || cookiePeriod === "") {
     cookiePeriod = periodOptions[3]; //default is last 7 days
   }
-  selectedPeriod.value = cookiePeriod;
+   selectedPeriod.value = cookiePeriod;
   loadMessages();
 
   changeRefreshInterval(5000);

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageList.vue
@@ -85,7 +85,7 @@ defineExpose({
   </div>
   <div v-for="(message, index) in props.messages" class="row box repeat-item failed-message" :key="message.id">
     <label class="check col-1" :for="`checkbox${message.id}`" @click="labelClicked($event, index)">
-      <input type="checkbox" :disabled="message.retryInProgress || message.submittedForRetrial || message.deleteInProgress" class="checkbox" v-model="message.selected" :value="message.id" :id="`checkbox${message.id}`" />
+      <input type="checkbox" :disabled="message.retryInProgress || message.submittedForRetrial || message.deleteInProgress|| message.restoreInProgress" class="checkbox" v-model="message.selected" :value="message.id" :id="`checkbox${message.id}`" />
     </label>
     <div class="col-11 failed-message-data">
       <div class="row">
@@ -94,28 +94,30 @@ defineExpose({
             <div class="col-12 no-side-padding" @click="navigateToMessage($event, message.id)">
               <p class="lead break">{{ message.message_type || "Message Type Unknown - missing metadata EnclosedMessageTypes" }}</p>
               <p class="metadata">
-                <span v-if="message.submittedForRetrial" tooltip="Message was submitted for retrying" class="label sidebar-label label-info metadata-label">To retry</span>
-                <span v-if="message.retryInProgress" tooltip="Message is being retried" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-arrow-clockwise"></i> Retry in progress</span>
-                <span v-if="message.retried" tooltip="Message is being retried" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-arrow-clockwise"></i> Retried</span>
-                <span v-if="message.resolved" class="label sidebar-label label-info metadata-label">Resolved</span>
+                  <span v-if="message.submittedForRetrial" tooltip="Message was submitted for retrying" class="label sidebar-label label-info metadata-label">To retry</span>
+                  <span v-if="message.retryInProgress" tooltip="Message is being retried" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-arrow-clockwise"></i> Retry in progress</span>
+                  <span v-if="message.retried" tooltip="Message is being retried" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-arrow-clockwise"></i> Retried</span>
+                  <span v-if="message.resolved" class="label sidebar-label label-info metadata-label">Resolved</span>
 
-                <span v-if="message.deleteInProgress" tooltip="Message is being deleted" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-trash"></i> Scheduled for deletion</span>
+                  <span v-if="message.restoreInProgress" tooltip="Message is being restored" class="label sidebar-label label-info metadata-label metadata in-progress"> Restore in progress</span>
+
+                  <span v-if="message.deleteInProgress" tooltip="Message is being deleted" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-trash"></i> Scheduled for deletion</span>
                 <span v-if="message.restoreInProgress" tooltip="Message is being restored" class="label sidebar-label label-warning metadata-label metadata in-progress"><i class="bi-recycle"></i> Restore in progress</span>
-                <span v-if="message.archived" tooltip="Message is being deleted" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-trash"></i> Deleted</span>
-                <span v-if="message.number_of_processing_attempts > 1" tooltip="This message has already failed {{message.number_of_processing_attempts}} times" class="label sidebar-label label-important metadata-label">{{ message.number_of_processing_attempts === 10 ? "9+" : message.number_of_processing_attempts }} Retry Failures</span>
+                  <span v-if="message.archived" tooltip="Message is being deleted" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-trash"></i> Deleted</span>
+                  <span v-if="message.number_of_processing_attempts > 1" tooltip="This message has already failed {{message.number_of_processing_attempts}} times" class="label sidebar-label label-important metadata-label">{{ message.number_of_processing_attempts === 10 ? "9+" : message.number_of_processing_attempts }} Retry Failures</span>
 
-                <span v-if="message.edited" tooltip="Message was edited" class="label sidebar-label label-info metadata-label">Edited</span>
+                  <span v-if="message.edited" tooltip="Message was edited" class="label sidebar-label label-info metadata-label">Edited</span>
 
-                <span class="metadata"><i class="fa fa-clock-o"></i> Failed: <time-since :dateUtc="message.time_of_failure"></time-since></span>
-                <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{ message.receiving_endpoint.name }}</span>
-                <span class="metadata"><i class="fa fa-laptop"></i> Machine: {{ message.receiving_endpoint.host }}</span>
-                <span class="metadata" v-if="message.redirect"><i class="fa pa-redirect-source pa-redirect-small"></i> Redirect: {{ message.redirect }}</span>
-                <!-- for deleted messages-->
-                <span class="metadata" v-if="message.status == 'archived'"><i class="fa fa-clock-o"></i> Deleted: <time-since :date-utc="message.last_modified"></time-since></span>
-                <span class="metadata danger" v-if="message.status == 'archived' && message.delete_soon"><i class="fa fa-trash-o danger"></i> Scheduled for deletion: immediately</span>
-                <span class="metadata danger" v-if="message.status == 'archived' && !message.delete_soon"><i class="fa fa-trash-o danger"></i> Scheduled for deletion: <time-since class="danger" :date-utc="message.deleted_in"></time-since> </span>
+                  <span class="metadata"><i class="fa fa-clock-o"></i> Failed: <time-since :dateUtc="message.time_of_failure"></time-since></span>
+                  <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{ message.receiving_endpoint.name }}</span>
+                  <span class="metadata"><i class="fa fa-laptop"></i> Machine: {{ message.receiving_endpoint.host }}</span>
+                  <span class="metadata" v-if="message.redirect"><i class="fa pa-redirect-source pa-redirect-small"></i> Redirect: {{ message.redirect }}</span>
+                  <!-- for deleted messages-->
+                  <span class="metadata" v-if="message.status == 'archived'"><i class="fa fa-clock-o"></i> Deleted: <time-since :date-utc="message.last_modified"></time-since></span>
+                  <span class="metadata danger" v-if="message.status == 'archived' && message.delete_soon"><i class="fa fa-trash-o danger"></i> Scheduled for deletion: immediately</span>
+                  <span class="metadata danger" v-if="message.status == 'archived' && !message.delete_soon"><i class="fa fa-trash-o danger"></i> Scheduled for deletion: <time-since class="danger" :date-utc="message.deleted_in"></time-since> </span>
 
-                <button type="button" name="retryMessage" v-if="!message.retryInProgress && props.showRequestRetry" class="btn btn-link btn-sm" @click="emit('retryRequested', message.id)"><i aria-hidden="true" class="fa fa-repeat no-link-underline">&nbsp;</i>Request retry</button>
+                  <button type="button" name="retryMessage" v-if="!message.retryInProgress && props.showRequestRetry" class="btn btn-link btn-sm" @click="emit('retryRequested', message.id)"><i aria-hidden="true" class="fa fa-repeat no-link-underline">&nbsp;</i>Request retry</button>
               </p>
 
               <pre class="stacktrace-preview">{{ message.exception.message }}</pre>

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageList.vue
@@ -85,7 +85,7 @@ defineExpose({
   </div>
   <div v-for="(message, index) in props.messages" class="row box repeat-item failed-message" :key="message.id">
     <label class="check col-1" :for="`checkbox${message.id}`" @click="labelClicked($event, index)">
-      <input type="checkbox" :disabled="message.retryInProgress || message.submittedForRetrial" class="checkbox" v-model="message.selected" :value="message.id" :id="`checkbox${message.id}`" />
+      <input type="checkbox" :disabled="message.retryInProgress || message.submittedForRetrial || message.deleteInProgress" class="checkbox" v-model="message.selected" :value="message.id" :id="`checkbox${message.id}`" />
     </label>
     <div class="col-11 failed-message-data">
       <div class="row">
@@ -101,7 +101,7 @@ defineExpose({
 
                 <span v-if="message.deleteInProgress" tooltip="Message is being deleted" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-trash"></i> Scheduled for deletion</span>
                 <span v-if="message.restoreInProgress" tooltip="Message is being restored" class="label sidebar-label label-warning metadata-label metadata in-progress"><i class="bi-recycle"></i> Restore in progress</span>
-                <span v-if="message.archived" tooltip="Message is being deleted" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-trash"></i> Deleted</span>      
+                <span v-if="message.archived" tooltip="Message is being deleted" class="label sidebar-label label-info metadata-label metadata in-progress"><i class="bi-trash"></i> Deleted</span>
                 <span v-if="message.number_of_processing_attempts > 1" tooltip="This message has already failed {{message.number_of_processing_attempts}} times" class="label sidebar-label label-important metadata-label">{{ message.number_of_processing_attempts === 10 ? "9+" : message.number_of_processing_attempts }} Retry Failures</span>
 
                 <span v-if="message.edited" tooltip="Message was edited" class="label sidebar-label label-info metadata-label">Edited</span>

--- a/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
+++ b/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
@@ -41,19 +41,19 @@ function subIsActiveSubPath(subPath) {
 
             <!--Deleted Message Group-->
             <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('deleted-message-groups'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages/deleted-message-groups' }">Deleted Message Groups</RouterLink>
+              <RouterLink :to="{ path: '/failed-messages/deleted-message-groups' }">Deleted Message Groups </RouterLink>
               <span v-if="stats.number_of_archived_messages !== 0" title="There's varying numbers of deleted message groups depending on group type" class="badge badge-important">!</span>
             </h5>
 
             <!--All Deleted Messages-->
             <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('all-deleted-messages') || subIsActiveSubPath('/deleted-messages/group/'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages/all-deleted-messages' }">All Deleted Messages</RouterLink>
+              <RouterLink :to="{ path: '/failed-messages/all-deleted-messages' }">All Deleted Messages </RouterLink>
               <span v-if="stats.number_of_archived_messages !== 0" class="badge badge-important">{{ stats.number_of_archived_messages }}</span>
             </h5>
 
             <!--All Pending Retries -->
             <h5 v-if="!licenseStatus.isExpired && showPendingRetry" :class="{ active: subIsActive('pending-retries'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages/pending-retries' }">Pending Retries</RouterLink>
+              <RouterLink :to="{ path: '/failed-messages/pending-retries' }">Pending Retries </RouterLink>
               <span v-if="stats.number_of_pending_retries !== 0" class="badge badge-important">{{ stats.number_of_pending_retries }}</span>
             </h5>
           </div>


### PR DESCRIPTION
The PR addresses the following bugs
- fix the count badge spacing
- All failed message page- disable the checkbox when message is selected for deletion
- All deleted message page- disable the checkbox when message is selected for restore