### PR TITLE
Repo updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,8 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 5.0.x
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
-      - name: Add NODE_OPTIONS to ENVVARS # Must do this after Add msbuild to PATH as Add msbuild to PATH uses node v16 which will cause this to fail
+          dotnet-version: 7.0.x
+      - name: Add NODE_OPTIONS to ENVVARS # Must do this after checkout as checkout uses node v16 which will cause this to fail
         run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> $env:GITHUB_ENV
       - name: AngularJs - Install Host npm packages
         run: npm run load
@@ -37,7 +35,7 @@ jobs:
       - name: Remove NODE_OPTIONS to ENVVARS # Must do this before the next step so that the following node v16 steps don't fail
         run: echo "NODE_OPTIONS=" >> $env:GITHUB_ENV
       - name: Build
-        run: msbuild src -p:Configuration=Release -restore -m
+        run: dotnet build src --configuration Release
       - name: Upload assets
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -51,8 +49,7 @@ jobs:
           path: nugets/
           retention-days: 7
       - name: Run .NET tests
-        run: dotnet test --configuration Release --no-build --logger "GitHubActions;report-warnings=false"
-        working-directory: src/ServicePulse.Host.Tests
+        uses: Particular/run-tests-action@v1.5.1
       - name: Install test npm packages
         run: npm install
         working-directory: src/ServicePulse.Host.Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
   workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
-  # Signals build to create the installer
-  RELEASE_WORKFLOW: true
 jobs:
   release:
     runs-on: windows-2022
@@ -23,11 +21,6 @@ jobs:
         uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 7.0.x
-      - name: Setup Advanced Installer
-        run: |
-          $version = "20.2.1"
-          choco install advanced-installer --version=$version
-          & "C:\Program Files (x86)\Caphyon\Advanced Installer $version\bin\x86\AdvancedInstaller.com" /register ${{ secrets.ADVANCED_INSTALLER_LICENSE_KEY }}
       - name: Add NODE_OPTIONS to ENVVARS # Must do this after checkout as checkout uses node v16 which will cause this to fail
         run: echo "NODE_OPTIONS=--openssl-legacy-provider" >> $env:GITHUB_ENV
       - name: AngularJs - Install Host npm packages
@@ -41,14 +34,7 @@ jobs:
         working-directory: src/ServicePulse.Host
       - name: Remove NODE_OPTIONS to ENVVARS # Must do this before the next step so that the following node v16 steps don't fail
         run: echo "NODE_OPTIONS=" >> $env:GITHUB_ENV
-      - name: Prepare AIP file
-        run: |
-          $content = Get-Content -Raw -Path src/Setup/ServicePulse.aip
-          $content = $content -replace "replace-tenant-id", "${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}" -replace "replace-app-id", "${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}" -replace "replace-cert-name", "${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}"
-          Set-Content src/Setup/ServicePulse.aip $content
       - name: Build
-        env:
-          AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
         run: dotnet build src --configuration Release
       - id: save-version
         name: Save version
@@ -60,6 +46,20 @@ jobs:
           tenant-id: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
           client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
           certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
+      - name: Setup Advanced Installer
+        run: |
+          $version = "20.2.1"
+          choco install advanced-installer --version=$version
+          & "C:\Program Files (x86)\Caphyon\Advanced Installer $version\bin\x86\AdvancedInstaller.com" /register ${{ secrets.ADVANCED_INSTALLER_LICENSE_KEY }}
+      - name: Prepare AIP file
+        run: |
+          $content = Get-Content -Raw -Path src/Setup/ServicePulse.aip
+          $content = $content -replace "replace-tenant-id", "${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}" -replace "replace-app-id", "${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}" -replace "replace-cert-name", "${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}"
+          Set-Content src/Setup/ServicePulse.aip $content
+      - name: Build Windows installer
+        env:
+          AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
+        run: dotnet build src/Setup --configuration Release
       - name: Publish artifacts
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet build src --configuration Release
       - id: save-version
         name: Save version
-        run: echo "version=${{env.MinVerVersion}}" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf-8 -Append
+        run: echo "version=${{env.MinVerVersion}}" >> $Env:GITHUB_OUTPUT
       - name: Sign NuGet packages
         uses: Particular/sign-nuget-packages-action@v1.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
   RELEASE_WORKFLOW: true
 jobs:
   release:
-    runs-on: windows-2022 # Code signing requirement https://github.com/NuGet/Home/issues/7939
+    runs-on: windows-2022
     outputs:
       version: ${{ steps.save-version.outputs.version }}
     steps:
@@ -22,9 +22,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: 5.0.x
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+          dotnet-version: 7.0.x
       - name: Setup Advanced Installer
         run: |
           $version = "20.2.1"
@@ -51,7 +49,7 @@ jobs:
       - name: Build
         env:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-        run: msbuild src -p:Configuration=Release -restore -m
+        run: dotnet build src --configuration Release
       - id: save-version
         name: Save version
         run: echo "version=${{env.MinVerVersion}}" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf-8 -Append
