### PR TITLE
SPIKE: change fontawesome from v4.4 to v6

### DIFF
--- a/src/ServicePulse.Host/vue/package-lock.json
+++ b/src/ServicePulse.Host/vue/package-lock.json
@@ -8,6 +8,10 @@
       "name": "service-pulse",
       "version": "1.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-regular-svg-icons": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/vue-fontawesome": "^3.0.5",
         "bootstrap": "^5.2.0",
         "bootstrap-icons": "^1.10.3",
         "d3": "^7.6.1",
@@ -66,6 +70,60 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.5.tgz",
+      "integrity": "sha512-isZZ4+utQH9qg9cWxWYHQ9GwI3r5FeO7GnmzKYV+gbjxcptQhh+F99iZXi1Y9AvFUEgy8kRpAdvDlbb3drWFrw==",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4285,6 +4343,41 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
+    "@fortawesome/vue-fontawesome": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.5.tgz",
+      "integrity": "sha512-isZZ4+utQH9qg9cWxWYHQ9GwI3r5FeO7GnmzKYV+gbjxcptQhh+F99iZXi1Y9AvFUEgy8kRpAdvDlbb3drWFrw==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/src/ServicePulse.Host/vue/package.json
+++ b/src/ServicePulse.Host/vue/package.json
@@ -11,6 +11,10 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/vue-fontawesome": "^3.0.5",
     "bootstrap": "^5.2.0",
     "bootstrap-icons": "^1.10.3",
     "d3": "^7.6.1",

--- a/src/ServicePulse.Host/vue/src/components/PageFooter.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageFooter.vue
@@ -21,14 +21,15 @@ const scMonitoringAddressTooltip = computed(() => {
     <div class="container">
       <div class="row">
         <div class="connectivity-status">
-          <span>
-            <i class="fa fa-plus sp-blue"></i>
+          <span class="secondary">
+            <font-awesome-icon icon="fa-solid fa-plus" class="sp-blue" />
             <RouterLink :to="{ name: 'endpoint-connection' }">Connect new endpoint</RouterLink>
           </span>
 
           <span v-if="!newVersions.newSPVersion.newspversion && environment.sp_version"> ServicePulse v{{ environment.sp_version }} </span>
           <span v-if="newVersions.newSPVersion.newspversion && environment.sp_version">
-            ServicePulse v{{ environment.sp_version }} (<i v-if="newVersions.newSPVersion.newspversionnumber" class="fa fa-level-up fake-link"></i> <a :href="newVersions.newSPVersion.newspversionlink" target="_blank">v{{ newVersions.newSPVersion.newspversionnumber }} available</a>)
+            ServicePulse v{{ environment.sp_version }} (<font-awesome-icon v-if="newVersions.newSPVersion.newspversionnumber" icon="fa-solid fa-level-up" class="fake-link" />
+            <a :href="newVersions.newSPVersion.newspversionlink" target="_blank">v{{ newVersions.newSPVersion.newspversionnumber }} available</a>)
           </span>
           <span :title="scAddressTooltip">
             Service Control:
@@ -37,11 +38,12 @@ const scMonitoringAddressTooltip = computed(() => {
               <span v-if="!environment.sc_version">Connected</span>
               <span v-if="environment.sc_version" class="versionnumber">v{{ environment.sc_version }}</span>
               <span v-if="newVersions.newSCVersion.newscversion" class="newscversion"
-                >(<i class="fa fa-level-up fake-link"></i> <a :href="newVersions.newSCVersion.newscversionlink" target="_blank">v{{ newVersions.newSCVersion.newscversionnumber }} available</a>)</span
+                >(<font-awesome-icon icon="fa-solid fa-level-up" class="fake-link" />
+                <a :href="newVersions.newSCVersion.newscversionlink" target="_blank">v{{ newVersions.newSCVersion.newscversionnumber }} available</a>)</span
               >
             </span>
             <span v-if="!connectionState.connected && !connectionState.connecting" class="connection-failed"> <i class="fa pa-connection-failed"></i> Not connected </span>
-            <span v-if="connectionState.connecting" class="connection-establishing"> <i class="fa pa-connection-establishing"></i> Connecting </span>
+            <span v-if="connectionState.connecting" class="connection-establishing"> <i class="pa-connection-establishing"></i> Connecting </span>
           </span>
 
           <template v-if="isMonitoringEnabled">
@@ -55,7 +57,7 @@ const scMonitoringAddressTooltip = computed(() => {
                 >
               </span>
               <span v-if="!monitoringConnectionState.connected && !monitoringConnectionState.connecting" class="connection-failed"> <i class="fa pa-connection-failed"></i> Not connected </span>
-              <span v-if="monitoringConnectionState.connecting" class="connection-establishing"> <i class="fa pa-connection-establishing"></i> Connecting </span>
+              <span v-if="monitoringConnectionState.connecting" class="connection-establishing"> <i class="pa-connection-establishing"></i> Connecting </span>
             </span>
           </template>
         </div>

--- a/src/ServicePulse.Host/vue/src/main.js
+++ b/src/ServicePulse.Host/vue/src/main.js
@@ -6,10 +6,17 @@ import "vue-toastification/dist/index.css";
 import SimpleTypeahead from "vue3-simple-typeahead";
 import "vue3-simple-typeahead/dist/vue3-simple-typeahead.css"; //Optional default CSS
 import "./assets/main.css";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faPlus, faLevelUp } from "@fortawesome/free-solid-svg-icons";
+
+//Add font-awesome icons that will be used in the solution
+library.add(faPlus, faLevelUp);
 
 const app = createApp(App);
 
 app.use(router);
+app.component("font-awesome-icon", FontAwesomeIcon);
 const toastOptions = {
   position: POSITION.BOTTOM_RIGHT,
   timeout: 5000,


### PR DESCRIPTION
v4.4 of fontawesome requires the entire css and fontset to be delivered with the bundled code on every page load. v6 allows us to only take the icons that are actually being used, and also delivers them as SVG.

This PR starts on the conversion (converting the footer icons, not the header icons or any others) as a pattern to follow.

The downside of this change is that the icons will change look slightly, which won't be reflected in the angularJS pages
v4.4
![image](https://github.com/Particular/ServicePulse/assets/155411597/1f527e76-e924-4ad5-944d-ef70e0c54896)

v6 (lack of padding needs to be fixed)
![image](https://github.com/Particular/ServicePulse/assets/155411597/e1f79f7d-290a-4d6c-acb5-cb6cb92b6d96)

