### PR TITLE
 ServicePulse version 1.34.4 and 1.35.0: buttons "Retry all" and "Delete all" do not work

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
@@ -251,15 +251,15 @@ function calculatePageNumbers() {
 }
 
 function retryGroup() {
-  useShowToast("info", "Info", "Retrying all messages...");
-  useRetryExceptionGroup(groupId).then(() => {
+    useShowToast("info", "Info", "Retrying all messages...");
+  useRetryExceptionGroup(groupId.value).then(() => {
     messages.value.forEach((m) => (m.retryInProgress = true));
   });
 }
 
 function deleteGroup() {
-  useShowToast("info", "Info", "Deleting all messages...");
-  useArchiveExceptionGroup(groupId).then(() => {
+    useShowToast("info", "Info", "Deleting all messages...");
+  useArchiveExceptionGroup(groupId.value).then(() => {
     messages.value.forEach((m) => (m.deleteInProgress = true));
   });
 }


### PR DESCRIPTION
fix "Retry all" and "Delete all" functionality in all failed messages