### PR TITLE
Enable css sourcemaps

### DIFF
--- a/src/ServicePulse.Host/vue/vite.config.js
+++ b/src/ServicePulse.Host/vue/vite.config.js
@@ -8,6 +8,9 @@ const __dirname = path.dirname(__filename);
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  css:{
+    devSourcemap:true
+  },
   plugins: [
     vue(),
     {


### PR DESCRIPTION
While using the browser DevTools to inspect CSS, it is only possible to know what file a style is coming from if source maps files are enabled for development.