### PR TITLE
Don't allow spaces in comments

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessageGroupNoteEdit.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessageGroupNoteEdit.vue
@@ -24,6 +24,10 @@ function editNote() {
   emit("editNoteConfirmed", updatedGroup);
 }
 
+function isValidComment() {
+  return grpcomment.value && grpcomment.value.trim();
+}
+
 function close() {
   emit("cancelEditNote");
 }
@@ -58,8 +62,8 @@ onMounted(() => {
             </div>
           </div>
           <div class="modal-footer">
-            <button v-if="settings.comment"  :disabled="!grpcomment" class="btn btn-primary" @click="editNote">Modify</button>
-            <button v-if="!settings.comment"  :disabled="!grpcomment"  class="btn btn-primary" @click="createNote">Create</button>
+            <button v-if="settings.comment"  :disabled="!isValidComment()" class="btn btn-primary" @click="editNote">Modify</button>
+            <button v-if="!settings.comment"  :disabled="!isValidComment()"  class="btn btn-primary" @click="createNote">Create</button>
             <button class="btn btn-default" @click="close">Cancel</button>
           </div>
         </form>


### PR DESCRIPTION
Validates that a comment isn't just a bunch of spaces. There must be at least some text in there.