### PR TITLE
Enabling vscode interactive debugger from multiple folders

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,31 +1,34 @@
 {
     "version": "0.2.0",
-    "configurations": [
+    "configurations": [     
       {
         "name": "Debug Vue on Docker Port - Edge",
         "type": "msedge",
         "request": "launch",
         "url": "http://localhost:1331",
-        "webRoot": "${workspaceFolder}/src",        
+        "webRoot": "${workspaceFolder}/src/ServicePulse.Host/vue/src",
       },
       {
         "name": "Debug Vue on Docker Port - Chrome",
         "type": "chrome",
         "request": "launch",
         "url": "http://localhost:1331",
-        "webRoot": "${workspaceFolder}/src",        
-      },      
+        "webRoot": "${workspaceFolder}/src/ServicePulse.Host/vue/src",
+      }, 
       {
         "name": "Storybook Debug with Edge",
         "type": "node-terminal",
         "request": "launch",
         "command": "npm run storybook-dont-auto-open",
-        "cwd": "${workspaceFolder}",        
-        "internalConsoleOptions": "openOnFirstSessionStart",
+        "cwd": "${workspaceFolder}/src/ServicePulse.Host/vue",        
+        "internalConsoleOptions": "openOnFirstSessionStart",        
+        "sourceMaps": true,        
         "serverReadyAction": {
           "pattern": "Local:.+(https?://[^:]+:[0-9]+)",
           "uriFormat": "%s",
-          "action": "debugWithEdge"
+          "action":"debugWithEdge",
+          "webRoot": "${workspaceFolder}/src/ServicePulse.Host/vue",
+          "killOnServerStop": true
         }
       },
       {
@@ -33,14 +36,14 @@
         "type": "node-terminal",
         "request": "launch",
         "command": "npm run storybook-dont-auto-open",
-        "cwd": "${workspaceFolder}",        
+        "cwd": "${workspaceFolder}/src/ServicePulse.Host/vue",        
         "internalConsoleOptions": "openOnFirstSessionStart",        
         "sourceMaps": true,        
         "serverReadyAction": {
           "pattern": "Local:.+(https?://[^:]+:[0-9]+)",
           "uriFormat": "%s",
           "action":"debugWithChrome",
-          "webRoot": "${workspaceFolder}",
+          "webRoot": "${workspaceFolder}/src/ServicePulse.Host/vue",
           "killOnServerStop": true
         }
       }

--- a/src/ServicePulse.Host/.vscode/launch.json
+++ b/src/ServicePulse.Host/.vscode/launch.json
@@ -6,34 +6,34 @@
         "type": "msedge",
         "request": "launch",
         "url": "http://localhost:1331",
-        "webRoot": "${workspaceFolder}/src",        
+        "webRoot": "${workspaceFolder}/vue/src",        
       },
       {
         "name": "Debug Vue on Docker Port - Chrome",
         "type": "chrome",
         "request": "launch",
         "url": "http://localhost:1331",
-        "webRoot": "${workspaceFolder}/src",        
+        "webRoot": "${workspaceFolder}/vue/src",        
       },      
       {
         "name": "Storybook Debug with Edge",
         "type": "node-terminal",
         "request": "launch",
         "command": "npm run storybook-dont-auto-open",
-        "cwd": "${workspaceFolder}",        
+        "cwd": "${workspaceFolder}/vue",        
         "internalConsoleOptions": "openOnFirstSessionStart",
         "serverReadyAction": {
           "pattern": "Local:.+(https?://[^:]+:[0-9]+)",
           "uriFormat": "%s",
           "action": "debugWithEdge"
         }
-      },
+      },      
       {
         "name": "Storybook Debug with Chrome",
         "type": "node-terminal",
         "request": "launch",
         "command": "npm run storybook-dont-auto-open",
-        "cwd": "${workspaceFolder}",        
+        "cwd": "${workspaceFolder}/vue",        
         "internalConsoleOptions": "openOnFirstSessionStart",        
         "sourceMaps": true,        
         "serverReadyAction": {

--- a/src/ServicePulse.Host/vue/package.json
+++ b/src/ServicePulse.Host/vue/package.json
@@ -9,7 +9,8 @@
     "preview": "npm run lint && vite preview",
     "test:unit": "npm run lint && vitest --environment jsdom --root src/",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006",    
+    "storybook-dont-auto-open": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook"
   },


### PR DESCRIPTION
Adding vscode configurations for interactive debugging.

Debugging configurations are available when vscode is opened from any of the following locations:

- the repo root
- src/ServicePulse.Host
- src/ServicePulse.Host/vue