### PR TITLE
add trailing slash to monitoring url

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
@@ -42,7 +42,12 @@ function testServiceControlUrl(event) {
 
 function testMonitoringUrl(event) {
   if (event) {
-    testingMonitoring.value = true;
+      testingMonitoring.value = true;
+
+      if (!monitoringUrl.value.endsWith("/") && monitoringUrl.value !== "!") {
+          monitoringUrl.value += "/";
+      }
+
     return fetch(monitoringUrl.value + "monitored-endpoints")
       .then((response) => {
         monitoringValid.value = response.ok && response.headers.has("X-Particular-Version");

--- a/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
@@ -106,7 +106,7 @@ function saveConnections(event) {
                 <div class="col-7 form-group">
                   <label for="monitoringUrl"
                     >CONNECTION URL
-                    <span class="auxilliary-label">(OPTIONAL)</span>
+                      <span class="auxilliary-label">(OPTIONAL) ( Enter ! to disable monitoring)</span>
                     <template v-if="monitoringConnectionState.unableToConnect && !useIsMonitoringDisabled()">
                       <span class="failed-validation"> <i class="fa fa-exclamation-triangle"></i> Unable to connect </span>
                     </template>


### PR DESCRIPTION
This PR fixes [Connection test fails if the url does not end with a slash  #1469](https://github.com/Particular/ServicePulse/issues/1469)