### PR TITLE
Allow displaying logical endpoint

### DIFF
--- a/src/ServicePulse.Host/angular/app/js/.eslintrc.js
+++ b/src/ServicePulse.Host/angular/app/js/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
     "env": {
         "browser": true,
-        "es6": false,
+        "es6": true,
         "node": false,
         "jquery": true
     },
@@ -11,7 +11,7 @@ module.exports = {
         "SharedArrayBuffer": "readonly"
     },
     "parserOptions": {
-        "ecmaVersion": 5,
+        "ecmaVersion": 2020,
         "sourceType": "script"
     },
     "rules": {

--- a/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.controller.js
+++ b/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.controller.js
@@ -22,6 +22,7 @@
         $scope.sortOptions = ['Name', 'Latest heartbeat'];
         $scope.sort = 'Name';
         $scope.sortDir = '';
+        $scope.display = 'Endpoint Instances';
 
         $scope.isInactiveEndpoints = true;
 
@@ -33,75 +34,123 @@
             updateUI();
         }, 5000);
 
+        function mapEndpointsToDisplay(endpoints) {
+            if ($scope.display == 'Logical Endpoints') {
+                var logicalNames = [...new Set(endpoints.data.map(function (endpoint) { return endpoint.name; }))];
+                var logicalEndpoints = logicalNames.map(function (endpointName) {
+                    var aliveList = endpoints.data.filter(function (ep) { 
+                        return ep.name == endpointName && ep.monitor_heartbeat && ep.heartbeat_information.reported_status === 'beating';
+                    });
+
+                    var aliveCount = aliveList ? aliveList.length : 0;
+                    var downCount = endpoints.data.filter(function (ep) { 
+                        return ep.name == endpointName && ep.monitor_heartbeat;
+                    }).length - aliveCount;
+
+                    return {
+                        name: endpointName,
+                        aliveCount: aliveCount,
+                        downCount: downCount,
+                        heartbeat_information: {
+                            reported_status: aliveList && aliveList.length ? 'beating' : 'dead',
+                            last_report_at: aliveList && aliveList.length ? aliveList[0].heartbeat_information.last_report_at : undefined
+                        },
+                        monitor_heartbeat: endpoints.data.filter(function (ep) { 
+                            return ep.name == endpointName
+                        }).some(function (ep) {
+                            return ep.monitor_heartbeat;
+                        })
+                    };
+                });
+
+                return { data: logicalEndpoints };
+            }
+
+            return endpoints;
+        }
+
         function updateUI() {
-            configurationService.getEndpoints().then(function(endpoints) {
-                var endpointList = endpoints.data;
+            configurationService.getEndpoints()
+                .then(mapEndpointsToDisplay)
+                .then(function(endpoints) {
+                    var endpointList = endpoints.data;
 
-                // remove unmonitored
-                var unmonitored = endpointList.filter(function(umi) {
-                    return !umi.monitor_heartbeat;
-                });
+                    // remove unmonitored
+                    var unmonitored = endpointList.filter(function(umi) {
+                        return !umi.monitor_heartbeat;
+                    });
 
-                var i, obj;
+                    var i, obj;
 
-                for (i = 0; i < $scope.model.active.length; i++) {
-                    obj = $scope.model.active[i];
-                    if (unmonitored.find(function (endpoint) { return endpoint.id == obj.id; }) !== -1) {
-                        $scope.model.active.splice(i, 1);
-                        i--; // we just made the array 1 shorter
+                    for (i = 0; i < $scope.model.active.length; i++) {
+                        obj = $scope.model.active[i];
+                        if (unmonitored.find(function (endpoint) { return $scope.display == 'Endpoint Instances' ? endpoint.id == obj.id : endpoint.name == obj.name; }) !== -1) {
+                            $scope.model.active.splice(i, 1);
+                            i--; // we just made the array 1 shorter
+                        }
                     }
-                }
 
-                for (i = 0; i < $scope.model.inactive.length; i++) {
-                    obj = $scope.model.inactive[i];
-                    if (unmonitored.find(function (endpoint) { return endpoint.id == obj.id; }) !== -1) {
-                        $scope.model.inactive.splice(i, 1);
-                        i--;
+                    for (i = 0; i < $scope.model.inactive.length; i++) {
+                        obj = $scope.model.inactive[i];
+                        if (unmonitored.find(function (endpoint) { return $scope.display == 'Endpoint Instances' ? endpoint.id == obj.id : endpoint.name == obj.name; }) !== -1) {
+                            $scope.model.inactive.splice(i, 1);
+                            i--;
+                        }
                     }
-                }
 
-                var monitored = endpointList.filter(function(mi) {
-                    return mi.monitor_heartbeat;
-                });
+                    var monitored = endpointList.filter(function(mi) {
+                        return mi.monitor_heartbeat;
+                    });
 
-                for (var j = 0; j < monitored.length; j++) {
-                    var item = monitored[j];
+                    for (var j = 0; j < monitored.length; j++) {
+                        var item = monitored[j];
 
-                    var activeIndex = $scope.model.active.map(function(bi) { return bi.id; }).indexOf(item.id);
-                    var inactiveIndex = $scope.model.inactive.map(function(bi) { return bi.id; }).indexOf(item.id);
+                        var activeIndex = $scope.model.active.map(function(bi) { return $scope.display == 'Endpoint Instances' ? bi.id : bi.name; }).indexOf($scope.display == 'Endpoint Instances' ? item.id : item.name);
+                        var inactiveIndex = $scope.model.inactive.map(function(bi) { return $scope.display == 'Endpoint Instances' ? bi.id : bi.name; }).indexOf($scope.display == 'Endpoint Instances' ? item.id : item.name);
 
-                    if (Object.prototype.hasOwnProperty.call(item, 'heartbeat_information') && item.heartbeat_information.reported_status === 'beating') {
-                        if (activeIndex === -1) {
-                            $scope.model.active.push(item);
+                        if (Object.prototype.hasOwnProperty.call(item, 'heartbeat_information') && item.heartbeat_information.reported_status === 'beating') {
+                            if (activeIndex === -1) {
+                                $scope.model.active.push(item);
+                            } else {
+                                var activeitem = $scope.model.active[activeIndex];
+                                activeitem.heartbeat_information.last_report_at = item.heartbeat_information.last_report_at;
+                            }
+                            if (inactiveIndex !== -1) {
+                                $scope.model.inactive.splice(inactiveIndex, 1);
+                            }
                         } else {
-                            var activeitem = $scope.model.active[activeIndex];
-                            activeitem.heartbeat_information.last_report_at = item.heartbeat_information.last_report_at;
-                        }
-                        if (inactiveIndex !== -1) {
-                            $scope.model.inactive.splice(inactiveIndex, 1);
-                        }
-                    } else {
-                        if (inactiveIndex === -1) {
-                            $scope.model.inactive.push(item);
-                        }
-                        if (activeIndex !== -1) {
-                            $scope.model.active.splice(activeIndex, 1);
-                        }
+                            if (inactiveIndex === -1) {
+                                $scope.model.inactive.push(item);
+                            }
+                            if (activeIndex !== -1) {
+                                $scope.model.active.splice(activeIndex, 1);
+                            }
 
+                        }
                     }
-                }
 
-                var sort = getSortFunction();
+                    var sort = getSortFunction();
 
-                $scope.model.inactive.sort(sort);
-                $scope.model.active.sort(sort);
-            });
+                    $scope.model.inactive.sort(sort);
+                    $scope.model.active.sort(sort);
+                });
         }
 
         $scope.deleteEndpoint = function(endpoint) {
             configurationService.deleteEndpoint(endpoint.id).then(function() {
                 $scope.model.inactive.splice($scope.model.inactive.indexOf(endpoint), 1);
             });
+        }
+
+        $scope.endpointDisplayName = function(endpoint) {
+            if ($scope.display == 'Logical Endpoints') {
+                if (endpoint.aliveCount > 0) {
+                    return endpoint.name + ' (' + endpoint.aliveCount + ' instance' + (endpoint.aliveCount > 1 ? 's)' : ')');
+                }
+
+                return endpoint.name + ' (0 out of ' + endpoint.downCount + ' previous instance' + (endpoint.downCount > 1 ? 's' : '') + ' reporting)';
+            }
+            return endpoint.name + '@' + endpoint.host_display_name;
         }
 
         function autoGetEndPoints() {
@@ -137,6 +186,11 @@
                 }, function(message) {
                     result.workflow_state = createWorkflowState('error', message);
                 });
+        };
+
+        $scope.changeDisplay = function(display) {
+            $scope.display = display;
+            updateUI();
         };
 
         $scope.changeSort = function(sortBy, sortDir) {

--- a/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.controller.js
+++ b/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.controller.js
@@ -11,6 +11,7 @@
     function controller(
         $scope,
         $interval,
+        $cookies,
         sharedDataService,
         configurationService,
         notifyService) {
@@ -22,9 +23,15 @@
         $scope.sortOptions = ['Name', 'Latest heartbeat'];
         $scope.sort = 'Name';
         $scope.sortDir = '';
-        $scope.display = 'Endpoint Instances';
+        $scope.display = getSavedDisplayType();
 
         $scope.isInactiveEndpoints = true;
+
+        function getSavedDisplayType() {
+            var savedDisplayType = $cookies.get('heartbeats_display_type');
+
+            return savedDisplayType || 'Endpoint Instances';
+        }
 
         $scope.$on('$destroy', function() {
             $interval.cancel(timeoutId);
@@ -190,6 +197,8 @@
 
         $scope.changeDisplay = function(display) {
             $scope.display = display;
+
+            $cookies.put('heartbeats_display_type', display);
             updateUI();
         };
 
@@ -229,6 +238,7 @@
     controller.$inject = [
         '$scope',
         '$interval',
+        '$cookies',
         'sharedDataService',
         'configurationService',
         'notifyService'

--- a/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.html
+++ b/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.html
@@ -23,6 +23,18 @@
 
             <div class="filter-group">
 
+                <div class="msg-group-menu dropdown" ng-if="!isEndpointsConfiguration">
+                    <label class="control-label">Display:</label>
+                    <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {{display}}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li><a ng-click="changeDisplay('Endpoint Instances')">Endpoint Instances</a></li>
+                        <li><a ng-click="changeDisplay('Logical Endpoints')">Logical Endpoints</a></li>
+                    </ul>
+                </div>
+
                 <div class="msg-group-menu dropdown">
                     <label class="control-label">Sort by:</label>
                     <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -32,18 +44,6 @@
                     <ul class="dropdown-menu">
                         <li ng-repeat-start="sort in sortOptions"><a ng-click="changeSort(sort, 'asc')">{{sort}}</a></li>
                         <li ng-repeat-end><a ng-click="changeSort(sort, 'desc')">{{sort}} <span>(Descending)</span></a></li>
-                    </ul>
-                </div>
-
-                <div class="msg-group-menu dropdown">
-                    <label class="control-label">Display:</label>
-                    <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        {{display}}
-                        <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li><a ng-click="changeDisplay('Endpoint Instances')">Endpoint Instances</a></li>
-                        <li><a ng-click="changeDisplay('Logical Endpoints')">Logical Endpoints</a></li>
                     </ul>
                 </div>
                 

--- a/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.html
+++ b/src/ServicePulse.Host/angular/app/js/views/endpoints/endpoints.html
@@ -34,6 +34,18 @@
                         <li ng-repeat-end><a ng-click="changeSort(sort, 'desc')">{{sort}} <span>(Descending)</span></a></li>
                     </ul>
                 </div>
+
+                <div class="msg-group-menu dropdown">
+                    <label class="control-label">Display:</label>
+                    <button type="button" class="btn btn-default dropdown-toggle sp-btn-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {{display}}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li><a ng-click="changeDisplay('Endpoint Instances')">Endpoint Instances</a></li>
+                        <li><a ng-click="changeDisplay('Logical Endpoints')">Logical Endpoints</a></li>
+                    </ul>
+                </div>
                 
                 <input type="text" placeholder="Filter by name..." class="form-control-static" ng-model="endpointFilter" />
 
@@ -51,7 +63,7 @@
                                 <div class="col-sm-12 no-side-padding">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <p class="lead hard-wrap">{{endpoint.name}}@{{endpoint.host_display_name}}</p>
+                                            <p class="lead hard-wrap">{{endpointDisplayName(endpoint)}}</p>
                                             <p>
                                                 latest heartbeat received <sp-moment date="{{endpoint.heartbeat_information.last_report_at}}"></sp-moment>
                                             </p>
@@ -77,7 +89,7 @@
                                 <div class="col-sm-12 no-side-padding">
                                     <div class="row box-header">
                                         <div class="col-sm-12 no-side-padding">
-                                            <p class="lead hard-wrap">{{endpoint.name}}@{{endpoint.host_display_name}} <a class="remove-item" ng-if="isDeleteEndpointsEnabled" ng-click="deleteEndpoint(endpoint)"><i class="fa fa-trash" uib-tooltip="Remove endpoint from list"></i></a></p>
+                                            <p class="lead hard-wrap">{{endpointDisplayName(endpoint)}} <a class="remove-item" ng-if="isDeleteEndpointsEnabled && display=='Endpoint Instances'" ng-click="deleteEndpoint(endpoint)"><i class="fa fa-trash" uib-tooltip="Remove endpoint from list"></i></a></p>
                                             <p>
                                                 latest heartbeat received <sp-moment date="{{endpoint.heartbeat_information.last_report_at}}"></sp-moment>
                                             </p>


### PR DESCRIPTION
This adds a dropdown to the filter section which allows the user to show only the endpoints' logical names instead of always physical.

![image](https://github.com/Particular/ServicePulse/assets/1060960/002eefc6-a678-449c-9cec-1f08264d0a8b)

It also includes some summary information about how many endpoints are beating and how many used to be beating.

![image](https://github.com/Particular/ServicePulse/assets/1060960/74dfb02e-f57c-49bf-8bce-c71eef35ab61)

![image](https://github.com/Particular/ServicePulse/assets/1060960/fa650ad9-e754-4ade-b305-35b3f0691fc2)

Configuration still allows the user to disable individual instances.

![image](https://github.com/Particular/ServicePulse/assets/1060960/234a34ab-6487-45c2-bcc1-1929d0a85248)


Documentation PR: https://github.com/Particular/docs.particular.net/pull/6069