### PR TITLE
Use RepoRootDir property instead of SolutionDir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build Windows installer
         env:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-        run: dotnet build src/Setup -property:SolutionDir=..\..\..\..\ --configuration Release
+        run: dotnet build src/Setup --configuration Release
       - name: Publish artifacts
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -28,7 +28,8 @@
       <ResourceFiles Include="res\**\*.*" />
     </ItemGroup>
     <PropertyGroup>
-      <SetupExeOutputFolder>$(SolutionDir)..\assets\</SetupExeOutputFolder>
+      <RepoRootDir>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\))</RepoRootDir>
+      <SetupExeOutputFolder>$(RepoRootDir)assets\</SetupExeOutputFolder>
       <SetupExeName>Particular.ServicePulse-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).exe</SetupExeName>
     </PropertyGroup>
     <MakeDir Directories="$(SetupExeOutputFolder)" />
@@ -39,9 +40,9 @@
     <Copy SourceFiles="$(AIPFile)" DestinationFolder="$(IntermediateOutputPath)" />
     <Copy SourceFiles="$(CommandFile)" DestinationFolder="$(IntermediateOutputPath)" />
     <Copy SourceFiles="@(ResourceFiles)" DestinationFolder="$(IntermediateOutputPath)res\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(SolutionDir)Setup -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name SP_PATH -value $(SolutionDir)ServicePulse.Host\bin\$(Configuration)\net48 -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name CUSTOMACTIONS_PATH -value $(SolutionDir)ServicePulse.Install.CustomActions\bin\$(Configuration)\net48 -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(RepoRootDir)src\Setup -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name SP_PATH -value $(RepoRootDir)src\ServicePulse.Host\bin\$(Configuration)\net48 -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name CUSTOMACTIONS_PATH -value $(RepoRootDir)src\ServicePulse.Install.CustomActions\bin\$(Configuration)\net48 -valuetype Folder" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetVersion $(MinVerMajor).$(MinVerMinor).$(MinVerPatch)" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetPackageName $(SetupExeOutputFolder)$(SetupExeName) -buildname DefaultBuild" />
     <Exec Command="$(AdvancedInstallerExe) /execute $(IntermediateOutputPath)$(AIPFile) $(IntermediateOutputPath)$(CommandFile)" />


### PR DESCRIPTION
This aligns the Setup project with the approach used in ServiceControl, where the required value is set in the project file, so it will always be available regardless of how the project is built.