### PR TITLE
Endpoint details pinia store

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
@@ -9,7 +9,7 @@ import { useGetDefaultPeriod } from "../../composables/serviceHistoryPeriods.js"
 import { useFormatTime, useFormatLargeNumber } from "../../composables/formatter.js";
 import { licenseStatus } from "../../composables/serviceLicense.js";
 import { useFetchFromMonitoring, useIsMonitoringDisabled, useDeleteFromMonitoring, useOptionsFromMonitoring } from "../../composables/serviceServiceControlUrls";
-import { useGetExceptionGroupsForEndpoint } from "../../composables/serviceMessageGroup.js";
+//stores
 import { useMonitoringStore } from "../../stores/MonitoringStore";
 import { useFailedMessageStore } from "../../stores/FailedMessageStore";
 // Components
@@ -84,7 +84,7 @@ async function getEndpointDetails() {
   }
 }
 
-function updateUI() {
+async function updateUI() {
   isLoading.value = false;
 
   if (endpoint.value.error) {
@@ -123,8 +123,7 @@ function updateUI() {
 
     endpoint.value.instances.forEach(async function (instance) {
       //get errror count by instance id
-
-        await failedMessageStore.getFailedMessagesList(instance.id);
+        await failedMessageStore.getFailedMessagesList("Endpoint Instance",instance.id);
         if (!failedMessageStore.isFailedMessagesEmpty) {
             instance.serviceControlId = failedMessageStore.serviceControlId;
             instance.errorCount = failedMessageStore.errorCount;
@@ -137,12 +136,12 @@ function updateUI() {
     loadedSuccessfully.value = true;
   }
   //get errror count by endpoint name
-  useGetExceptionGroupsForEndpoint("Endpoint Name", endpointName).then((result) => {
-    if (result.length > 0) {
-      endpoint.value.serviceControlId = result[0].id;
-      endpoint.value.errorCount = result[0].count;
+    await failedMessageStore.getFailedMessagesList("Endpoint Name", endpointName);
+    if (!failedMessageStore.isFailedMessagesEmpty) {
+        endpoint.value.serviceControlId = failedMessageStore.serviceControlId;
+        endpoint.value.errorCount = failedMessageStore.errorCount;
     }
-  });
+
 }
 
 function filterOutSystemMessage(data) {
@@ -196,7 +195,6 @@ function getDisconnectedCount() {
   var checkInterval;
   return useFetchFromMonitoring(`${`monitored-endpoints`}/disconnected`)
     .then((response) => {
-      //console.log(response);
       disconnectedCount = response.data;
     })
     .catch((err) => {

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
@@ -70,43 +70,15 @@ async function getEndpointDetails() {
   var selectedHistoryPeriod = historyPeriod.value.pVal;
     if (!useIsMonitoringDisabled() && !monitoringConnectionState.unableToConnect) {
     await monitoringStore.getEndpointDetails(endpointName, selectedHistoryPeriod);
-        var response = monitoringStore.endpointDetails;
-    if (response.status === 404) {
-      endpoint.value = { notFound: true };
-    } else if (response.status !== 200) {
-      endpoint.value = { error: true };
-    } else {
-      var data = response.json();
-      if (!data) {
-        filterOutSystemMessage(data);
-        var endpointDetails = data;
+    var responseData = monitoringStore.endpointDetails;
+    if (responseData !=null ) {
+        filterOutSystemMessage(responseData);
+        var endpointDetails = responseData;
         endpointDetails.isScMonitoringDisconnected = false;
         endpointDetails.isStale = true;
         Object.assign(endpoint.value, endpointDetails);
         updateUI();
-      }
     }
-    //return useFetchFromMonitoring(`${`monitored-endpoints`}/${endpointName}?history=${selectedHistoryPeriod}`)
-    //.then((response) => {
-    //  if (response.status === 404) {
-    //    endpoint.value = { notFound: true };
-    //  } else if (response.status !== 200) {
-    //    endpoint.value = { error: true };
-    //  }
-    //  return response.json();
-    //})
-    //.then((data) => {
-    //  filterOutSystemMessage(data);
-    //  var endpointDetails = data;
-    //  endpointDetails.isScMonitoringDisconnected = false;
-    //  endpointDetails.isStale = true;
-    //  Object.assign(endpoint.value, endpointDetails);
-    //  return updateUI();
-    //})
-    //.catch((err) => {
-    //  console.log(err);
-    //  return { error: err };
-    //});
   }
 }
 

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
@@ -79,7 +79,7 @@ async function getEndpointDetails() {
         endpointDetails.isScMonitoringDisconnected = false;
         endpointDetails.isStale = true;
         Object.assign(endpoint.value, endpointDetails);
-        updateUI();
+       await updateUI();
     }
   }
 }

--- a/src/ServicePulse.Host/vue/src/composables/serviceMonitoringEndpoints.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceMonitoringEndpoints.js
@@ -72,6 +72,24 @@ export function useGroupEndpoints(endpoints, numberOfSegments) {
   return [...groups.values()];
 }
 
+/**
+ * @param {string}  - the endpoint name whose details is needed
+ * @param {Number} - The history period value.  The default is (1)
+ * @returns {object} - The details of the endpoint
+ */
+export async function useGetEndpointDetails(endpointName, historyPeriod=1) {
+    const endpointDetails = ref({});
+    if (!useIsMonitoringDisabled() && !monitoringConnectionState.unableToConnect) {
+        try {
+            const response = await useFetchFromMonitoring(`${`monitored-endpoints`}/${endpointName}?history=${historyPeriod}`);
+            const data = await response.json();
+            endpointDetails.value = data;
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return endpointDetails.value;
+}
 async function addEndpointsFromScSubscription(endpoints) {
   const exceptionGroups = await useGetExceptionGroups("Endpoint Name");
 

--- a/src/ServicePulse.Host/vue/src/composables/serviceMonitoringEndpoints.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceMonitoringEndpoints.js
@@ -98,12 +98,12 @@ export async function useGetDisconnectedEndpointCount() {
     var disconnectedCount = 0;
         try {
             const response = await useFetchFromMonitoring(`${`monitored-endpoints`}/disconnected`);
-            disconnectedCount = response.data
+            disconnectedCount = response.data;
         } catch (error) {
             console.error(error);
         }
-    
-    return endpointDetails.value;
+
+    return disconnectedCount;
 }
 async function addEndpointsFromScSubscription(endpoints) {
   const exceptionGroups = await useGetExceptionGroups("Endpoint Name");

--- a/src/ServicePulse.Host/vue/src/composables/serviceMonitoringEndpoints.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceMonitoringEndpoints.js
@@ -90,6 +90,21 @@ export async function useGetEndpointDetails(endpointName, historyPeriod=1) {
     }
     return endpointDetails.value;
 }
+
+/**
+ * @returns {Number} - The count of disconnected endpoint
+ */
+export async function useGetDisconnectedEndpointCount() {
+    var disconnectedCount = 0;
+        try {
+            const response = await useFetchFromMonitoring(`${`monitored-endpoints`}/disconnected`);
+            disconnectedCount = response.data
+        } catch (error) {
+            console.error(error);
+        }
+    
+    return endpointDetails.value;
+}
 async function addEndpointsFromScSubscription(endpoints) {
   const exceptionGroups = await useGetExceptionGroups("Endpoint Name");
 

--- a/src/ServicePulse.Host/vue/src/stores/FailedMessageStore.js
+++ b/src/ServicePulse.Host/vue/src/stores/FailedMessageStore.js
@@ -9,12 +9,12 @@ export const useFailedMessageStore = defineStore("FailedMessageStore", {
   },
   actions: {
       async getFailedMessagesList(instanceId) {
-          this.failedMessagesList = await useGetExceptionGroupsForEndpoint(instanceId);
+          this.failedMessagesList = await useGetExceptionGroupsForEndpoint("Endpoint Instance", instanceId);
     }
   },
   getters: {
       serviceControlId: (state) => state.failedMessagesList[0].id,
-      errorCount: (state) => state.failedMessagesList[0].length,
-      isFailedMessagesEmpty: (state) => state.failedMessagesListCount === 0,
+      errorCount: (state) => state.failedMessagesList[0].count,
+      isFailedMessagesEmpty: (state) => state.errorCount === 0,
   },
 });

--- a/src/ServicePulse.Host/vue/src/stores/FailedMessageStore.js
+++ b/src/ServicePulse.Host/vue/src/stores/FailedMessageStore.js
@@ -1,0 +1,20 @@
+import { defineStore } from "pinia";
+import { useGetExceptionGroupsForEndpoint } from "../composables/serviceMessageGroup.js";
+
+export const useFailedMessageStore = defineStore("FailedMessageStore", {
+  state: () => {
+    return {
+      failedMessagesList: [],
+    };
+  },
+  actions: {
+      async getFailedMessagesList(instanceId) {
+          this.failedMessagesList = await useGetExceptionGroupsForEndpoint(instanceId);
+    }
+  },
+  getters: {
+      serviceControlId: (state) => state.failedMessagesList[0].id,
+      errorCount: (state) => state.failedMessagesList[0].length,
+      isFailedMessagesEmpty: (state) => state.failedMessagesListCount === 0,
+  },
+});

--- a/src/ServicePulse.Host/vue/src/stores/FailedMessageStore.js
+++ b/src/ServicePulse.Host/vue/src/stores/FailedMessageStore.js
@@ -8,9 +8,9 @@ export const useFailedMessageStore = defineStore("FailedMessageStore", {
     };
   },
   actions: {
-      async getFailedMessagesList(instanceId) {
-          this.failedMessagesList = await useGetExceptionGroupsForEndpoint("Endpoint Instance", instanceId);
-    }
+      async getFailedMessagesList(classifier, classiferFilter) {
+          this.failedMessagesList = await useGetExceptionGroupsForEndpoint(classifier, classiferFilter);
+      },
   },
   getters: {
       serviceControlId: (state) => state.failedMessagesList[0].id,

--- a/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
+++ b/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
@@ -1,21 +1,25 @@
 import { defineStore } from "pinia";
-import { useGetAllMonitoredEndpoints, useGetEndpointDetails } from "../composables/serviceMonitoringEndpoints";
+import { useGetAllMonitoredEndpoints, useGetEndpointDetails, useGetDisconnectedEndpointCount } from "../composables/serviceMonitoringEndpoints";
 
 
 export const useMonitoringStore = defineStore("MonitoringStore", {
   state: () => {
     return {
       endpointList: [],
-      endpointDetails: {},
+        endpointDetails: {},
+        disconnectedEndpointCount: 0,
     };
   },
   actions: {
     async updateEndpointList(historyPeriod) {
-          this.endpointList = await useGetAllMonitoredEndpoints(historyPeriod);
+        this.endpointList = await useGetAllMonitoredEndpoints(historyPeriod);
     },
     async getEndpointDetails(endpointName, historyPeriod) {
         this.endpointDetails = await useGetEndpointDetails(endpointName, historyPeriod);
-    },
+      },
+    async getDisconnectedEndpointCount() {
+        this.disconnectedEndpointCount = await useGetDisconnectedEndpointCount();
+      },
   },
   getters: {
     endpointListCount: (state) => state.endpointList.length,

--- a/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
+++ b/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
-import { useGetAllMonitoredEndpoints } from "../composables/serviceMonitoringEndpoints";
-import { useFetchFromMonitoring } from "../composables/serviceServiceControlUrls";
+import { useGetAllMonitoredEndpoints, useGetEndpointDetails } from "../composables/serviceMonitoringEndpoints";
+
 
 export const useMonitoringStore = defineStore("MonitoringStore", {
   state: () => {
@@ -11,10 +11,10 @@ export const useMonitoringStore = defineStore("MonitoringStore", {
   },
   actions: {
     async updateEndpointList(historyPeriod) {
-      this.endpointList = await useGetAllMonitoredEndpoints(historyPeriod);
+          this.endpointList = await useGetAllMonitoredEndpoints(historyPeriod);
     },
     async getEndpointDetails(endpointName, historyPeriod) {
-        this.endpointDetails = await useFetchFromMonitoring(`${`monitored-endpoints`}/${endpointName}?history=${historyPeriod}`);
+        this.endpointDetails = await useGetEndpointDetails(endpointName, historyPeriod);
     },
   },
   getters: {

--- a/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
+++ b/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
@@ -1,13 +1,20 @@
 import { defineStore } from "pinia";
 import { useGetAllMonitoredEndpoints } from "../composables/serviceMonitoringEndpoints";
+import { useFetchFromMonitoring } from "../composables/serviceServiceControlUrls";
 
 export const useMonitoringStore = defineStore("MonitoringStore", {
   state: () => {
-    return { endpointList: [] };
+    return {
+      endpointList: [],
+      endpointDetails: {},
+    };
   },
   actions: {
     async updateEndpointList(historyPeriod) {
       this.endpointList = await useGetAllMonitoredEndpoints(historyPeriod);
+    },
+    async getEndpointDetails(endpointName, historyPeriod) {
+        this.endpointDetails = await useFetchFromMonitoring(`${`monitored-endpoints`}/${endpointName}?history=${historyPeriod}`);
     },
   },
   getters: {


### PR DESCRIPTION
Add Pinia store to the endpoint details page in order to retrieve the following 
- Endpoint details
- Failed messages count 

The PR also has added the option to retrieve the disconnected endpoint count 