### PR TITLE
Set node_options in release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3.4.0
+      - name: Add NODE_OPTIONS to ENVVARS # Must do this after checkout as checkout uses node v16 which will cause this to fail
+        run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> $env:GITHUB_ENV
       - name: Build AngularJS and Vue.js
         run: .\build.ps1
         shell: pwsh
         working-directory: src/ServicePulse.Host
+      - name: Remove NODE_OPTIONS to ENVVARS # Must do this before the next step so that the following node v16 steps don't fail
+        run: echo "NODE_OPTIONS=" >> $env:GITHUB_ENV
       - name: Update app.constants.js
         run: |
           $filename = "src/ServicePulse.Host/app/js/app.constants.js"


### PR DESCRIPTION
The node options are set during the build and test, but not during the docker files.