### PR TITLE
Fix: clear virtual dom between component tests runs

### DIFF
--- a/src/ServicePulse.Host/vue/vitest.config.ts
+++ b/src/ServicePulse.Host/vue/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
   },
   test: {
+    globals: true,
     clearMocks: true,
     css: true,
     coverage: {


### PR DESCRIPTION
The virtual screen (JSDOM) is being reused between tests runs, making rendered components from other tests to stick. This PR fixes the problem.