### PR TITLE
Added typed links

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventItemShort.vue
@@ -6,6 +6,7 @@ import { ref } from "vue";
 import { RouterLink } from "vue-router";
 
 import type DataViewPageModel from "@/components/DataViewPageModel";
+import routeLinks from "@/router/routeLinks";
 
 const pageModel = ref<DataViewPageModel<EventLogItemType>>({ data: [], totalCount: 0 });
 </script>
@@ -22,7 +23,7 @@ const pageModel = ref<DataViewPageModel<EventLogItemType>>({ data: [], totalCoun
       <template #footer>
         <div v-if="pageModel.totalCount > 10" class="row text-center">
           <div class="col-12">
-            <RouterLink :to="{ name: 'events' }" class="btn btn-default btn-secondary btn-all-events">View all events</RouterLink>
+            <RouterLink :to="routeLinks.events" class="btn btn-default btn-secondary btn-all-events">View all events</RouterLink>
           </div>
         </div>
       </template>

--- a/src/ServicePulse.Host/vue/src/components/EventLogItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventLogItem.vue
@@ -3,6 +3,7 @@ import { useRouter } from "vue-router";
 import TimeSince from "../components/TimeSince.vue";
 import type EventLogItem from "@/resources/EventLogItem";
 import { Severity } from "@/resources/EventLogItem";
+import routeLinks from "@/router/routeLinks";
 
 defineProps<{ eventLogItem: EventLogItem }>();
 const router = useRouter();
@@ -10,30 +11,30 @@ const router = useRouter();
 function navigateToEvent(eventLogItem: EventLogItem) {
   switch (eventLogItem.category) {
     case "Endpoints":
-      router.push({ name: "endpoint-connection" });
+      router.push(routeLinks.configuration.endpointConnection.link);
       break;
     case "HeartbeatMonitoring":
-      window.location.assign("/a/#/endpoints");
+      window.location.assign(routeLinks.heartbeats);
       break;
     case "CustomChecks":
-      window.location.assign("/a/#/custom-checks");
+      window.location.assign(routeLinks.customChecks);
       break;
     case "EndpointControl":
-      window.location.assign("/a/#/endpoints");
+      window.location.assign(routeLinks.heartbeats);
       break;
     case "MessageFailures":
       if (eventLogItem.related_to?.length && eventLogItem.related_to[0].search("message") > 0) {
         const messageId = eventLogItem.related_to[0].substring(9);
-        router.push({ name: "message", params: { id: messageId } });
+        router.push(routeLinks.failedMessage.message.link(messageId));
       } else {
-        router.push({ name: "failed-messages" });
+        router.push(routeLinks.failedMessage.root);
       }
       break;
     case "Recoverability":
-      router.push({ name: "failed-messages" });
+      router.push(routeLinks.failedMessage.root);
       break;
     case "MessageRedirects":
-      router.push({ name: "retry-redirects" });
+      router.push(routeLinks.configuration.retryRedirects.link);
       break;
     default:
   }

--- a/src/ServicePulse.Host/vue/src/components/LicenseExpired.vue
+++ b/src/ServicePulse.Host/vue/src/components/LicenseExpired.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { licenseStatus } from "../composables/serviceLicense";
+import routeLinks from "@/router/routeLinks";
 </script>
 
 <template>
@@ -8,7 +9,7 @@ import { licenseStatus } from "../composables/serviceLicense";
       <h1>Platform license expired</h1>
       <p>Please update your license to continue using the Particular Service Platform</p>
       <div class="action-toolbar">
-        <a class="btn btn-default btn-primary" href="#/configuration">View license details</a>
+        <a class="btn btn-default btn-primary" :href="routeLinks.configuration.license.link">View license details</a>
       </div>
     </div>
   </template>
@@ -18,7 +19,7 @@ import { licenseStatus } from "../composables/serviceLicense";
       <p>To continue using the Particular Service Platform, please extend your license</p>
       <div class="action-toolbar">
         <a class="btn btn-default btn-primary" href="https://particular.net/extend-your-trial?p=servicepulse" target="_blank">Extend your license <i class="fa fa-external-link"></i></a>
-        <a class="btn btn-default btn-secondary" href="#/configuration">View license details</a>
+        <a class="btn btn-default btn-secondary" :href="routeLinks.configuration.license.link">View license details</a>
       </div>
     </div>
   </template>
@@ -27,7 +28,7 @@ import { licenseStatus } from "../composables/serviceLicense";
       <h1>Platform license expired</h1>
       <p>Your upgrade protection period has elapsed and your license is not valid for this version of ServicePulse.</p>
       <div class="action-toolbar">
-        <a class="btn btn-default btn-primary" href="#/configuration">View license details</a>
+        <a class="btn btn-default btn-primary" :href="routeLinks.configuration.license.link">View license details</a>
       </div>
     </div>
   </template>

--- a/src/ServicePulse.Host/vue/src/components/PageFooter.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageFooter.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import { connectionState, environment, monitoringConnectionState, newVersions } from "../composables/serviceServiceControl";
 import { monitoringUrl, serviceControlUrl } from "../composables/serviceServiceControlUrls";
+import routeLinks from "@/router/routeLinks";
 
 const isMonitoringEnabled = computed(() => {
   return monitoringUrl.value !== "!" && monitoringUrl.value !== "" && monitoringUrl.value !== null && monitoringUrl.value !== undefined;
@@ -23,7 +24,7 @@ const scMonitoringAddressTooltip = computed(() => {
         <div class="connectivity-status">
           <span class="secondary">
             <i class="fa fa-plus sp-blue"></i>
-            <RouterLink :to="{ name: 'endpoint-connection' }">Connect new endpoint</RouterLink>
+            <RouterLink :to="routeLinks.configuration.endpointConnection.link">Connect new endpoint</RouterLink>
           </span>
 
           <span v-if="!newVersions.newSPVersion.newspversion && environment.sp_version"> ServicePulse v{{ environment.sp_version }} </span>

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -7,8 +7,7 @@ import { licenseStatus } from "../composables/serviceLicense";
 import ExclamationMark from "./ExclamationMark.vue";
 import { LicenseWarningLevel } from "@/composables/LicenseStatus";
 import { WarningLevel } from "@/components/WarningLevel";
-
-const baseUrl = window.defaultConfig.base_url;
+import routeLinks from "@/router/routeLinks";
 
 function subIsActive(input, exact) {
   const paths = Array.isArray(input) ? input : [input];
@@ -38,47 +37,47 @@ const displayDanger = computed(() => {
       <div id="navbar" class="navbar navbar-expand-lg">
         <ul class="nav navbar-nav navbar-inverse">
           <li :class="{ active: subIsActive('/dashboard', true) }">
-            <RouterLink :to="{ name: 'dashboard' }">
+            <RouterLink :to="routeLinks.dashboard">
               <i class="fa fa-dashboard icon-white" title="Dashboard"></i>
               <span class="navbar-label">Dashboard</span>
             </RouterLink>
           </li>
           <li :class="{ active: subIsActive('/a/#/endpoints') }">
-            <a :href="`${baseUrl}a/#/endpoints`">
+            <a :href="routeLinks.heartbeats">
               <i class="fa fa-heartbeat icon-white" title="Heartbeats"></i>
               <span class="navbar-label">Heartbeats</span>
               <span v-if="stats.number_of_failed_heartbeats > 0" class="badge badge-important">{{ stats.number_of_failed_heartbeats }}</span>
             </a>
           </li>
           <li v-if="useIsMonitoringEnabled()" :class="{ active: subIsActive('/a/#/monitoring') || subIsActive('/a/#/monitoring/endpoint') }">
-            <a :href="`${baseUrl}a/#/monitoring`">
+            <a :href="routeLinks.monitoring">
               <i class="fa pa-monitoring icon-white" title="Monitoring"></i>
               <span class="navbar-label">Monitoring</span>
               <span v-if="stats.number_of_disconnected_endpoints > 0" class="badge badge-important">{{ stats.number_of_disconnected_endpoints }}</span>
             </a>
           </li>
           <li :class="{ active: subIsActive('/failed-messages') }">
-            <RouterLink :to="{ name: 'failed-messages' }">
+            <RouterLink :to="routeLinks.failedMessage.root">
               <i class="fa fa-envelope icon-white" title="Failed Messages"></i>
               <span class="navbar-label">Failed Messages</span>
               <span v-if="stats.number_of_failed_messages > 0" class="badge badge-important">{{ stats.number_of_failed_messages }}</span>
             </RouterLink>
           </li>
           <li :class="{ active: subIsActive('/a/#/custom-checks') }">
-            <a :href="`${baseUrl}a/#/custom-checks`">
+            <a :href="routeLinks.customChecks">
               <i class="fa fa-check icon-white" title="Custom Checks"></i>
               <span class="navbar-label">Custom Checks</span>
               <span v-if="stats.number_of_failed_checks > 0" class="badge badge-important">{{ stats.number_of_failed_checks }}</span>
             </a>
           </li>
           <li :class="{ active: subIsActive('/events') }">
-            <RouterLink :to="{ name: 'events' }" exact>
+            <RouterLink :to="routeLinks.events" exact>
               <i class="fa fa-list-ul icon-white" title="Events"></i>
               <span class="navbar-label">Events</span>
             </RouterLink>
           </li>
           <li :class="{ active: subIsActive('/configuration') }">
-            <RouterLink :to="{ name: 'license' }" exact>
+            <RouterLink :to="routeLinks.configuration.root" exact>
               <i class="fa fa-cog icon-white" title="Configuration"></i>
               <span class="navbar-label">Configuration</span>
               <exclamation-mark :type="WarningLevel.Warning" v-if="displayWarn" />

--- a/src/ServicePulse.Host/vue/src/components/ServiceControlNotAvailable.vue
+++ b/src/ServicePulse.Host/vue/src/components/ServiceControlNotAvailable.vue
@@ -1,6 +1,7 @@
 ﻿<script setup lang="ts">
 import { connectionState } from "./../composables/serviceServiceControl";
 import { serviceControlUrl } from "./../composables/serviceServiceControlUrls";
+import routeLinks from "@/router/routeLinks";
 </script>
 
 <template>
@@ -14,7 +15,7 @@ import { serviceControlUrl } from "./../composables/serviceServiceControlUrls";
         >. Please ensure that ServiceControl is running and accessible from your machine.
       </p>
       <div class="action-toolbar">
-        <RouterLink :to="{ name: 'connections' }"><span class="btn btn-default btn-primary whiteText">View Connection Details</span></RouterLink>
+        <RouterLink :to="routeLinks.configuration.connections.link"><span class="btn btn-default btn-primary whiteText">View Connection Details</span></RouterLink>
         <a class="btn btn-default btn-secondary" href="https://docs.particular.net/monitoring/metrics/">Learn more</a>
       </div>
     </div>

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/DeletedMessageGroups.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/DeletedMessageGroups.vue
@@ -12,6 +12,7 @@ import TimeSince from "../TimeSince.vue";
 import LicenseExpired from "../../components/LicenseExpired.vue";
 import ServiceControlNotAvailable from "../ServiceControlNotAvailable.vue";
 import ConfirmDialog from "../ConfirmDialog.vue";
+import routeLinks from "@/router/routeLinks";
 
 let pollingFaster = false;
 const messageGroupList = ref();
@@ -210,7 +211,7 @@ function isBeingRestored(status) {
 
 function navigateToGroup($event, groupId) {
   if ($event.target.localName !== "button") {
-    router.push({ name: "deleted-message-groups", params: { groupId: groupId } });
+    router.push(routeLinks.failedMessage.deletedGroup.link(groupId));
   }
 }
 

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/FlowDiagram.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/FlowDiagram.vue
@@ -3,6 +3,7 @@ import { onMounted, ref } from "vue";
 import { useFetchFromServiceControl } from "../../composables/serviceServiceControlUrls";
 import { MarkerType, useVueFlow, VueFlow } from "@vue-flow/core";
 import TimeSince from "../TimeSince.vue";
+import routeLinks from "@/router/routeLinks";
 
 const props = defineProps({
   conversationId: String,
@@ -180,7 +181,7 @@ function typeIcon(type) {
             <i class="fa" :class="typeIcon(nodeProps.data.type)" :title="nodeProps.data.type" />
             <div class="lead righ-side-ellipsis" :title="nodeProps.data.nodeName">
               <strong>
-                <RouterLink v-if="nodeProps.data.isError" :to="{ name: 'message', params: { id: nodeProps.data.id } }">{{ nodeProps.data.nodeName }}</RouterLink>
+                <RouterLink v-if="nodeProps.data.isError" :to="routeLinks.failedMessage.message.link(nodeProps.data.id)">{{ nodeProps.data.nodeName }}</RouterLink>
                 <span v-else>{{ nodeProps.data.nodeName }}</span>
               </strong>
             </div>

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageGroupList.vue
@@ -8,6 +8,7 @@ import NoData from "../NoData.vue";
 import TimeSince from "../TimeSince.vue";
 import FailedMessageGroupNoteEdit from "./FailedMessageGroupNoteEdit.vue";
 import ConfirmDialog from "../ConfirmDialog.vue";
+import routeLinks from "@/router/routeLinks";
 
 const emit = defineEmits(["InitialLoadComplete", "ExceptionGroupCountUpdated"]);
 
@@ -268,7 +269,7 @@ function clearInMemoryData() {
 
 function navigateToGroup($event, groupId) {
   if ($event.target.localName !== "button") {
-    router.push({ name: "message-groups", params: { groupId: groupId } });
+    router.push(routeLinks.failedMessage.group.link(groupId));
   }
 }
 

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageList.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageList.vue
@@ -2,6 +2,7 @@
 import { useRouter } from "vue-router";
 import TimeSince from "../TimeSince.vue";
 import NoData from "../NoData.vue";
+import routeLinks from "@/router/routeLinks";
 
 let lastLabelClickedIndex = undefined;
 const router = useRouter();
@@ -63,7 +64,7 @@ function clearSelection() {
 
 function navigateToMessage($event, messageId) {
   if ($event.target.name !== "retryMessage") {
-    router.push({ path: `/failed-messages/message/${messageId}` });
+    router.push(routeLinks.failedMessage.message.link(messageId));
   }
 }
 

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/MessageView.vue
@@ -11,6 +11,7 @@ import moment from "moment";
 import ConfirmDialog from "../ConfirmDialog.vue";
 import FlowDiagram from "./FlowDiagram.vue";
 import EditRetryDialog from "./EditRetryDialog.vue";
+import routeLinks from "@/router/routeLinks";
 
 let refreshInterval = undefined;
 let pollingFaster = false;
@@ -379,7 +380,7 @@ onUnmounted(() => {
                   >{{ failedMessage.number_of_processing_attempts }} Retry Failures</span
                 >
                 <span v-if="failedMessage.edited" tooltip="Message was edited" class="label sidebar-label label-info metadata-label">Edited</span>
-                <span v-if="failedMessage.edited" class="metadata metadata-link"><i class="fa fa-history"></i> <RouterLink :to="`/failed-messages/message/${failedMessage.edit_of}`">View previous version</RouterLink></span>
+                <span v-if="failedMessage.edited" class="metadata metadata-link"><i class="fa fa-history"></i> <RouterLink :to="routeLinks.failedMessage.message.link(failedMessage.edit_of)">View previous version</RouterLink></span>
                 <span v-if="failedMessage.time_of_failure" class="metadata"><i class="fa fa-clock-o"></i> Failed: <time-since :date-utc="failedMessage.time_of_failure"></time-since></span>
                 <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{ failedMessage.receiving_endpoint?.name }}</span>
                 <span class="metadata"><i class="fa fa-laptop"></i> Machine: {{ failedMessage.receiving_endpoint?.host }}</span>

--- a/src/ServicePulse.Host/vue/src/router/config.ts
+++ b/src/ServicePulse.Host/vue/src/router/config.ts
@@ -1,0 +1,109 @@
+import DashboardView from "@/views/DashboardView.vue";
+import type { RouteComponent } from "vue-router";
+import FailedMessagesView from "@/views/FailedMessagesView.vue";
+import EventsView from "@/views/EventsView.vue";
+import ConfigurationView from "@/views/ConfigurationView.vue";
+import routeLinks from "@/router/routeLinks";
+
+export interface RouteItem {
+  path: string;
+  alias?: string[];
+  title: string;
+  component: RouteComponent | (() => Promise<RouteComponent>);
+  children?: RouteItem[];
+}
+
+const config: RouteItem[] = [
+  {
+    path: routeLinks.dashboard,
+    alias: ["/"],
+    component: DashboardView,
+    title: "Dashboard",
+  },
+  {
+    path: routeLinks.failedMessage.root,
+    component: FailedMessagesView,
+    title: "Failed Messages",
+    children: [
+      {
+        title: "Failed Messages",
+        path: routeLinks.failedMessage.failedMessagesGroups.template,
+        component: () => import("@/components/failedmessages/FailedMessageGroups.vue"),
+      },
+      {
+        path: routeLinks.failedMessage.allFailedMessages.template,
+        title: "All Failed Messages",
+        component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
+      },
+      {
+        path: routeLinks.failedMessage.deletedMessagesGroup.template,
+        title: "Deleted Message Groups",
+        component: () => import("@/components/failedmessages/DeletedMessageGroups.vue"),
+      },
+      {
+        path: routeLinks.failedMessage.allDeletedMessages.template,
+        title: "All Deleted Messages",
+        component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
+      },
+      {
+        path: routeLinks.failedMessage.pendingRetries.template,
+        title: "Pending Retries",
+        component: () => import("@/components/failedmessages/PendingRetries.vue"),
+      },
+      {
+        title: "All Failed Messages",
+        path: routeLinks.failedMessage.group.template,
+        component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
+      },
+      {
+        title: "All Deleted Messages",
+        path: routeLinks.failedMessage.deletedGroup.template,
+        component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
+      },
+      {
+        path: routeLinks.failedMessage.message.template,
+        title: "Message",
+        component: () => import("@/components/failedmessages/MessageView.vue"),
+      },
+    ],
+  },
+  {
+    path: routeLinks.events,
+    component: EventsView,
+    title: "Events",
+  },
+  {
+    path: routeLinks.configuration.root,
+    title: "Configuration",
+    component: ConfigurationView,
+    children: [
+      {
+        title: "License",
+        path: routeLinks.configuration.license.template,
+        component: () => import("@/components/configuration/PlatformLicense.vue"),
+      },
+      {
+        title: "Health Check Notifications",
+        path: routeLinks.configuration.healthCheckNotifications.template,
+        component: () => import("@/components/configuration/HealthCheckNotifications.vue"),
+      },
+      {
+        title: "Retry Redirects",
+        path: routeLinks.configuration.retryRedirects.template,
+        component: () => import("@/components/configuration/RetryRedirects.vue"),
+      },
+      {
+        title: "Connections",
+        path: routeLinks.configuration.connections.template,
+        component: () => import("@/components/configuration/PlatformConnections.vue"),
+      },
+      {
+        title: "Endpoint Connection",
+        path: routeLinks.configuration.endpointConnection.template,
+        component: () => import("@/components/configuration/EndpointConnection.vue"),
+      },
+    ],
+  },
+];
+
+export default config;

--- a/src/ServicePulse.Host/vue/src/router/index.ts
+++ b/src/ServicePulse.Host/vue/src/router/index.ts
@@ -21,7 +21,7 @@ const routes = config.map((item) => {
 
 const router = createRouter({
   history: createWebHashHistory(window.defaultConfig.base_url),
-  routes: routes,
+  routes,
 });
 
 router.beforeEach((to, from, next) => {

--- a/src/ServicePulse.Host/vue/src/router/index.ts
+++ b/src/ServicePulse.Host/vue/src/router/index.ts
@@ -1,124 +1,31 @@
-import { createRouter, createWebHashHistory } from "vue-router";
-import DashboardView from "@/views/DashboardView.vue";
-import FailedMessagesView from "@/views/FailedMessagesView.vue";
-import EventsView from "@/views/EventsView.vue";
-import ConfigurationView from "@/views/ConfigurationView.vue";
+import { createRouter, createWebHashHistory, type RouteRecordRaw } from "vue-router";
+import config from "./config";
+
+function meta(item: { title: string }) {
+  return { title: `${item.title} • ServicePulse` };
+}
+
+const routes = config.map((item) => {
+  return {
+    path: item.path,
+    meta: meta(item),
+    alias: item.alias ?? [],
+    component: item.component,
+    children: item.children?.map<RouteRecordRaw>((child) => ({
+      path: child.path,
+      meta: meta(child),
+      component: child.component,
+    })),
+  };
+});
 
 const router = createRouter({
   history: createWebHashHistory(window.defaultConfig.base_url),
-  routes: [
-    {
-      path: "/dashboard",
-      name: "dashboard",
-      component: DashboardView,
-      meta: {
-        title: "Dashboard • ServicePulse",
-      },
-    },
-    {
-      path: "/",
-      redirect: "/dashboard",
-    },
-    {
-      path: "/failed-messages",
-      component: FailedMessagesView,
-      meta: {
-        title: "Failed Messages • ServicePulse",
-      },
-      children: [
-        {
-          name: "failed-messages",
-          path: "",
-          component: () => import("@/components/failedmessages/FailedMessageGroups.vue"),
-        },
-        {
-          path: "all-failed-messages",
-          component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
-        },
-        {
-          path: "deleted-message-groups",
-          component: () => import("@/components/failedmessages/DeletedMessageGroups.vue"),
-        },
-        {
-          path: "all-deleted-messages",
-          component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
-        },
-        {
-          path: "pending-retries",
-          component: () => import("@/components/failedmessages/PendingRetries.vue"),
-        },
-        {
-          name: "message-groups",
-          path: "group/:groupId",
-          component: () => import("@/components/failedmessages/AllFailedMessages.vue"),
-        },
-        {
-          name: "deleted-message-groups",
-          path: "deleted-messages/group/:groupId",
-          component: () => import("@/components/failedmessages/AllDeletedMessages.vue"),
-        },
-      ],
-    },
-    {
-      path: "/failed-messages/message/:id",
-      name: "message",
-      component: () => import("@/components/failedmessages/MessageView.vue"),
-      meta: {
-        title: "Message • ServicePulse",
-      },
-    },
-    {
-      path: "/events",
-      name: "events",
-      component: EventsView,
-      meta: {
-        title: "Events • ServicePulse",
-      },
-    },
-    {
-      path: "/configuration",
-      name: "configuration",
-      // route level code-splitting
-      // this generates a separate chunk (About.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: ConfigurationView,
-      meta: {
-        title: "Configuration • ServicePulse",
-      },
-      children: [
-        {
-          name: "license",
-          path: "",
-          component: () => import("@/components/configuration/PlatformLicense.vue"),
-        },
-        {
-          name: "health-check-notifications",
-          path: "health-check-notifications",
-          component: () => import("@/components/configuration/HealthCheckNotifications.vue"),
-        },
-        {
-          name: "retry-redirects",
-          path: "retry-redirects",
-          component: () => import("@/components/configuration/RetryRedirects.vue"),
-        },
-        {
-          name: "connections",
-          path: "connections",
-          component: () => import("@/components/configuration/PlatformConnections.vue"),
-        },
-        {
-          name: "endpoint-connection",
-          path: "endpoint-connection",
-          component: () => import("@/components/configuration/EndpointConnection.vue"),
-        },
-      ],
-    },
-  ],
-  strict: false,
+  routes: routes,
 });
 
 router.beforeEach((to, from, next) => {
-  document.title = to.meta.title || "ServicePulse";
+  document.title = to.meta.title;
   next();
 });
 

--- a/src/ServicePulse.Host/vue/src/router/routeLinks.ts
+++ b/src/ServicePulse.Host/vue/src/router/routeLinks.ts
@@ -1,0 +1,46 @@
+const failedMessagesLinks = (root: string) => {
+  function createLink(template: string) {
+    return { link: `${root}/${template}`, template: template };
+  }
+
+  return {
+    root: root,
+    failedMessagesGroups: createLink(""),
+    allFailedMessages: createLink("all-failed-messages"),
+    deletedMessagesGroup: createLink("deleted-message-groups"),
+    allDeletedMessages: createLink("all-deleted-messages"),
+    pendingRetries: createLink("pending-retries"),
+    group: { link: (groupId: string) => `${root}/group/${groupId}`, template: "group/:groupId" },
+    deletedGroup: { link: (groupId: string) => `${root}/deleted-messages/group/${groupId}`, template: "deleted-messages/group/:groupId" },
+    message: { link: (id: string) => `${root}/message/${id}`, template: "message/:id" },
+  };
+};
+
+const configurationLinks = (root: string) => {
+  function createLink(template: string) {
+    return { link: `${root}/${template}`, template: template };
+  }
+
+  return {
+    root: root,
+    license: createLink(""),
+    healthCheckNotifications: createLink("health-check-notifications"),
+    retryRedirects: createLink("retry-redirects"),
+    connections: createLink("connections"),
+    endpointConnection: createLink("endpoint-connection"),
+  };
+};
+
+const baseUrl = window.defaultConfig.base_url;
+
+const routeLinks = {
+  dashboard: "/dashboard",
+  heartbeats: `${baseUrl}a/#/endpoints`,
+  monitoring: `${baseUrl}a/#/monitoring`,
+  failedMessage: failedMessagesLinks("/failed-messages"),
+  customChecks: `${baseUrl}a/#/custom-checks`,
+  events: "/events",
+  configuration: configurationLinks("/configuration"),
+};
+
+export default routeLinks;

--- a/src/ServicePulse.Host/vue/src/router/vue-router.d.ts
+++ b/src/ServicePulse.Host/vue/src/router/vue-router.d.ts
@@ -8,7 +8,6 @@ export {};
 
 declare module "vue-router" {
   interface RouteMeta {
-    // is optional
-    title?: string;
+    title: string;
   }
 }

--- a/src/ServicePulse.Host/vue/src/views/ConfigurationView.vue
+++ b/src/ServicePulse.Host/vue/src/views/ConfigurationView.vue
@@ -6,6 +6,7 @@ import { useIsMonitoringEnabled } from "../composables/serviceServiceControlUrls
 import { useRedirects } from "../composables/serviceRedirects";
 import ExclamationMark from "../components/ExclamationMark.vue";
 import convertToWarningLevel from "@/components/configuration/convertToWarningLevel";
+import routeLinks from "@/router/routeLinks";
 
 const redirectCount = ref(0);
 
@@ -34,17 +35,17 @@ onMounted(async () => {
       <div class="col-sm-12">
         <div class="nav tabs">
           <h5 :class="{ active: subIsActive('configuration'), disabled: !connectionState.connected && !connectionState.connectedRecently }" class="nav-item">
-            <RouterLink :to="{ name: 'license' }">License</RouterLink>
+            <RouterLink :to="routeLinks.configuration.license.link">License</RouterLink>
             <exclamation-mark :type="convertToWarningLevel(licenseStatus.warningLevel)" />
           </h5>
           <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('health-check-notifications'), disabled: !connectionState.connected && !connectionState.connectedRecently }" class="nav-item">
-            <RouterLink :to="{ name: 'health-check-notifications' }">Health Check Notifications</RouterLink>
+            <RouterLink :to="routeLinks.configuration.healthCheckNotifications.link">Health Check Notifications</RouterLink>
           </h5>
           <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('retry-redirects'), disabled: !connectionState.connected && !connectionState.connectedRecently }" class="nav-item">
-            <RouterLink :to="{ name: 'retry-redirects' }">Retry Redirects ({{ redirectCount }})</RouterLink>
+            <RouterLink :to="routeLinks.configuration.retryRedirects.link">Retry Redirects ({{ redirectCount }})</RouterLink>
           </h5>
           <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('connections') }" class="nav-item">
-            <RouterLink :to="{ name: 'connections' }">
+            <RouterLink :to="routeLinks.configuration.connections.link">
               Connections
               <template v-if="connectionState.unableToConnect || (monitoringConnectionState.unableToConnect && useIsMonitoringEnabled())">
                 <span><i class="fa fa-exclamation-triangle"></i></span>
@@ -52,7 +53,7 @@ onMounted(async () => {
             </RouterLink>
           </h5>
           <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('endpoint-connection'), disabled: !connectionState.connected && !connectionState.connectedRecently }" class="nav-item">
-            <RouterLink :to="{ name: 'endpoint-connection' }">Endpoint Connection</RouterLink>
+            <RouterLink :to="routeLinks.configuration.endpointConnection.link">Endpoint Connection</RouterLink>
           </h5>
         </div>
       </div>

--- a/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
+++ b/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
@@ -3,6 +3,7 @@ import { RouterLink, RouterView, useRoute } from "vue-router";
 import { licenseStatus } from "../composables/serviceLicense";
 import { connectionState, stats } from "../composables/serviceServiceControl";
 import LicenseExpired from "../components/LicenseExpired.vue";
+import routeLinks from "@/router/routeLinks";
 
 const showPendingRetry = window.defaultConfig.showPendingRetry;
 const route = useRoute();
@@ -25,7 +26,7 @@ function subIsActiveSubPath(subPath) {
           <div class="tabs">
             <!--Failed Message Groups-->
             <h5 :class="{ active: subIsActive('/failed-messages'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages' }">
+              <RouterLink :to="routeLinks.failedMessage.root">
                 Failed Message Groups
                 <span v-show="stats.number_of_failed_messages === 0"> (0) </span>
               </RouterLink>
@@ -34,25 +35,25 @@ function subIsActiveSubPath(subPath) {
 
             <!--All Failed Messages-->
             <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('all-failed-messages') || subIsActiveSubPath('/failed-messages/group/'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages/all-failed-messages' }">All Failed Messages </RouterLink>
+              <RouterLink :to="routeLinks.failedMessage.allFailedMessages.link">All Failed Messages </RouterLink>
               <span v-if="stats.number_of_failed_messages !== 0" class="badge badge-important">{{ stats.number_of_failed_messages }}</span>
             </h5>
 
             <!--Deleted Message Group-->
             <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('deleted-message-groups'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages/deleted-message-groups' }">Deleted Message Groups </RouterLink>
+              <RouterLink :to="routeLinks.failedMessage.deletedMessagesGroup.link">Deleted Message Groups </RouterLink>
               <span v-if="stats.number_of_archived_messages !== 0" title="There's varying numbers of deleted message groups depending on group type" class="badge badge-important">!</span>
             </h5>
 
             <!--All Deleted Messages-->
             <h5 v-if="!licenseStatus.isExpired" :class="{ active: subIsActive('all-deleted-messages') || subIsActiveSubPath('/deleted-messages/group/'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages/all-deleted-messages' }">All Deleted Messages </RouterLink>
+              <RouterLink :to="routeLinks.failedMessage.allDeletedMessages.link">All Deleted Messages </RouterLink>
               <span v-if="stats.number_of_archived_messages !== 0" class="badge badge-important">{{ stats.number_of_archived_messages }}</span>
             </h5>
 
             <!--All Pending Retries -->
             <h5 v-if="!licenseStatus.isExpired && showPendingRetry" :class="{ active: subIsActive('pending-retries'), disabled: !connectionState.connected && !connectionState.connectedRecently }">
-              <RouterLink :to="{ path: '/failed-messages/pending-retries' }">Pending Retries </RouterLink>
+              <RouterLink :to="routeLinks.failedMessage.pendingRetries.link">Pending Retries </RouterLink>
               <span v-if="stats.number_of_pending_retries !== 0" class="badge badge-important">{{ stats.number_of_pending_retries }}</span>
             </h5>
           </div>


### PR DESCRIPTION
As part of the work I am doing for the throughput reporting, I need to add a new top nav link, and I noticed all our links are hard coded and not centralised.
So this is just a cleanup for better linking within the app.

So from a consumer perspective, you know take in `routerLinks`, and then you reference a link, eg:
```
<RouterLink :to="routeLinks.dashboard">
```

I have updated all hardcoded links to use this new way, with the exception of https://github.com/Particular/ServicePulse/blob/843554f03ee27cda1a5ae32140b53c4a5149a763/src/ServicePulse.Host/vue/src/composables/serviceLicense.ts#L10-L17 which should use templates!


