### PR TITLE
Specify powershell for all release steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,14 @@ jobs:
         uses: actions/checkout@v3.4.0
       - name: Add NODE_OPTIONS to ENVVARS # Must do this after checkout as checkout uses node v16 which will cause this to fail
         run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> $env:GITHUB_ENV
+        shell: pwsh
       - name: Build AngularJS and Vue.js
         run: .\build.ps1
         shell: pwsh
         working-directory: src/ServicePulse.Host
       - name: Remove NODE_OPTIONS to ENVVARS # Must do this before the next step so that the following node v16 steps don't fail
         run: echo "NODE_OPTIONS=" >> $env:GITHUB_ENV
+        shell: pwsh
       - name: Update app.constants.js
         run: |
           $filename = "src/ServicePulse.Host/app/js/app.constants.js"


### PR DESCRIPTION
On Ubuntu, the envvar is set using bash but the build is run using powershell meaning that ubuntu doesn't have the `NODE_OPTIONS` envvar set correctly when it runs. Thereby failing the docker image builds. This changes makes it that all envvar steps as well as the build step are all executed using powershell.