### PR TITLE
Replace failed messages angular links with vue

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
@@ -35,34 +35,29 @@ function iconSubClasses(eventItem) {
   };
 }
 
-function navigateToEvent(eventLogItem) {
-  switch (eventLogItem.category) {
+    function navigateToEvent(eventLogItem) {
+    switch (eventLogItem.category) {
     case "Endpoints":
       router.push("/configuration#endpoints");
       break;
     case "HeartbeatMonitoring":
-      //router.push('/a/#/endpoints');
       window.location = "/a/#/endpoints";
       break;
     case "CustomChecks":
-      //router.push('/a/#/custom-checks');
       window.location = "/a/#/custom-checks";
       break;
     case "EndpointControl":
-      //router.push('/a/#/endpoints');
       window.location = "/a/#/endpoints";
       break;
     case "MessageFailures":
-      var newlocation = "/a/#/failed-messages/groups";
-      if (eventLogItem.related_to && eventLogItem.related_to[0].search("message") > 0) {
-        newlocation = "/a/#/failed-messages" + eventLogItem.related_to[0];
+      var newlocation = "/failed-messages";
+      if (eventLogItem.related_to && eventLogItem.related_to.length>0 && eventLogItem.related_to[0].search("message") > 0) {
+      newlocation = "/failed-messages" + eventLogItem.related_to[0];
       }
-      //router.push(newlocation);
-      window.location = newlocation;
+      router.push(newlocation);
       break;
     case "Recoverability":
-      //router.push('/a/#/failed-messages/groups');
-      window.location = "/a/#/failed-messages/groups";
+      router.push('/failed-messages');
       break;
     case "MessageRedirects":
       router.push("/configuration#retry-redirects");

--- a/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
@@ -51,7 +51,7 @@ function navigateToEvent(eventLogItem) {
       break;
     case "MessageFailures":
       var newlocation = "/failed-messages";
-      if (eventLogItem.related_to && eventLogItem.related_to.length>0 && eventLogItem.related_to[0].search("message") > 0) {
+      if (eventLogItem.related_to && eventLogItem.related_to.length > 0 && eventLogItem.related_to[0].search("message") > 0) {
         newlocation = "/failed-messages" + eventLogItem.related_to[0];
       }
       router.push(newlocation);

--- a/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
@@ -35,8 +35,8 @@ function iconSubClasses(eventItem) {
   };
 }
 
-    function navigateToEvent(eventLogItem) {
-    switch (eventLogItem.category) {
+function navigateToEvent(eventLogItem) {
+  switch (eventLogItem.category) {
     case "Endpoints":
       router.push("/configuration#endpoints");
       break;

--- a/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
@@ -52,7 +52,7 @@ function navigateToEvent(eventLogItem) {
     case "MessageFailures":
       var newlocation = "/failed-messages";
       if (eventLogItem.related_to && eventLogItem.related_to.length>0 && eventLogItem.related_to[0].search("message") > 0) {
-      newlocation = "/failed-messages" + eventLogItem.related_to[0];
+        newlocation = "/failed-messages" + eventLogItem.related_to[0];
       }
       router.push(newlocation);
       break;

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -52,17 +52,6 @@ const displayDanger = computed(() => {
               <span v-if="stats.number_of_disconnected_endpoints > 0" class="badge badge-important">{{ stats.number_of_disconnected_endpoints }}</span>
             </a>
           </li>
-          <li
-            :class="{
-              active: subIsActive('/a/#/failed-messages/groups') || subIsActive('/a/#/failed-messages/all') || subIsActive('/a/#/failed-messages/archived') || subIsActive('/a/#/failed-messages/pending-retries'),
-            }"
-          >
-            <a href="/a/#/failed-messages/groups">
-              <i class="fa fa-envelope icon-white"></i>
-              <span class="navbar-label">Failed Messages (AngularJS)</span>
-              <span v-if="stats.number_of_failed_messages > 0" class="badge badge-important">{{ stats.number_of_failed_messages }}</span>
-            </a>
-          </li>
           <li :class="{ active: subIsActive('/failed-messages') }">
             <RouterLink :to="{ name: 'failed-messages' }">
               <i class="fa fa-envelope icon-white"></i>


### PR DESCRIPTION
This PR replaces the angular failed component links on
- Page header
- Dashboard