### PR TITLE
Consistent header per page

### DIFF
--- a/src/ServicePulse.Host/vue/src/views/DashboardView.vue
+++ b/src/ServicePulse.Host/vue/src/views/DashboardView.vue
@@ -16,12 +16,6 @@ import { licenseStatus } from "@/composables/serviceLicense";
       <template v-if="connectionState.connected">
         <div class="row">
           <div class="col-12">
-            <h1>Dashboard</h1>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-12">
             <h6>System status</h6>
             <div class="row box system-status">
               <div class="col-12">

--- a/src/ServicePulse.Host/vue/src/views/EventsView.vue
+++ b/src/ServicePulse.Host/vue/src/views/EventsView.vue
@@ -13,11 +13,11 @@ const pageModel = ref<DataViewPageModel<EventLogItemType>>({ data: [], totalCoun
 </script>
 
 <template>
-  <div class="container">
-    <LicenseExpired />
-    <template v-if="!licenseStatus.isExpired">
-      <ServiceControlNotAvailable />
-      <template v-if="connectionState.connected">
+  <LicenseExpired />
+  <template v-if="!licenseStatus.isExpired">
+    <ServiceControlNotAvailable />
+    <template v-if="connectionState.connected">
+      <div class="container">
         <div class="row">
           <div class="col-12">
             <h1>Events</h1>
@@ -35,7 +35,7 @@ const pageModel = ref<DataViewPageModel<EventLogItemType>>({ data: [], totalCoun
             </div>
           </div>
         </div>
-      </template>
+      </div>
     </template>
-  </div>
+  </template>
 </template>

--- a/src/ServicePulse.Host/vue/src/views/EventsView.vue
+++ b/src/ServicePulse.Host/vue/src/views/EventsView.vue
@@ -13,28 +13,29 @@ const pageModel = ref<DataViewPageModel<EventLogItemType>>({ data: [], totalCoun
 </script>
 
 <template>
-  <LicenseExpired />
-  <template v-if="!licenseStatus.isExpired">
-    <ServiceControlNotAvailable />
-    <template v-if="connectionState.connected">
-      <div class="events events-view">
-        <DataView api-url="eventlogitems" v-model="pageModel" :auto-refresh-seconds="5" :show-items-per-page="true" :items-per-page="20">
-          <template #data>
-            <div class="row">
-              <div class="col-sm-12">
-                <h1>Events</h1>
-                <EventLogItem v-for="item of pageModel.data" :eventLogItem="item" :key="item.id" />
-              </div>
-            </div>
-          </template>
-        </DataView>
-      </div>
-    </template>
-  </template>
-</template>
+  <div class="container">
+    <LicenseExpired />
+    <template v-if="!licenseStatus.isExpired">
+      <ServiceControlNotAvailable />
+      <template v-if="connectionState.connected">
+        <div class="row">
+          <div class="col-12">
+            <h1>Events</h1>
+          </div>
+        </div>
 
-<style scoped>
-.events {
-  margin-top: 2em;
-}
-</style>
+        <div class="row">
+          <div class="col-12">
+            <div class="events-view">
+              <DataView api-url="eventlogitems" v-model="pageModel" :auto-refresh-seconds="5" :show-items-per-page="true" :items-per-page="20">
+                <template #data>
+                  <EventLogItem v-for="item of pageModel.data" :eventLogItem="item" :key="item.id" />
+                </template>
+              </DataView>
+            </div>
+          </div>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>

--- a/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
+++ b/src/ServicePulse.Host/vue/src/views/FailedMessagesView.vue
@@ -22,6 +22,11 @@ function subIsActiveSubPath(subPath) {
   <template v-if="!licenseStatus.isExpired">
     <div class="container">
       <div class="row">
+        <div class="col-12">
+          <h1>Failed Messages</h1>
+        </div>
+      </div>
+      <div class="row">
         <div class="col-sm-12">
           <div class="tabs">
             <!--Failed Message Groups-->


### PR DESCRIPTION
I noticed a lack of consistent headers, so this PR ensures all top-level pages are consistent.
I followed the "Configuration" page as the template to follow.
<img width="842" alt="image" src="https://github.com/Particular/ServicePulse/assets/122651/37e3c8f5-081b-448c-bfd6-cba13ca3bbda">

## Before
Dashboard
<img width="792" alt="image" src="https://github.com/Particular/ServicePulse/assets/122651/e3c48855-adaf-42cc-b713-edbd361de270">

Events
<img width="790" alt="image" src="https://github.com/Particular/ServicePulse/assets/122651/a9b24363-1f46-4d7e-89c8-9503b1be5a03">

Failed Messages
<img width="804" alt="image" src="https://github.com/Particular/ServicePulse/assets/122651/e987c64e-46e5-4d0b-91f3-d295d4332abe">



## After
Removed "Dashboard" title, given this is the main page, I don't think we need the "Dashboard" title
<img width="1011" alt="image" src="https://github.com/Particular/ServicePulse/assets/122651/13c074c1-1d35-4de9-8874-0c652104d250">

Events page
<img width="873" alt="image" src="https://github.com/Particular/ServicePulse/assets/122651/d63afb67-dd34-41fa-9677-3666c1afa6b3">

Failing Messages
<img width="761" alt="image" src="https://github.com/Particular/ServicePulse/assets/122651/147dc39b-8f67-4f7f-ace1-b782624f205d">
