### PR TITLE
Fixed issues found in 1.38.0 smoke test

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -6,6 +6,7 @@ import { useIsMonitoringEnabled } from "../composables/serviceServiceControlUrls
 import { licenseStatus } from "../composables/serviceLicense";
 import ExclamationMark from "./ExclamationMark.vue";
 import { LicenseWarningLevel } from "@/composables/LicenseStatus";
+import { WarningLevel } from "@/components/WarningLevel";
 
 const baseUrl = window.defaultConfig.base_url;
 

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessageGroups.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessageGroups.vue
@@ -144,3 +144,16 @@ onMounted(async () => {
     </template>
   </template>
 </template>
+
+<style>
+.lead {
+  word-wrap: break-word;
+  color: #181919 !important;
+  font-size: 1em !important;
+  font-weight: bold !important;
+  margin-bottom: 0.2em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/FlowDiagram.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/FlowDiagram.vue
@@ -227,17 +227,6 @@ function typeIcon(type) {
   text-align: left;
 }
 
-.lead {
-  word-wrap: break-word;
-  color: #181919 !important;
-  font-size: 1em !important;
-  font-weight: bold !important;
-  margin-bottom: 0.2em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .node {
   background-color: #fff;
   border-color: #cccbcc;

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
@@ -504,4 +504,15 @@ button img {
 .msg-tabs {
   margin-bottom: 20px;
 }
+
+.lead {
+  word-wrap: break-word;
+  color: #181919 !important;
+  font-size: 1em !important;
+  font-weight: bold !important;
+  margin-bottom: 0.2em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 </style>

--- a/src/ServicePulse.Host/vue/vite.config.ts
+++ b/src/ServicePulse.Host/vue/vite.config.ts
@@ -23,8 +23,7 @@ function createCSPOverrides(hostPort: number, configuredDestinations: string[]) 
 const port = 5173;
 const defaultUrls = [
   "http://10.211.55.3:*", // The default Parallels url to access Windows VM
-  "http://localhost:33333", // Default SC Error instance
-  "http://localhost:33633"  // Default SC Monitoring instance
+  "http://localhost:*",
 ];
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
Fixed applied after smoke testing 1.38.0

- Configuration tab disappears when license warning is rendered
- Content Security Policy is too restrictive
- Failed Message titles are not bolded