### PR TITLE
Extracting mounting of the app into a function

### DIFF
--- a/src/ServicePulse.Host/vue/src/main.ts
+++ b/src/ServicePulse.Host/vue/src/main.ts
@@ -1,43 +1,7 @@
-import { createApp } from "vue";
-import { Tooltip } from "bootstrap";
-import { createPinia } from "pinia";
-import App from "./App.vue";
-import router from "./router";
-import SimpleTypeahead from "vue3-simple-typeahead";
-import Toast, { type PluginOptions, POSITION } from "vue-toastification";
+import makeRouter from "./router";
+import { mount } from "./mount";
 import "vue-toastification/dist/index.css";
 import "vue3-simple-typeahead/dist/vue3-simple-typeahead.css"; //Optional default CSS
 import "./assets/main.css";
 
-const app = createApp(App);
-
-const toastOptions: PluginOptions = {
-  position: POSITION.BOTTOM_RIGHT,
-  timeout: 5000,
-  transition: "Vue-Toastification__fade",
-  hideProgressBar: true,
-  containerClassName: "toast-container",
-  toastClassName: "vue-toast",
-  closeButtonClassName: "toast-close-button",
-};
-
-app.config.errorHandler = (err, instance, info) => {
-  console.error(instance, err);
-};
-
-app
-  .use(router)
-  .use(Toast, toastOptions)
-  .use(SimpleTypeahead)
-  .use(createPinia())
-  // make v-tooltip available in all components
-  .directive("tooltip", {
-    mounted: (el) => {
-      const tooltip = new Tooltip(el, { trigger: "hover" });
-      el.tooltip = tooltip;
-    },
-    beforeUnmount: (el) => {
-      el.tooltip.hide();
-    },
-  })
-  .mount("#app");
+mount({ router: makeRouter() });

--- a/src/ServicePulse.Host/vue/src/mount.ts
+++ b/src/ServicePulse.Host/vue/src/mount.ts
@@ -1,0 +1,46 @@
+import { createApp } from "vue";
+import type { Router } from "vue-router";
+import App from "./App.vue";
+import Toast, { type PluginOptions, POSITION } from "vue-toastification";
+import { Tooltip } from "bootstrap";
+import { createPinia } from "pinia";
+import SimpleTypeahead from "vue3-simple-typeahead";
+
+const toastOptions: PluginOptions = {
+  position: POSITION.BOTTOM_RIGHT,
+  timeout: 5000,
+  transition: "Vue-Toastification__fade",
+  hideProgressBar: true,
+  containerClassName: "toast-container",
+  toastClassName: "vue-toast",
+  closeButtonClassName: "toast-close-button",
+};
+
+export function mount({ router }: { router: Router }): void {
+  router.beforeEach((to, _from, next) => {
+    document.title = to.meta.title || "ServicePulse";
+    next();
+  });
+
+  const app = createApp(App);
+  app
+    .use(router)
+    .use(Toast, toastOptions)
+    .use(SimpleTypeahead)
+    .use(createPinia())
+    // make v-tooltip available in all components
+    .directive("tooltip", {
+      mounted: (el) => {
+        const tooltip = new Tooltip(el, { trigger: "hover" });
+        el.tooltip = tooltip;
+      },
+      beforeUnmount: (el) => {
+        el.tooltip.hide();
+      },
+    });
+  app.mount(`#app`);
+
+  app.config.errorHandler = (err, instance, info) => {
+    console.error(instance, err);
+  };
+}

--- a/src/ServicePulse.Host/vue/src/router/index.ts
+++ b/src/ServicePulse.Host/vue/src/router/index.ts
@@ -5,138 +5,135 @@ import FailedMessagesView from "@/views/FailedMessagesView.vue";
 import EventsView from "@/views/EventsView.vue";
 import ConfigurationView from "@/views/ConfigurationView.vue";
 
