### PR TITLE
Fix navbar alignment when screen less than 992px

### DIFF
--- a/src/ServicePulse.Host/vue/src/assets/navbar.css
+++ b/src/ServicePulse.Host/vue/src/assets/navbar.css
@@ -4,7 +4,8 @@
 }  
 
 .navbar {
-    height: 60px;
+    height: 60px;    
+    flex-wrap:nowrap;
 }
 
 .navbar-inverse {


### PR DESCRIPTION
Solves https://github.com/Particular/ServicePulse/issues/1503

When browser width less than 992px the menu jumps outside the navbar

![image](https://github.com/Particular/ServicePulse/assets/4316196/3b857f26-3be4-4ab0-8486-495949d949b5)
