### PR TITLE
Disable "Edit & Retry" on an already edited and retried message 

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
@@ -400,7 +400,7 @@ onUnmounted(() => {
           <div class="row">
             <div class="col-sm-12 no-side-padding">
               <div class="active break group-title">
-                <h1 class="message-type-title">{{ failedMessage.message_type }} TESTING</h1>
+                <h1 class="message-type-title">{{ failedMessage.message_type }}</h1>
               </div>
             </div>
           </div>

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
@@ -400,7 +400,7 @@ onUnmounted(() => {
           <div class="row">
             <div class="col-sm-12 no-side-padding">
               <div class="active break group-title">
-                <h1 class="message-type-title">{{ failedMessage.message_type }}</h1>
+                <h1 class="message-type-title">{{ failedMessage.message_type }} TESTING</h1>
               </div>
             </div>
           </div>
@@ -433,7 +433,7 @@ onUnmounted(() => {
                 <button type="button" class="btn btn-default" v-if="!failedMessage.archived" :disabled="failedMessage.retried || failedMessage.resolved" @click="showDeleteConfirm = true"><i class="fa fa-trash"></i> Delete message</button>
                 <button type="button" class="btn btn-default" v-if="failedMessage.archived" @click="showRestoreConfirm = true"><i class="fa fa-undo"></i> Restore</button>
                 <button type="button" class="btn btn-default" :disabled="failedMessage.retried || failedMessage.archived || failedMessage.resolved" @click="showRetryConfirm = true"><i class="fa fa-refresh"></i> Retry message</button>
-                <button type="button" class="btn btn-default" v-if="failedMessage.isEditAndRetryEnabled" @click="showEditAndRetryModal()"><i class="fa fa-pencil"></i> Edit & retry</button>
+                <button type="button" class="btn btn-default" v-if="failedMessage.isEditAndRetryEnabled" :disabled="failedMessage.retried || failedMessage.archived || failedMessage.resolved"  @click="showEditAndRetryModal()"><i class="fa fa-pencil"></i> Edit & retry</button>
                 <button type="button" class="btn btn-default" @click="debugInServiceInsight()" title="Browse this message in ServiceInsight, if installed"><img src="@/assets/si-icon.svg" /> View in ServiceInsight</button>
                 <button type="button" class="btn btn-default" v-if="!failedMessage.notFound && !failedMessage.error" @click="exportMessage()"><i class="fa fa-download"></i> Export message</button>
               </div>


### PR DESCRIPTION

- Original Issue: https://github.com/Particular/ServicePulse/issues/1526
- Internal issue: https://github.com/Particular/PlatformBugs/issues/1224

This PR disables the "Edit & Retry" button on a failed message that has already been edited and retried.
