### PR TITLE
Removing .js from imports

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
@@ -1,7 +1,7 @@
 ﻿<script setup>
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
-import { getEventLogItems } from "../composables/eventLogItems.js";
+import { getEventLogItems } from "../composables/eventLogItems";
 import TimeSince from "./TimeSince.vue";
 
 const router = useRouter();

--- a/src/ServicePulse.Host/vue/src/components/LicenseExpired.vue
+++ b/src/ServicePulse.Host/vue/src/components/LicenseExpired.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { licenseStatus } from "./../composables/serviceLicense.js";
+import { licenseStatus } from "./../composables/serviceLicense";
 </script>
 
 <template>

--- a/src/ServicePulse.Host/vue/src/components/PageFooter.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageFooter.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from "vue";
-import { environment, newVersions, connectionState, monitoringConnectionState } from "../composables/serviceServiceControl.js";
-import { serviceControlUrl, monitoringUrl } from "../composables/serviceServiceControlUrls.js";
+import { environment, newVersions, connectionState, monitoringConnectionState } from "../composables/serviceServiceControl";
+import { serviceControlUrl, monitoringUrl } from "../composables/serviceServiceControlUrls";
 
 const isMonitoringEnabled = computed(() => {
   return monitoringUrl.value !== "!" && monitoringUrl.value !== "" && monitoringUrl.value !== null && monitoringUrl.value !== undefined;

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { RouterLink, useRoute } from "vue-router";
 import { computed } from "vue";
-import { stats, connectionState, monitoringConnectionState } from "../composables/serviceServiceControl.js";
+import { stats, connectionState, monitoringConnectionState } from "../composables/serviceServiceControl";
 import { useIsMonitoringEnabled } from "../composables/serviceServiceControlUrls";
-import { licenseStatus } from "./../composables/serviceLicense.js";
+import { licenseStatus } from "./../composables/serviceLicense";
 import ExclamationMark from "./ExclamationMark.vue";
 
 const baseUrl = window.defaultConfig.base_url;

--- a/src/ServicePulse.Host/vue/src/components/configuration/EndpointConnection.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/EndpointConnection.vue
@@ -2,8 +2,8 @@
 import { ref, onMounted } from "vue";
 import LicenseExpired from "../LicenseExpired.vue";
 import ServiceControlNotAvailable from "../ServiceControlNotAvailable.vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
-import { useServiceControlConnections, connectionState } from "../../composables/serviceServiceControl.js";
+import { licenseStatus } from "../../composables/serviceLicense";
+import { useServiceControlConnections, connectionState } from "../../composables/serviceServiceControl";
 import BusyIndicator from "../BusyIndicator.vue";
 import { HighCode } from "vue-highlight-code";
 import "vue-highlight-code/dist/style.css";
@@ -26,7 +26,7 @@ const queryErrors = ref([]);
 async function getCode() {
   loading.value = true;
 
-  var snippetTemplate = `var servicePlatformConnection = ServicePlatformConnectionConfiguration.Parse(@"<json>");
+  const snippetTemplate = `var servicePlatformConnection = ServicePlatformConnectionConfiguration.Parse(@"<json>");
 
     endpointConfiguration.ConnectToServicePlatform(servicePlatformConnection);
     `;
@@ -42,7 +42,7 @@ endpointConfiguration.ConnectToServicePlatform(servicePlatformConnection);
     errorQueue: connections.serviceControl.settings.ErrorQueue,
     metrics: connections.monitoring.settings,
   };
-  var jsonText = JSON.stringify(config, null, 4);
+  let jsonText = JSON.stringify(config, null, 4);
   jsonConfig.value = jsonText;
 
   jsonText = jsonText.replaceAll('"', '""');

--- a/src/ServicePulse.Host/vue/src/components/configuration/HealthCheckNotifications.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/HealthCheckNotifications.vue
@@ -2,11 +2,11 @@
 import { ref, onMounted } from "vue";
 import LicenseExpired from "../LicenseExpired.vue";
 import ServiceControlNotAvailable from "../ServiceControlNotAvailable.vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
+import { licenseStatus } from "../../composables/serviceLicense";
 import { connectionState } from "../../composables/serviceServiceControl";
 import HealthCheckNotifications_EmailConfiguration from "./HealthCheckNotifications_ConfigureEmail.vue";
-import { useEmailNotifications, useUpdateEmailNotifications, useTestEmailNotifications, useToggleEmailNotifications } from "../../composables/serviceNotifications.js";
-import { useShowToast } from "../../composables/toast.js";
+import { useEmailNotifications, useUpdateEmailNotifications, useTestEmailNotifications, useToggleEmailNotifications } from "../../composables/serviceNotifications";
+import { useShowToast } from "../../composables/toast";
 
 // This is needed because the ConfigurationView.vue routerView expects this event.
 // The event is only actually emitted on the RetryRedirects.vue component

--- a/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { ref } from "vue";
 import LicenseExpired from "../LicenseExpired.vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
-import { updateServiceControlUrls, serviceControlUrl as configuredServiceControlUrl, monitoringUrl as configuredMonitoringUrl, useIsMonitoringDisabled } from "./../../composables/serviceServiceControlUrls.js";
+import { licenseStatus } from "../../composables/serviceLicense";
+import { updateServiceControlUrls, serviceControlUrl as configuredServiceControlUrl, monitoringUrl as configuredMonitoringUrl, useIsMonitoringDisabled } from "./../../composables/serviceServiceControlUrls";
 import { connectionState, monitoringConnectionState } from "../../composables/serviceServiceControl";
 
 // This is needed because the ConfigurationView.vue routerView expects this event.

--- a/src/ServicePulse.Host/vue/src/components/configuration/PlatformLicense.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/PlatformLicense.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from "vue";
-import { license, licenseStatus } from "./../../composables/serviceLicense.js";
+import { license, licenseStatus } from "./../../composables/serviceLicense";
 import ServiceControlNotAvailable from "../ServiceControlNotAvailable.vue";
 import { connectionState } from "../../composables/serviceServiceControl";
 import BusyIndicator from "../BusyIndicator.vue";

--- a/src/ServicePulse.Host/vue/src/components/configuration/RetryRedirects.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/RetryRedirects.vue
@@ -1,15 +1,15 @@
 <script setup>
 import { ref, reactive, onMounted } from "vue";
 import LicenseExpired from "../LicenseExpired.vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
+import { licenseStatus } from "../../composables/serviceLicense";
 import ServiceControlNotAvailable from "../ServiceControlNotAvailable.vue";
 import { connectionState } from "../../composables/serviceServiceControl";
 import RetryRedirectEdit from "./RetryRedirectEdit.vue";
 import NoData from "../NoData.vue";
 import BusyIndicator from "../BusyIndicator.vue";
-import { useShowToast } from "../../composables/toast.js";
+import { useShowToast } from "../../composables/toast";
 import TimeSince from "../TimeSince.vue";
-import { useRedirects, useUpdateRedirects, useCreateRedirects, useDeleteRedirects, useRetryPendingMessagesForQueue } from "../../composables/serviceRedirects.js";
+import { useRedirects, useUpdateRedirects, useCreateRedirects, useDeleteRedirects, useRetryPendingMessagesForQueue } from "../../composables/serviceRedirects";
 import ConfirmDialog from "../ConfirmDialog.vue";
 
 const isExpired = licenseStatus.isExpired;

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/AllDeletedMessages.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/AllDeletedMessages.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { ref, onBeforeMount, onMounted, onUnmounted } from "vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
-import { connectionState } from "../../composables/serviceServiceControl.js";
-import { useFetchFromServiceControl, usePatchToServiceControl } from "../../composables/serviceServiceControlUrls.js";
-import { useShowToast } from "../../composables/toast.js";
+import { licenseStatus } from "../../composables/serviceLicense";
+import { connectionState } from "../../composables/serviceServiceControl";
+import { useFetchFromServiceControl, usePatchToServiceControl } from "../../composables/serviceServiceControlUrls";
+import { useShowToast } from "../../composables/toast";
 import { useRoute, onBeforeRouteLeave } from "vue-router";
 import { useCookies } from "vue3-cookies";
 import LicenseExpired from "../../components/LicenseExpired.vue";
@@ -31,7 +31,7 @@ const periodOptions = ["All Deleted", "Deleted in the last 2 Hours", "Deleted in
 
 function loadMessages() {
   let startDate = new Date(0);
-  let endDate = new Date();
+  const endDate = new Date();
 
   switch (selectedPeriod.value) {
     case "All Deleted":
@@ -66,7 +66,7 @@ function loadPagedMessages(groupId, page, sortBy, direction, startDate, endDate)
   if (typeof page === "undefined") page = 1;
   if (typeof startDate === "undefined") startDate = new Date(0).toISOString();
   if (typeof endDate === "undefined") endDate = new Date().toISOString();
-  let dateRange = startDate + "..." + endDate;
+  const dateRange = startDate + "..." + endDate;
   let loadGroupDetailsPromise;
   if (groupId && !groupName.value) {
     loadGroupDetailsPromise = loadGroupDetails(groupId);
@@ -97,7 +97,7 @@ function loadPagedMessages(groupId, page, sortBy, direction, startDate, endDate)
       messages.value = updateMessagesScheduledDeletionDate(data);
     } catch (err) {
       console.log(err);
-      var result = {
+      const result = {
         message: "error",
       };
       return result;
@@ -117,7 +117,7 @@ function updateMessagesScheduledDeletionDate(messages) {
   //check deletion time
   messages.forEach((message) => {
     message.error_retention_period = moment.duration(configuration.value.data_retention.error_retention_period).asHours();
-    var countdown = moment(message.last_modified).add(message.error_retention_period, "hours");
+    const countdown = moment(message.last_modified).add(message.error_retention_period, "hours");
     message.delete_soon = countdown < moment();
     message.deleted_in = countdown.format();
   });

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/AllFailedMessages.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from "vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
-import { connectionState } from "../../composables/serviceServiceControl.js";
-import { useFetchFromServiceControl, usePatchToServiceControl } from "../../composables/serviceServiceControlUrls.js";
-import { useShowToast } from "../../composables/toast.js";
+import { licenseStatus } from "../../composables/serviceLicense";
+import { connectionState } from "../../composables/serviceServiceControl";
+import { useFetchFromServiceControl, usePatchToServiceControl } from "../../composables/serviceServiceControlUrls";
+import { useShowToast } from "../../composables/toast";
 import { useRetryMessages } from "../../composables/serviceFailedMessage";
 import { useDownloadFile } from "../../composables/fileDownloadCreator";
 import { useRoute, onBeforeRouteLeave } from "vue-router";
@@ -93,7 +93,7 @@ function loadPagedMessages(groupId, page, sortBy, direction) {
       messages.value = data;
     } catch (err) {
       console.log(err);
-      var result = {
+      const result = {
         message: "error",
       };
       return result;
@@ -147,7 +147,7 @@ function exportSelected() {
     let d = {};
 
     if (type == "array" || type == "object") {
-      for (let i in obj) {
+      for (const i in obj) {
         const newD = parseObject(obj[i], propertiesToSkip, path + i + ".");
         d = Object.assign(d, newD);
       }
@@ -167,12 +167,12 @@ function exportSelected() {
   const selectedMessages = messageList.value.getSelectedMessages();
   const propertiesToSkip = ["hover", "selected", "hover2", "$$hashKey", "panel", "edit_of", "edited"];
 
-  var preparedMessagesForExport = [];
-  for (var i = 0; i < selectedMessages.length; i++) {
+  const preparedMessagesForExport = [];
+  for (let i = 0; i < selectedMessages.length; i++) {
     preparedMessagesForExport.push(parseObject(selectedMessages[i], propertiesToSkip));
   }
 
-  var csvStr = toCSV(preparedMessagesForExport);
+  const csvStr = toCSV(preparedMessagesForExport);
   useDownloadFile(csvStr, "text/csv", "failedMessages.csv");
 }
 

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/DeletedMessageGroups.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/DeletedMessageGroups.vue
@@ -1,10 +1,10 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { licenseStatus } from "../../composables/serviceLicense.js";
-import { stats, connectionState } from "../../composables/serviceServiceControl.js";
-import { useShowToast } from "../../composables/toast.js";
-import { useGetArchiveGroups, useRestoreGroup } from "../../composables/serviceMessageGroup.js";
+import { licenseStatus } from "../../composables/serviceLicense";
+import { stats, connectionState } from "../../composables/serviceServiceControl";
+import { useShowToast } from "../../composables/toast";
+import { useGetArchiveGroups, useRestoreGroup } from "../../composables/serviceMessageGroup";
 import { useFetchFromServiceControl } from "../../composables/serviceServiceControlUrls";
 import { useCookies } from "vue3-cookies";
 import NoData from "../NoData.vue";
@@ -65,7 +65,7 @@ async function getArchiveGroups(classifier) {
   let maxIndex = archiveGroups.value.reduce((currentMax, currentGroup) => Math.max(currentMax, currentGroup.index), 0);
 
   result.forEach((serverGroup) => {
-    let previousGroup = archiveGroups.value.find((oldGroup) => oldGroup.id == serverGroup.id);
+    const previousGroup = archiveGroups.value.find((oldGroup) => oldGroup.id == serverGroup.id);
 
     if (previousGroup) {
       serverGroup.index = previousGroup.index;
@@ -96,7 +96,7 @@ async function getArchiveGroups(classifier) {
 }
 
 function initializeGroupState(group) {
-  var operationStatus = (group.operation_status ? group.operation_status.toLowerCase() : null) || "none";
+  let operationStatus = (group.operation_status ? group.operation_status.toLowerCase() : null) || "none";
   if (operationStatus === "preparing" && group.operation_progress === 1) {
     operationStatus = "queued";
   }
@@ -107,7 +107,7 @@ function initializeGroupState(group) {
 
 function loadDefaultGroupingClassifier() {
   const cookies = useCookies().cookies;
-  let cookieGrouping = cookies.get("archived_groups_classification");
+  const cookieGrouping = cookies.get("archived_groups_classification");
 
   if (cookieGrouping) {
     return cookieGrouping;
@@ -171,15 +171,15 @@ async function restoreGroup() {
   }
 }
 
-var statusesForRestoreOperation = ["restorestarted", "restoreprogressing", "restorefinalizing", "restorecompleted"];
+const statusesForRestoreOperation = ["restorestarted", "restoreprogressing", "restorefinalizing", "restorecompleted"];
 function getClassesForRestoreOperation(stepStatus, currentStatus) {
   return getClasses(stepStatus, currentStatus, statusesForRestoreOperation);
 }
 
 //getClasses
 var getClasses = function (stepStatus, currentStatus, statusArray) {
-  var indexOfStep = statusArray.indexOf(stepStatus);
-  var indexOfCurrent = statusArray.indexOf(currentStatus);
+  const indexOfStep = statusArray.indexOf(stepStatus);
+  const indexOfCurrent = statusArray.indexOf(currentStatus);
   if (indexOfStep > indexOfCurrent) {
     return "left-to-do";
   } else if (indexOfStep === indexOfCurrent) {
@@ -189,7 +189,7 @@ var getClasses = function (stepStatus, currentStatus, statusArray) {
   return "completed";
 };
 
-var acknowledgeGroup = function (dismissedGroup) {
+const acknowledgeGroup = function (dismissedGroup) {
   undismissedRestoreGroups.value.splice(
     undismissedRestoreGroups.value.findIndex((group) => {
       return group.id === dismissedGroup.id;

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessageGroups.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessageGroups.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted } from "vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
-import { connectionState } from "../../composables/serviceServiceControl.js";
+import { licenseStatus } from "../../composables/serviceLicense";
+import { connectionState } from "../../composables/serviceServiceControl";
 import { useFetchFromServiceControl } from "../../composables/serviceServiceControlUrls";
 import { useCookies } from "vue3-cookies";
 import LicenseExpired from "../../components/LicenseExpired.vue";
@@ -80,7 +80,7 @@ function classifierChanged(classifier) {
 
 function loadDefaultGroupingClassifier() {
   const cookies = useCookies().cookies;
-  let cookieGrouping = cookies.get("failed_groups_classification");
+  const cookieGrouping = cookies.get("failed_groups_classification");
 
   if (cookieGrouping) {
     return cookieGrouping;

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
-import { stats } from "../../composables/serviceServiceControl.js";
-import { useShowToast } from "../../composables/toast.js";
-import { useDeleteNote, useEditOrCreateNote, useGetExceptionGroups, useArchiveExceptionGroup, useAcknowledgeArchiveGroup, useRetryExceptionGroup } from "../../composables/serviceMessageGroup.js";
+import { stats } from "../../composables/serviceServiceControl";
+import { useShowToast } from "../../composables/toast";
+import { useDeleteNote, useEditOrCreateNote, useGetExceptionGroups, useArchiveExceptionGroup, useAcknowledgeArchiveGroup, useRetryExceptionGroup } from "../../composables/serviceMessageGroup";
 import NoData from "../NoData.vue";
 import TimeSince from "../TimeSince.vue";
 import FailedMessageGroupNoteEdit from "./FailedMessageGroupNoteEdit.vue";
@@ -70,7 +70,7 @@ async function getExceptionGroups(classifier) {
 function initializeGroupState(group, index) {
   group.index = index;
 
-  var operationStatus = (group.operation_status ? group.operation_status.toLowerCase() : null) || "none";
+  let operationStatus = (group.operation_status ? group.operation_status.toLowerCase() : null) || "none";
   if (operationStatus === "preparing" && group.operation_progress === 1) {
     operationStatus = "queued";
   }
@@ -152,7 +152,7 @@ function editNote(group) {
 }
 
 //delete a group
-var statusesForArchiveOperation = ["archivestarted", "archiveprogressing", "archivefinalizing", "archivecompleted"];
+const statusesForArchiveOperation = ["archivestarted", "archiveprogressing", "archivefinalizing", "archivecompleted"];
 function deleteGroup(group) {
   groupDeleteSuccessful.value = null;
   selectedGroup.value.groupid = group.id;
@@ -219,7 +219,7 @@ async function saveRetryGroup(group) {
   }
 }
 
-var statusesForRetryOperation = ["waiting", "preparing", "queued", "forwarding"];
+const statusesForRetryOperation = ["waiting", "preparing", "queued", "forwarding"];
 function getClassesForRetryOperation(stepStatus, currentStatus) {
   if (currentStatus === "queued") {
     currentStatus = "forwarding";
@@ -229,8 +229,8 @@ function getClassesForRetryOperation(stepStatus, currentStatus) {
 
 //getClasses
 var getClasses = function (stepStatus, currentStatus, statusArray) {
-  var indexOfStep = statusArray.indexOf(stepStatus);
-  var indexOfCurrent = statusArray.indexOf(currentStatus);
+  const indexOfStep = statusArray.indexOf(stepStatus);
+  const indexOfCurrent = statusArray.indexOf(currentStatus);
   if (indexOfStep > indexOfCurrent) {
     return "left-to-do";
   } else if (indexOfStep === indexOfCurrent) {
@@ -240,7 +240,7 @@ var getClasses = function (stepStatus, currentStatus, statusArray) {
   }
 };
 
-var acknowledgeGroup = async function (group) {
+const acknowledgeGroup = async function (group) {
   const result = await useAcknowledgeArchiveGroup(group.id);
   if (result.message === "success") {
     if (group.operation_status === "ArchiveCompleted") {

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
@@ -5,7 +5,7 @@ import { useFetchFromServiceControl } from "../../composables/serviceServiceCont
 import { useUnarchiveMessage, useArchiveMessage, useRetryMessages } from "../../composables/serviceFailedMessage";
 import { useServiceControlUrls } from "../../composables/serviceServiceControlUrls";
 import { useDownloadFile } from "../../composables/fileDownloadCreator";
-import { useShowToast } from "../../composables/toast.js";
+import { useShowToast } from "../../composables/toast";
 import NoData from "../NoData.vue";
 import TimeSince from "../TimeSince.vue";
 import moment from "moment";
@@ -15,7 +15,7 @@ import EditRetryDialog from "./EditRetryDialog.vue";
 
 let refreshInterval = undefined;
 let pollingFaster = false;
-let panel = ref();
+const panel = ref();
 const route = useRoute();
 const failedMessage = ref({});
 const configuration = ref([]);
@@ -37,7 +37,7 @@ async function loadFailedMessage() {
       failedMessage.value = { error: true };
     }
     const data = await response.json();
-    var message = data;
+    const message = data;
     message.archived = message.status === "archived";
     message.resolved = message.status === "resolved";
     message.retried = message.status === "retryIssued";
@@ -78,7 +78,7 @@ async function getEditAndRetryConfig() {
 }
 
 function updateMessageDeleteDate() {
-  var countdown = moment(failedMessage.value.last_modified).add(failedMessage.value.error_retention_period, "hours");
+  const countdown = moment(failedMessage.value.last_modified).add(failedMessage.value.error_retention_period, "hours");
   failedMessage.value.delete_soon = countdown < moment();
   failedMessage.value.deleted_in = countdown.format();
 }
@@ -136,7 +136,7 @@ async function downloadHeadersAndBody() {
       return;
     }
 
-    var message = data[0];
+    const message = data[0];
     failedMessage.value.headers = message.headers;
     failedMessage.value.conversationId = message.headers.find((header) => header.key === "NServiceBus.ConversationId").value;
 
@@ -191,7 +191,7 @@ function formatXml(xml) {
       }
     }
 
-    let shift = ["\n"]; // array of shifts
+    const shift = ["\n"]; // array of shifts
 
     for (let ix = 0; ix < 100; ix++) {
       shift.push(shift[ix] + space);
@@ -202,7 +202,7 @@ function formatXml(xml) {
 
   const indent = "\t";
 
-  let arr = xml
+  const arr = xml
     .replace(/>\s*</gm, "><")
     .replace(/</g, "~::~<")
     .replace(/\s*xmlns([=:])/g, "~::~xmlns$1")
@@ -291,7 +291,7 @@ function exportMessage() {
   txtStr += failedMessage.value.exception.stack_trace;
 
   txtStr += "\n\nHEADERS";
-  for (var i = 0; i < failedMessage.value.headers.length; i++) {
+  for (let i = 0; i < failedMessage.value.headers.length; i++) {
     txtStr += "\n" + failedMessage.value.headers[i].key + ": " + failedMessage.value.headers[i].value;
   }
 

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/PendingRetries.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/PendingRetries.vue
@@ -1,10 +1,10 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from "vue";
-import { licenseStatus } from "../../composables/serviceLicense.js";
-import { connectionState } from "../../composables/serviceServiceControl.js";
+import { licenseStatus } from "../../composables/serviceLicense";
+import { connectionState } from "../../composables/serviceServiceControl";
 import { useEndpoints } from "../../composables/serviceEndpoints";
-import { useFetchFromServiceControl, usePostToServiceControl, usePatchToServiceControl } from "../../composables/serviceServiceControlUrls.js";
-import { useShowToast } from "../../composables/toast.js";
+import { useFetchFromServiceControl, usePostToServiceControl, usePatchToServiceControl } from "../../composables/serviceServiceControlUrls";
+import { useShowToast } from "../../composables/toast";
 import { useCookies } from "vue3-cookies";
 import OrderBy from "./OrderBy.vue";
 import LicenseExpired from "../../components/LicenseExpired.vue";
@@ -66,7 +66,7 @@ function clearSelectedQueue() {
 
 function loadPendingRetryMessages() {
   let startDate = new Date(0);
-  let endDate = new Date();
+  const endDate = new Date();
 
   switch (selectedPeriod.value) {
     case "Retried in the last 2 Hours":
@@ -118,7 +118,7 @@ async function loadPagedPendingRetryMessages(page, sortBy, direction, searchPhra
     messages.value = data;
   } catch (err) {
     console.log(err);
-    var result = {
+    const result = {
       message: "error",
     };
     return result;

--- a/src/ServicePulse.Host/vue/src/composables/serviceLicense.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceLicense.js
@@ -1,7 +1,7 @@
 import { reactive, computed, watch } from "vue";
 import { useGetDayDiffFromToday } from "./formatter";
 import { useFetchFromServiceControl } from "./serviceServiceControlUrls";
-import { useShowToast } from "./toast.js";
+import { useShowToast } from "./toast";
 
 const subscriptionExpiring =
   '<div class="license-warning"><strong>Platform license expires soon</strong><div>Once the license expires you\'ll no longer be able to continue using the Particular Service Platform.</div><a href="#/configuration" class="btn btn-license-warning">View license details</a></div>';

--- a/src/ServicePulse.Host/vue/src/composables/serviceMessageGroup.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceMessageGroup.js
@@ -1,4 +1,4 @@
-import { useDeleteFromServiceControl, usePostToServiceControl, useFetchFromServiceControl } from "./serviceServiceControlUrls.js";
+import { useDeleteFromServiceControl, usePostToServiceControl, useFetchFromServiceControl } from "./serviceServiceControlUrls";
 
 export async function useGetExceptionGroups(classifier) {
   try {
@@ -7,7 +7,7 @@ export async function useGetExceptionGroups(classifier) {
     return data;
   } catch (err) {
     console.log(err);
-    var result = {
+    const result = {
       message: "error",
     };
     return result;
@@ -22,7 +22,7 @@ export async function useGetArchiveGroups(classifier) {
     return data;
   } catch (err) {
     console.log(err);
-    var result = {
+    const result = {
       message: "error",
     };
     return result;

--- a/src/ServicePulse.Host/vue/src/composables/serviceRedirects.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceRedirects.js
@@ -1,4 +1,4 @@
-import { useFetchFromServiceControl, useDeleteFromServiceControl, usePutToServiceControl, usePostToServiceControl } from "./serviceServiceControlUrls.js";
+import { useFetchFromServiceControl, useDeleteFromServiceControl, usePutToServiceControl, usePostToServiceControl } from "./serviceServiceControlUrls";
 
 const redirects = {
   data: [],
@@ -37,7 +37,7 @@ async function getRedirects() {
 export async function useRetryPendingMessagesForQueue(queueName) {
   try {
     const response = await usePostToServiceControl("errors/queues/" + queueName + "/retry");
-    var result = {
+    const result = {
       message: response.ok ? "success" : "error:" + response.statusText,
       status: response.status,
       statusText: response.statusText,
@@ -45,7 +45,7 @@ export async function useRetryPendingMessagesForQueue(queueName) {
     return result;
   } catch (err) {
     console.log(err);
-    var result_1 = {
+    const result_1 = {
       message: "error",
     };
     return result_1;
@@ -59,7 +59,7 @@ export async function useUpdateRedirects(redirectId, sourceEndpoint, targetEndpo
       fromphysicaladdress: sourceEndpoint,
       tophysicaladdress: targetEndpoint,
     });
-    var result = {
+    const result = {
       message: response.ok ? "success" : "error:" + response.statusText,
       status: response.status,
       statusText: response.statusText,
@@ -68,7 +68,7 @@ export async function useUpdateRedirects(redirectId, sourceEndpoint, targetEndpo
     return result;
   } catch (err) {
     console.log(err);
-    var result_1 = {
+    const result_1 = {
       message: "error",
     };
     return result_1;
@@ -81,7 +81,7 @@ export async function useCreateRedirects(sourceEndpoint, targetEndpoint) {
       fromphysicaladdress: sourceEndpoint,
       tophysicaladdress: targetEndpoint,
     });
-    var result = {
+    const result = {
       message: response.ok ? "success" : "error:" + response.statusText,
       status: response.status,
       statusText: response.statusText,
@@ -90,7 +90,7 @@ export async function useCreateRedirects(sourceEndpoint, targetEndpoint) {
     return result;
   } catch (err) {
     console.log(err);
-    var result_1 = {
+    const result_1 = {
       message: "error",
     };
     return result_1;
@@ -100,7 +100,7 @@ export async function useCreateRedirects(sourceEndpoint, targetEndpoint) {
 export async function useDeleteRedirects(redirectId) {
   try {
     const response = await useDeleteFromServiceControl("redirects/" + redirectId);
-    var result = {
+    const result = {
       message: response.ok ? "success" : "error:" + response.statusText,
       status: response.status,
       statusText: response.statusText,
@@ -109,7 +109,7 @@ export async function useDeleteRedirects(redirectId) {
     return result;
   } catch (err) {
     console.log(err);
-    var result_1 = {
+    const result_1 = {
       message: "error",
     };
     return result_1;

--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControl.js
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControl.js
@@ -1,8 +1,8 @@
 import { reactive, onMounted, watch, computed } from "vue";
 import { useIsSupported, useIsUpgradeAvailable } from "./serviceSemVer";
-import { useServiceProductUrls } from "./serviceProductUrls.js";
+import { useServiceProductUrls } from "./serviceProductUrls";
 import { useFetchFromServiceControl, useFetchFromMonitoring, serviceControlUrl, monitoringUrl, useIsMonitoringDisabled } from "./serviceServiceControlUrls";
-import { useShowToast } from "./toast.js";
+import { useShowToast } from "./toast";
 
 export const stats = reactive({
   active_endpoints: 0,

--- a/src/ServicePulse.Host/vue/src/views/ConfigurationView.vue
+++ b/src/ServicePulse.Host/vue/src/views/ConfigurationView.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { ref, onMounted } from "vue";
-import { licenseStatus } from "../composables/serviceLicense.js";
+import { licenseStatus } from "../composables/serviceLicense";
 import { connectionState, monitoringConnectionState } from "../composables/serviceServiceControl";
 import { useIsMonitoringEnabled } from "../composables/serviceServiceControlUrls";
-import { useRedirects } from "../composables/serviceRedirects.js";
+import { useRedirects } from "../composables/serviceRedirects";
 import ExclamationMark from "../components/ExclamationMark.vue";
 
 const redirectCount = ref(0);

--- a/src/ServicePulse.Host/vue/src/views/DashboardView.vue
+++ b/src/ServicePulse.Host/vue/src/views/DashboardView.vue
@@ -4,7 +4,7 @@ import EventItemShort from "../components/EventItemShort.vue";
 import LicenseExpired from "../components/LicenseExpired.vue";
 import ServiceControlNotAvailable from "../components/ServiceControlNotAvailable.vue";
 import { connectionState, stats } from "../composables/serviceServiceControl";
-import { licenseStatus } from "./../composables/serviceLicense.js";
+import { licenseStatus } from "./../composables/serviceLicense";
 </script>
 
 <template>

--- a/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
+++ b/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { RouterLink, useRoute } from "vue-router";
-import { licenseStatus } from "./../composables/serviceLicense.js";
+import { licenseStatus } from "./../composables/serviceLicense";
 import { stats, connectionState } from "../composables/serviceServiceControl";
 import { RouterView } from "vue-router";
 import LicenseExpired from "../components/LicenseExpired.vue";


### PR DESCRIPTION
This is quite a few files, but is just removing the `.js` from the imports, so that once we rename the files to `.ts` we don't need to revisit these imports.