### PR TITLE
Fix header change actions

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/failedmessages/EditMessageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/EditMessageHeader.vue
@@ -49,10 +49,10 @@ onMounted(() => {
     <input :class="{ 'header-removed': header.isMarkedAsRemoved }" class="form-control" :disabled="header.isLocked" v-model="header.value" />
   </td>
   <td>
-    <a v-if="!header.isLocked && !header.isMarkedAsRemoved" href="#" @click="markHeaderAsRemoved()">
+    <a v-if="!header.isLocked && !header.isMarkedAsRemoved" @click="markHeaderAsRemoved()">
       <i class="fa fa-trash" tooltip="Protected system header"></i>
     </a>
-    <a v-if="header.isChanged" href="#" @click="resetHeaderChanges()">
+    <a v-if="header.isChanged" @click="resetHeaderChanges()">
       <i class="fa fa-undo" tooltip="Protected system header"></i>
     </a>
   </td>


### PR DESCRIPTION
## Symptoms

When the [edit and retry](https://docs.particular.net/servicepulse/intro-editing-messages) functionality is enabled, clicking the button to delete or reset a header navigates to the dashboard. This prevents the user from completing the retry operation.

## Root cause

The actions are anchor tags which had an `href="#"` attribute. With the href in place the browser navigates away from the modal. This can also be solved with `.prevent` event modifiers but the href is not needed.