### PR TITLE
Simplify EndpointList component HTML and CSS 

### DIFF
--- a/src/ServicePulse.Host/vue/src/assets/main.css
+++ b/src/ServicePulse.Host/vue/src/assets/main.css
@@ -4040,13 +4040,19 @@ div.alert.alert-warning strong {
     text-transform: uppercase;
     color: #181919;
 }
-
-.table-col {
-    width: 16%;
-}
-
 .table-first-col {
     width: 20%;
     padding-left: 15px;
     padding-right: 15px;
+}
+.table-col {
+    width: 16%;
+}
+@media only screen and (min-width: 1730px) {
+    .table-first-col {
+        width: 30%;
+    }
+    .table-col {
+        width: 14%;
+    }
 }

--- a/src/ServicePulse.Host/vue/src/assets/main.css
+++ b/src/ServicePulse.Host/vue/src/assets/main.css
@@ -1807,13 +1807,6 @@ hr.top-separator {
     border-color: #00A3C4;
 }
 
-.table-head-row {
-    font-size: 12px;
-    text-transform: uppercase;
-    color: #181919;
-    padding-bottom: 5px;
-}
-
   .table-head-row p {
       font-size: 12px;
       text-transform: uppercase;
@@ -4031,4 +4024,29 @@ div.alert.alert-warning strong {
 
 .tooltip {
   font-size: 12px;
+}
+
+
+
+/* Endpoint graph table*/
+
+.table-head-row {
+    display: flex;
+    padding-bottom: 5px;
+    padding-top: 20px;
+    border-bottom: 1px solid #ced6d3;
+    border-top: 1px solid #eee;
+    font-size: 12px;
+    text-transform: uppercase;
+    color: #181919;
+}
+
+.table-col {
+    width: 16%;
+}
+
+.table-first-col {
+    width: 20%;
+    padding-left: 15px;
+    padding-right: 15px;
 }

--- a/src/ServicePulse.Host/vue/src/assets/main.css
+++ b/src/ServicePulse.Host/vue/src/assets/main.css
@@ -1704,12 +1704,6 @@ hr.top-separator {
     margin-left: 0.5%;
 }
 
-.endpoint-row {
-    height: 61px;
-    position: relative;
-    padding: 2px 0 4px;
-}
-
 .endpoint-row .graphicon {
     top: 14px;
     left: 120px;
@@ -4055,4 +4049,15 @@ div.alert.alert-warning strong {
     .table-col {
         width: 14%;
     }
+}
+.endpoint-row {
+    display: flex;
+    height: 61px;
+    position: relative;
+    padding: 2px 0 4px;
+    border-top: 1px solid #eee;
+    border-right: 1px solid #fff;
+    border-bottom: 1px solid #eee;
+    border-left: 1px solid #fff;
+    background-color: #FFF;
 }

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
@@ -123,22 +123,22 @@ function formatGraphDecimal(input, deci) {
 
     <!--Table headings-->
     <div v-if="endpoints && endpoints.length > 0" class="row box box-no-click table-head-row">
-      <div class="col-xs-2 col-xl-7">
+      <div class="col-xl-7">
         <endpoint-list-sortable-column>Endpoint name</endpoint-list-sortable-column>
       </div>
-      <div class="col-xs-2 col-xl-1 no-side-padding">
+      <div class="col-xl-1 no-side-padding">
         <endpoint-list-sortable-column v-tooltip title="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint.">Queue Length<template #unit>(MSGS)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xs-2 col-xl-1 no-side-padding">
+      <div class="col-xl-1 no-side-padding">
         <endpoint-list-sortable-column v-tooltip title="Throughput: The number of messages per second successfully processed by a receiving endpoint.">Throughput<template #unit>(msgs/s)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xs-2 col-xl-1 no-side-padding">
+      <div class="col-xl-1 no-side-padding">
         <endpoint-list-sortable-column v-tooltip title="Scheduled retries: The number of messages per second scheduled for retries (immediate or delayed).">Scheduled retries <template #unit>(msgs/s)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xs-2 col-xl-1 no-side-padding">
+      <div class="col-xl-1 no-side-padding">
         <endpoint-list-sortable-column v-tooltip title="Processing time: The time taken for a receiving endpoint to successfully process a message."> Processing Time <template #unit>(t)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xs-2 col-xl-1 no-side-padding">
+      <div class="col-xl-1 no-side-padding">
         <endpoint-list-sortable-column v-tooltip title="Critical time: The elapsed time from when a message was sent, until it was successfully processed by a receiving endpoint."> Critical Time <template #unit>(t)</template></endpoint-list-sortable-column>
       </div>
     </div>
@@ -150,7 +150,7 @@ function formatGraphDecimal(input, deci) {
         <div class="row box endpoint-row" v-for="(endpoint, index) in endpoints" :key="index" v-show="endpoints.length" v-on:mouseenter="endpoint.hover1 = true" v-on:mouseleave="endpoint.hover1 = false">
           <div class="col-xs-12 no-side-padding">
             <div class="row">
-              <div class="col-xs-2 col-xl-7 endpoint-name name-overview">
+              <div class="col-xl-7 endpoint-name name-overview">
                 <div class="box-header">
                   <div class="col-lg-max-8 no-side-padding lead righ-side-ellipsis endpoint-details-link">
                     <a @click="navigateToEndpointDetails($event, endpoint.name)" class="cursorpointer" v-tooltip :title="endpoint.name">
@@ -178,7 +178,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Queue Length-->
-              <div class="col-xs-2 col-xl-1 no-side-padding">
+              <div class="col-xl-1 no-side-padding">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'queue-length'"></EndpointGraph>-->
@@ -192,7 +192,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Throughput-->
-              <div class="col-xs-2 col-xl-1 no-side-padding">
+              <div class="col-xl-1 no-side-padding">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'throughput'"></EndpointGraph>-->
@@ -206,7 +206,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Scheduled Retries-->
-              <div class="col-xs-2 col-xl-1 no-side-padding">
+              <div class="col-xl-1 no-side-padding">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'retries'"></EndpointGraph>-->
@@ -220,7 +220,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Processing Time-->
-              <div class="col-xs-2 col-xl-1 no-side-padding">
+              <div class="col-xl-1 no-side-padding">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'processing-time'"></EndpointGraph>-->
@@ -235,7 +235,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Critical Time-->
-              <div class="col-xs-2 col-xl-1 no-side-padding">
+              <div class="col-xl-1 no-side-padding">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'critical-time'"></EndpointGraph>-->

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
@@ -122,23 +122,23 @@ function formatGraphDecimal(input, deci) {
     </div>
 
     <!--Table headings-->
-    <div v-if="endpoints && endpoints.length > 0" class="row box box-no-click table-head-row">
-      <div class="col-xl-7">
+    <div v-if="endpoints && endpoints.length > 0" class="table-head-row">
+      <div class="table-first-col">
         <endpoint-list-sortable-column>Endpoint name</endpoint-list-sortable-column>
       </div>
-      <div class="col-xl-1 no-side-padding">
+      <div class="table-col">
         <endpoint-list-sortable-column v-tooltip title="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint.">Queue Length<template #unit>(MSGS)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xl-1 no-side-padding">
+      <div class="table-col">
         <endpoint-list-sortable-column v-tooltip title="Throughput: The number of messages per second successfully processed by a receiving endpoint.">Throughput<template #unit>(msgs/s)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xl-1 no-side-padding">
+      <div class="table-col">
         <endpoint-list-sortable-column v-tooltip title="Scheduled retries: The number of messages per second scheduled for retries (immediate or delayed).">Scheduled retries <template #unit>(msgs/s)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xl-1 no-side-padding">
+      <div class="table-col">
         <endpoint-list-sortable-column v-tooltip title="Processing time: The time taken for a receiving endpoint to successfully process a message."> Processing Time <template #unit>(t)</template></endpoint-list-sortable-column>
       </div>
-      <div class="col-xl-1 no-side-padding">
+      <div class="table-col">
         <endpoint-list-sortable-column v-tooltip title="Critical time: The elapsed time from when a message was sent, until it was successfully processed by a receiving endpoint."> Critical Time <template #unit>(t)</template></endpoint-list-sortable-column>
       </div>
     </div>

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
@@ -146,9 +146,8 @@ function formatGraphDecimal(input, deci) {
     <!--endpointlist-->
     <div>
         <!-- end ngRepeat: endpoint in endpoints | filter: filter | orderBy: order.expression -->
-        <div class="box endpoint-row" v-for="(endpoint, index) in endpoints" :key="index" v-show="endpoints.length" v-on:mouseenter="endpoint.hover1 = true" v-on:mouseleave="endpoint.hover1 = false">
-            <div class="row">
-              <div class="col-xl-7 endpoint-name name-overview">
+        <div class="endpoint-row" v-for="(endpoint, index) in endpoints" :key="index" v-show="endpoints.length" v-on:mouseenter="endpoint.hover1 = true" v-on:mouseleave="endpoint.hover1 = false">
+              <div class="table-first-col endpoint-name name-overview">
                 <div class="box-header">
                   <div class="col-lg-max-8 no-side-padding lead righ-side-ellipsis endpoint-details-link">
                     <a @click="navigateToEndpointDetails($event, endpoint.name)" class="cursorpointer" v-tooltip :title="endpoint.name">
@@ -176,7 +175,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Queue Length-->
-              <div class="col-xl-1 no-side-padding">
+              <div class="table-col">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'queue-length'"></EndpointGraph>-->
@@ -190,7 +189,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Throughput-->
-              <div class="col-xl-1 no-side-padding">
+              <div class="table-col">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'throughput'"></EndpointGraph>-->
@@ -204,7 +203,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Scheduled Retries-->
-              <div class="col-xl-1 no-side-padding">
+              <div class="table-col">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'retries'"></EndpointGraph>-->
@@ -218,7 +217,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Processing Time-->
-              <div class="col-xl-1 no-side-padding">
+              <div class="table-col">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'processing-time'"></EndpointGraph>-->
@@ -233,7 +232,7 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
               <!--Critical Time-->
-              <div class="col-xl-1 no-side-padding">
+              <div class="table-col">
                 <div class="box-header">
                     <div class="no-side-padding">
                         <!--<EndpointGraph :type="'critical-time'"></EndpointGraph>-->
@@ -247,7 +246,7 @@ function formatGraphDecimal(input, deci) {
                   </div>
                 </div>
               </div>
-            </div>
+
 
         </div>
 

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
@@ -144,11 +144,9 @@ function formatGraphDecimal(input, deci) {
     </div>
 
     <!--endpointlist-->
-    <div class="row">
-      <div class="col-xs-12 no-side-padding">
+    <div>
         <!-- end ngRepeat: endpoint in endpoints | filter: filter | orderBy: order.expression -->
-        <div class="row box endpoint-row" v-for="(endpoint, index) in endpoints" :key="index" v-show="endpoints.length" v-on:mouseenter="endpoint.hover1 = true" v-on:mouseleave="endpoint.hover1 = false">
-          <div class="col-xs-12 no-side-padding">
+        <div class="box endpoint-row" v-for="(endpoint, index) in endpoints" :key="index" v-show="endpoints.length" v-on:mouseenter="endpoint.hover1 = true" v-on:mouseleave="endpoint.hover1 = false">
             <div class="row">
               <div class="col-xl-7 endpoint-name name-overview">
                 <div class="box-header">
@@ -250,9 +248,9 @@ function formatGraphDecimal(input, deci) {
                 </div>
               </div>
             </div>
-          </div>
+
         </div>
-      </div>
+
     </div>
   </section>
 </template>


### PR DESCRIPTION
Simplify the HTML used for the layout of the EndpointList component and its related CSS classes. 

Instead of using Bootstrap and creating other classes to overwrite some unwanted styles from Bootstrap, let's use "new/clean" classes that do the same work but with less code.