-const router = createRouter({
-  history: createWebHashHistory(window.defaultConfig.base_url),
-  routes: [
-    {
-      path: "/dashboard",
-      name: "dashboard",
-      component: DashboardView,
-      meta: {
-        title: "Dashboard • ServicePulse",
+const routes = [
+  {
+    path: "/dashboard",
+    name: "dashboard",
+    component: DashboardView,
+    meta: {
+      title: "Dashboard • ServicePulse",
+    },
+  },
+  {
+    path: "/",
+    redirect: "/dashboard",
+  },
+  {
+    path: "/monitoring",
+    name: "monitoring",
+    component: MonitoringView,
+    meta: {
+      title: "Monitored Endpoints • ServicePulse",
+    },
+  },
+  {
+    path: "/monitoring/endpoint/:endpointName",
+    name: "endpoint-details",
+    component: () => import("@/components/monitoring/EndpointDetails.vue"),
+    meta: {
+      title: "Endpoints Details • ServicePulse",
+    },
+  },
+  {
+    path: "/failed-messages",
+    component: FailedMessagesView,
+    meta: {
+      title: "Failed Messages • ServicePulse",
+    },
+    children: [
+      {
+        name: "failed-messages",
+        path: "",
+        component: () => import("@/components/failedmessages/FailedMessageGroups.vue"),
       },
-    },
-    {
-      path: "/",
-      redirect: "/dashboard",
-    },
-    {
-      path: "/monitoring",
-      name: "monitoring",
-      component: MonitoringView,
-      meta: {
-        title: "Monitored Endpoints • ServicePulse",
+      {
+        path: "all-failed-messages",
+        component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
       },
-    },
-    {
-      path: "/monitoring/endpoint/:endpointName",
-      name: "endpoint-details",
-      component: () => import("@/components/monitoring/EndpointDetails.vue"),
-      meta: {
-        title: "Endpoints Details • ServicePulse",
+      {
+        path: "deleted-message-groups",
+        component: () => import("@/components/failedmessages/DeletedMessageGroups.vue"),
       },
-    },
-    {
-      path: "/failed-messages",
-      component: FailedMessagesView,
-      meta: {
-        title: "Failed Messages • ServicePulse",
+      {
+        path: "all-deleted-messages",
+        component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
       },
-      children: [
-        {
-          name: "failed-messages",
-          path: "",
-          component: () => import("@/components/failedmessages/FailedMessageGroups.vue"),
-        },
-        {
-          path: "all-failed-messages",
-          component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
-        },
-        {
-          path: "deleted-message-groups",
-          component: () => import("@/components/failedmessages/DeletedMessageGroups.vue"),
-        },
-        {
-          path: "all-deleted-messages",
-          component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
-        },
-        {
-          path: "pending-retries",
-          component: () => import("@/components/failedmessages/PendingRetries.vue"),
-        },
-        {
-          name: "message-groups",
-          path: "group/:groupId",
-          component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
-        },
-        {
-          name: "deleted-message-groups",
-          path: "deleted-messages/group/:groupId",
-          component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
-        },
-      ],
-    },
-    {
-      path: "/failed-messages/message/:id",
-      name: "message",
-      component: () => import("@/components/failedmessages/MessageView.vue"),
-      meta: {
-        title: "Message • ServicePulse",
+      {
+        path: "pending-retries",
+        component: () => import("@/components/failedmessages/PendingRetries.vue"),
       },
-    },
-    {
-      path: "/events",
-      name: "events",
-      component: EventsView,
-      meta: {
-        title: "Events • ServicePulse",
+      {
+        name: "message-groups",
+        path: "group/:groupId",
+        component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
       },
-    },
-    {
-      path: "/configuration",
-      name: "configuration",
-      // route level code-splitting
-      // this generates a separate chunk (About.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: ConfigurationView,
-      meta: {
-        title: "Configuration • ServicePulse",
+      {
+        name: "deleted-message-groups",
+        path: "deleted-messages/group/:groupId",
+        component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
       },
-      children: [
-        {
-          name: "license",
-          path: "",
-          component: () => import("@/components/configuration/PlatformLicense.vue"),
-        },
-        {
-          name: "health-check-notifications",
-          path: "health-check-notifications",
-          component: () => import("@/components/configuration/HealthCheckNotifications.vue"),
-        },
-        {
-          name: "retry-redirects",
-          path: "retry-redirects",
-          component: () => import("@/components/configuration/RetryRedirects.vue"),
-        },
-        {
-          name: "connections",
-          path: "connections",
-          component: () => import("@/components/configuration/PlatformConnections.vue"),
-        },
-        {
-          name: "endpoint-connection",
-          path: "endpoint-connection",
-          component: () => import("@/components/configuration/EndpointConnection.vue"),
-        },
-      ],
+    ],
+  },
+  {
+    path: "/failed-messages/message/:id",
+    name: "message",
+    component: () => import("@/components/failedmessages/MessageView.vue"),
+    meta: {
+      title: "Message • ServicePulse",
     },
-  ],
-  strict: false,
-});
+  },
+  {
+    path: "/events",
+    name: "events",
+    component: EventsView,
+    meta: {
+      title: "Events • ServicePulse",
+    },
+  },
+  {
+    path: "/configuration",
+    name: "configuration",
+    // route level code-splitting
+    // this generates a separate chunk (About.[hash].js) for this route
+    // which is lazy-loaded when the route is visited.
+    component: ConfigurationView,
+    meta: {
+      title: "Configuration • ServicePulse",
+    },
+    children: [
+      {
+        name: "license",
+        path: "",
+        component: () => import("@/components/configuration/PlatformLicense.vue"),
+      },
+      {
+        name: "health-check-notifications",
+        path: "health-check-notifications",
+        component: () => import("@/components/configuration/HealthCheckNotifications.vue"),
+      },
+      {
+        name: "retry-redirects",
+        path: "retry-redirects",
+        component: () => import("@/components/configuration/RetryRedirects.vue"),
+      },
+      {
+        name: "connections",
+        path: "connections",
+        component: () => import("@/components/configuration/PlatformConnections.vue"),
+      },
+      {
+        name: "endpoint-connection",
+        path: "endpoint-connection",
+        component: () => import("@/components/configuration/EndpointConnection.vue"),
+      },
+    ],
+  },
+];
 
-router.beforeEach((to, from, next) => {
-  document.title = to.meta.title || "ServicePulse";
-  next();
-});
-
-export default router;
+export default function makeRouter() {
+  return createRouter({
+    history: createWebHashHistory(window.defaultConfig.base_url),
+    routes: routes,
+    strict: false,
+  });
+}


### PR DESCRIPTION
Extracting the mounting of the app into a function for reuse in acceptance tests. This allows to
- Pass a fresh instance of the router per each test running in parallel without interfering with each other
- Use a real router instead of a mocked one.