### PR TITLE
Run non-deploy portions of release workflow when CI workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: windows-2022
     outputs:
       version: ${{ steps.save-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,7 @@ jobs:
           (Get-Content $filename).replace("1.2.0", "${{ needs.release.outputs.version }}") | Set-Content $filename
         shell: pwsh
       - name: Build Docker image
+        if: ${{ matrix.image-name == 'servicepulse' || (github.event_name == 'push' && github.ref_type == 'tag') }}
         run: docker build -t particular/${{ matrix.image-name }}:${{ needs.release.outputs.version }} -f ${{ matrix.dockerfile }} .
         working-directory: src
       - name: Login to Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release
 on:
   push:
+    branches:
+      - master
+      - release-*
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-*'
+  pull_request:
   workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
@@ -13,6 +17,11 @@ jobs:
     outputs:
       version: ${{ steps.save-version.outputs.version }}
     steps:
+      - name: Check for secrets
+        env:
+          SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+        shell: pwsh
+        run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
       - name: Checkout
         uses: actions/checkout@v3.5.3
         with:
@@ -69,6 +78,7 @@ jobs:
             nugets/*
           retention-days: 1
       - name: Deploy
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: Particular/push-octopus-package-action@v1.1.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
@@ -86,6 +96,11 @@ jobs:
             dockerfile: dockerfile.nginx
       fail-fast: false
     steps:
+      - name: Check for secrets
+        env:
+          SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+        shell: pwsh
+        run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
       - name: Checkout
         uses: actions/checkout@v3.5.3
       - name: Add NODE_OPTIONS to ENVVARS # Must do this after checkout as checkout uses node v16 which will cause this to fail
@@ -103,13 +118,15 @@ jobs:
           $filename = "src/ServicePulse.Host/app/js/app.constants.js"
           (Get-Content $filename).replace("1.2.0", "${{ needs.release.outputs.version }}") | Set-Content $filename
         shell: pwsh
+      - name: Build Docker image
+        run: docker build -t particular/${{ matrix.image-name }}:${{ needs.release.outputs.version }} -f ${{ matrix.dockerfile }} .
+        working-directory: src
       - name: Login to Docker Hub
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Docker image
-        run: docker build -t particular/${{ matrix.image-name }}:${{ needs.release.outputs.version }} -f ${{ matrix.dockerfile }} .
-        working-directory: src
       - name: Push Docker image
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         run: docker push particular/${{ matrix.image-name }}:${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,26 @@ jobs:
             assets/*
             nugets/*
           retention-days: 1
+      - name : Verify release artifact counts
+        shell: pwsh
+        run: |
+          $assetsCount = (Get-ChildItem -Recurse -File assets).Count
+          $nugetsCount =  (Get-ChildItem -Recurse -File nugets).Count
+
+          $expectedAssetsCount = 1
+          $expectedNugetsCount = 1
+
+          if ($assetsCount -ne $expectedAssetsCount)
+          {
+              Write-Host Assets: Expected $expectedAssetsCount but found $assetsCount
+              exit -1
+          }
+
+          if ($nugetsCount -ne $expectedNugetsCount)
+          {
+              Write-Host Nugets: Expected $expectedNugetsCount but found $nugetsCount
+              exit -1
+          }
       - name: Deploy
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: Particular/push-octopus-package-action@v1.1.0


### PR DESCRIPTION
This PR makes the following changes:
- The release workflow now has all the same triggers as the CI workflow, meaning it will run whenever the CI workflow runs.
  - The steps that actually deploy the release artifacts are skipped unless the workflow is triggered from a tag. This means that nothing changes in our release process because of this PR.
  - The release workflow is skipped when Dependabot opens a PR because it would otherwise fail due to the code signing secrets not being available to Dependabot.
- A step to verify the expected number of release artifacts has been added. This means that if something causes the number of artifacts to change, the release workflow will fail. The counts need to be manually adjusted if there is an intentional change to the expected number of artifacts for a release.
- Building the Windows docker image is skipped because it takes too long to include as part of every PR.

The end result of this PR is that you'll see the release workflow running on every PR, making it easy to access release artifacts, like the Windows installer, for testing. This also means that it is easier to prevent the release workflow from being broken accidentally.