### PR TITLE
Fix problem with tag not being visible on master branch

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
@@ -251,15 +251,15 @@ function calculatePageNumbers() {
 }
 
 function retryGroup() {
-  useShowToast("info", "Info", "Retrying all messages...");
-  useRetryExceptionGroup(groupId).then(() => {
+    useShowToast("info", "Info", "Retrying all messages...");
+  useRetryExceptionGroup(groupId.value).then(() => {
     messages.value.forEach((m) => (m.retryInProgress = true));
   });
 }
 
 function deleteGroup() {
-  useShowToast("info", "Info", "Deleting all messages...");
-  useArchiveExceptionGroup(groupId).then(() => {
+    useShowToast("info", "Info", "Deleting all messages...");
+  useArchiveExceptionGroup(groupId.value).then(() => {
     messages.value.forEach((m) => (m.deleteInProgress = true));
   });
 }


### PR DESCRIPTION
The `1.35.1` tag was created before #1480 was merged, and the PR was merged with a squash merge, so the tagged commit is not currently visible from the `master` branch.

Once this PR is merged with a regular merge commit (and NOT a squash), this will get the tagged commit back as part of the `master` branch.