@@ -70,10 +68,6 @@ jobs:
             assets/*
             nugets/*
           retention-days: 1
-      - name: Install Octopus CLI
-        uses: OctopusDeploy/install-octopus-cli-action@v3.0.0
-        with:
-          version: latest
       - name: Deploy
         uses: Particular/push-octopus-package-action@v1.1.0
         with:

--- a/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
+++ b/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Particular.Approvals" Version="0.4.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServicePulse.Install.CustomActions/CustomAction.cs
+++ b/src/ServicePulse.Install.CustomActions/CustomAction.cs
@@ -7,7 +7,7 @@
     using System.Management;
     using System.Net;
     using System.Text.RegularExpressions;
-    using Microsoft.Deployment.WindowsInstaller;
+    using WixToolset.Dtf.WindowsInstaller;
 
     public class CustomActions
     {
@@ -47,7 +47,7 @@
 
                 var request = WebRequest.Create(url);
                 request.Timeout = 2000;
-#pragma warning disable IDE0019 // Use pattern matching
+
                 using (var response = request.GetResponse() as HttpWebResponse)
                 {
                     if (response == null)
@@ -65,7 +65,6 @@
                         session.Set("MONITORING_REPORTED_VERSION", version.Split(' ').First());
                     }
                 }
-#pragma warning restore IDE0019 // Use pattern matching
 
                 connectionSuccessful = true;
             }
@@ -94,7 +93,7 @@
 
                 var request = WebRequest.Create(url);
                 request.Timeout = 2000;
-#pragma warning disable IDE0019 // Use pattern matching
+
                 using (var response = request.GetResponse() as HttpWebResponse)
                 {
                     if (response == null)
@@ -112,7 +111,6 @@
                         session.Set("REPORTED_VERSION", version.Split(' ').First());
                     }
                 }
-#pragma warning restore IDE0019 // Use pattern matching
 
                 connectionSuccessful = true;
             }

--- a/src/ServicePulse.Install.CustomActions/ServicePulse.Install.CustomActions.csproj
+++ b/src/ServicePulse.Install.CustomActions/ServicePulse.Install.CustomActions.csproj
@@ -6,29 +6,15 @@
 
   <ItemGroup>
     <Reference Include="System.Management" />
-    <Reference Include="$(WixSdkPath)Microsoft.Deployment.WindowsInstaller.dll" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WiX" Version="3.11.2" />
+    <PackageReference Include="WixToolset.Dtf.CustomAction" Version="4.0.0" />
   </ItemGroup>
 
    <ItemGroup>
     <None Remove="CustomAction.config" />
     <Content Include="CustomAction.config" />
   </ItemGroup>
-
-  <!-- Workaround needed because importing WiX targets file below is too early for $(TargetName) and $(TargetExt) to be defined -->
-  <PropertyGroup>
-    <TargetCAFileName>ServicePulse.Install.CustomActions.CA.dll</TargetCAFileName>
-  </PropertyGroup>
-  <!-- End workaround -->
-
-  <Import Project="$(WixCATargetsPath)" Condition="Exists('$(WixCATargetsPath)')" />
-
-  <!-- Workaround needed because WiX targets don't currently work with SDK projects -->
-  <Target Name="CleanCAFile" DependsOnTargets="CleanCustomAction" BeforeTargets="CoreClean" Condition="'$(DesignTimeBuild)' != 'true'" />
-  <Target Name="CreateCAFile" DependsOnTargets="PackCustomAction" AfterTargets="CoreCompile" Condition="'$(DesignTimeBuild)' != 'true'" />
-  <!-- End workaround -->
 
 </Project>

--- a/src/ServicePulse.sln
+++ b/src/ServicePulse.sln
@@ -8,10 +8,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServicePulse.Install.CustomActions", "ServicePulse.Install.CustomActions\ServicePulse.Install.CustomActions.csproj", "{7E47B904-EF48-4F26-AAB5-BE435BCDC696}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Setup", "Setup\Setup.csproj", "{FA2792B9-B82D-4936-871E-16812FA60D13}"
-	ProjectSection(ProjectDependencies) = postProject
-		{7E47B904-EF48-4F26-AAB5-BE435BCDC696} = {7E47B904-EF48-4F26-AAB5-BE435BCDC696}
-		{D120B791-BD1B-4E06-B4E1-69801A73209B} = {D120B791-BD1B-4E06-B4E1-69801A73209B}
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "installer", "installer", "{CBD21A52-A2D6-45FF-B921-A0743CFB13F7}"
 EndProject
@@ -53,9 +49,7 @@ Global
 		{7E47B904-EF48-4F26-AAB5-BE435BCDC696}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E47B904-EF48-4F26-AAB5-BE435BCDC696}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FA2792B9-B82D-4936-871E-16812FA60D13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FA2792B9-B82D-4936-871E-16812FA60D13}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA2792B9-B82D-4936-871E-16812FA60D13}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FA2792B9-B82D-4936-871E-16812FA60D13}.Release|Any CPU.Build.0 = Release|Any CPU
 		{113A09CC-9665-4E87-9FC7-7E5C8C0AFE71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{113A09CC-9665-4E87-9FC7-7E5C8C0AFE71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{113A09CC-9665-4E87-9FC7-7E5C8C0AFE71}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -1,4 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+
+  <!--
+
+  WARNING
+  This project is not automatically built when building the solution.
+  To build the Windows installer, explicitly build this project after having built the solution.
+
+  -->
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -9,7 +17,7 @@
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <Target Name="CreateInstaller" AfterTargets="Build" Condition="'$(CI)' == 'true' AND '$(RELEASE_WORKFLOW)' == 'true'">
+  <Target Name="CreateInstaller" AfterTargets="Build">
     <PropertyGroup>
       <AdvancedInstallerPath>$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Caphyon\Advanced Installer@Advanced Installer Path)</AdvancedInstallerPath>
       <AdvancedInstallerExe>"$(AdvancedInstallerPath)bin\x86\AdvancedInstaller.com"</AdvancedInstallerExe>


### PR DESCRIPTION
This PR includes the following: 

- Wix Toolset updated to v4, which no longer requires .NET Framework 3.5 and works with SDK projects without workarounds
- Changes to how the Windows Installer gets built, matching how it is handled in ServiceControl
- Removed an unneeded package reference
- Tweaks to workflow files