### PR TITLE
Temporarily remove storybook from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,3 @@ jobs:
       - name: Run Javascript tests
         run: npm run test-firefox-ci
         working-directory: src/ServicePulse.Host.Tests
-      - name: Install Playwright
-        run: npx playwright install --with-deps
-        working-directory: src/ServicePulse.Host/vue
-      - name: Build Storybook
-        run: npm run build-storybook --quiet
-        working-directory: src/ServicePulse.Host/vue
-      - name: Serve Storybook and run tests
-        working-directory: src/ServicePulse.Host/vue
-        run: npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" "npx http-server storybook-static --port 6006 --silent" "npx wait-on tcp:6006 && npm run test-storybook"


### PR DESCRIPTION
This PR is removing storybook from the CI in order to not hold up other PRs

There will be another PR dedicated to storybook addressing the following:

- Introduction of Pinia 
- Stories will be reviewed/re-wired for all the applicable components
- Upgrad storybook the the latest version

 