### PR TITLE
Endpoint name group sorting

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/SortableColumn.vue
+++ b/src/ServicePulse.Host/vue/src/components/SortableColumn.vue
@@ -28,7 +28,7 @@ function toggleSort() {
 </script>
 <template>
   <div class="box-header">
-    <button @click="toggleSort" class="column-header-button">
+    <button v-if="props.sortBy" @click="toggleSort" class="column-header-button">
       <span>
         <slot></slot>
         <span class="table-header-unit"><slot name="unit"></slot></span>
@@ -37,10 +37,25 @@ function toggleSort() {
         </span>
       </span>
     </button>
+    <div v-else class="column-header">
+      <span>
+        <slot></slot>
+        <span class="table-header-unit"><slot name="unit"></slot></span>
+      </span>
+    </div>
   </div>
 </template>
 
 <style scoped>
+.column-header {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: default;
+  max-width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+}
 .column-header-button {
   background: none;
   border: none;

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
@@ -32,28 +32,28 @@ function updateSorting(isAscending) {
         <SortableColumn :sort-by="sortByColumn.ENDPOINTNAME" v-model="activeColumn" @isAscending="updateSorting">Endpoint name</SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn :sort-by="sortByColumn.QUEUELENGTH" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint."
+        <SortableColumn :sort-by="isGrouped ? '' : sortByColumn.QUEUELENGTH" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint."
           >Queue Length<template #unit>(MSGS)</template>
         </SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn :sort-by="sortByColumn.THROUGHPUT" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Throughput: The number of messages per second successfully processed by a receiving endpoint."
+        <SortableColumn :sort-by="isGrouped ? '' : sortByColumn.THROUGHPUT" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Throughput: The number of messages per second successfully processed by a receiving endpoint."
           >Throughput<template #unit>(msgs/s)</template>
         </SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn :sort-by="sortByColumn.SCHEDULEDRETRIES" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Scheduled retries: The number of messages per second scheduled for retries (immediate or delayed)."
+        <SortableColumn :sort-by="isGrouped ? '' : sortByColumn.SCHEDULEDRETRIES" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Scheduled retries: The number of messages per second scheduled for retries (immediate or delayed)."
           >Scheduled retries <template #unit>(msgs/s)</template>
         </SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn :sort-by="sortByColumn.PROCESSINGTIME" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Processing time: The time taken for a receiving endpoint to successfully process a message."
+        <SortableColumn :sort-by="isGrouped ? '' : sortByColumn.PROCESSINGTIME" v-model="activeColumn" @isAscending="updateSorting" v-tooltip title="Processing time: The time taken for a receiving endpoint to successfully process a message."
           >Processing Time <template #unit>(t)</template>
         </SortableColumn>
       </div>
       <div class="table-col">
         <SortableColumn
-          :sort-by="sortByColumn.CRITICALTIME"
+          :sort-by="isGrouped ? '' : sortByColumn.CRITICALTIME"
           v-model="activeColumn"
           @isAscending="updateSorting"
           v-tooltip
@@ -84,4 +84,10 @@ function updateSorting(isAscending) {
 
 <style scoped>
 @import "./endpoint.css";
+
+.endpoint-group-title {
+  font-size: 14px;
+  font-weight: bold;
+  margin: 20px 0 10px 5px;
+}
 </style>

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
@@ -7,6 +7,7 @@ import { useMonitoringStore } from "../../stores/MonitoringStore";
 const monitoringStore = useMonitoringStore();
 const endpoints = computed(() => monitoringStore.getEndpointList);
 const isGrouped = computed(() => monitoringStore.endpointListIsGrouped);
+const groupedEndpoints = computed(() => monitoringStore.grouping.groupedEndpoints);
 const activeColumn = ref("name");
 
 const sortByColumn = Object.freeze({
@@ -63,12 +64,12 @@ function updateSorting(isAscending) {
     </div>
     <div>
       <div v-if="isGrouped">
-        <div class="row" v-for="(endpointGroup, index) in monitoringStore.grouping.groupedEndpoints" :key="index">
+        <div class="row" v-for="(endpointGroup, index) in groupedEndpoints" :key="index">
           <div class="endpoint-group-title">
             {{ endpointGroup.group }}
           </div>
           <div class="row box endpoint-row" v-for="(groupedEndpoint, index) in endpointGroup.endpoints" :key="index">
-            <EndpointListRow :endpoint="groupedEndpoint.endpoint" />
+            <EndpointListRow :endpoint="groupedEndpoint" />
           </div>
         </div>
       </div>

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointListRow.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointListRow.vue
@@ -11,8 +11,15 @@ const settings = defineProps({
   endpoint: Object,
 });
 
-const endpoint = computed(() => settings.endpoint);
 const monitoringHistoryPeriodStore = useMonitoringHistoryPeriodStore();
+const monitoringStore = useMonitoringStore();
+const isGrouped = computed(() => monitoringStore.endpointListIsGrouped);
+const endpoint = computed(() => {
+  return isGrouped.value ? settings.endpoint.endpoint : settings.endpoint;
+});
+const groupedShortName = computed(() => {
+  return isGrouped.value ? settings.endpoint.shortName : null;
+});
 const router = useRouter();
 const supportsEndpointCount = ref();
 const { historyPeriod: selectedPeriod } = storeToRefs(monitoringHistoryPeriodStore);

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointListRow.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointListRow.vue
@@ -5,6 +5,7 @@ import { useFormatTime, useFormatLargeNumber } from "../../composables/formatter
 import { smallGraphsMinimumYAxis } from "./formatGraph";
 import SmallGraph from "./SmallGraph.vue";
 import { useMonitoringHistoryPeriodStore } from "@/stores/MonitoringHistoryPeriodStore";
+import { useMonitoringStore } from "../../stores/MonitoringStore";
 import { storeToRefs } from "pinia";
 
 const settings = defineProps({
@@ -17,8 +18,8 @@ const isGrouped = computed(() => monitoringStore.endpointListIsGrouped);
 const endpoint = computed(() => {
   return isGrouped.value ? settings.endpoint.endpoint : settings.endpoint;
 });
-const groupedShortName = computed(() => {
-  return isGrouped.value ? settings.endpoint.shortName : null;
+const shortName = computed(() => {
+  return isGrouped.value ? settings.endpoint.shortName : "";
 });
 const router = useRouter();
 const supportsEndpointCount = ref();
@@ -61,7 +62,7 @@ function formatGraphDecimal(input, deci) {
     <div class="box-header">
       <div class="no-side-padding lead righ-side-ellipsis endpoint-details-link">
         <a @click="navigateToEndpointDetails($event, endpoint.name)" class="cursorpointer" v-tooltip :title="endpoint.name">
-          {{ endpoint.name }}
+          {{ isGrouped ? shortName : endpoint.name }}
         </a>
         <span class="endpoint-count" v-if="endpoint.connectedCount || endpoint.disconnectedCount" v-tooltip :title="`Endpoint instance(s):` + endpoint.connectedCount || 0">({{ endpoint.connectedCount || 0 }})</span>
       </div>

--- a/src/ServicePulse.Host/vue/src/components/monitoring/MonitoringGroupBy.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/MonitoringGroupBy.vue
@@ -31,7 +31,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="dropdown" v-tooltip title="Endpoint grouping will take '.' in endpoint names to delimit segments. Grouping endpoints will disable list sorting.">
+  <div class="dropdown" v-tooltip title="Endpoint grouping will take '.' in endpoint names to delimit segments. Grouping endpoints will disable some list sorting.">
     <label class="control-label">Group by:</label>
     <button type="button" class="btn btn-dropdown dropdown-toggle sp-btn-menu" id="dropdownMenu1" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       {{ grouping.selectedGrouping === 0 ? "no grouping" : "max. " + grouping.selectedGrouping + " segments" }}

--- a/src/ServicePulse.Host/vue/src/components/monitoring/endpoint.css
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/endpoint.css
@@ -99,6 +99,7 @@ h1 .endpoint-status i.fa-envelope,
   border-bottom: 1px solid #eee;
   border-left: 1px solid #fff;
   background-color: #fff;
+  margin: 0px;
 }
 
 .endpoint-name,

--- a/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
+++ b/src/ServicePulse.Host/vue/src/stores/MonitoringStore.js
@@ -58,17 +58,14 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
   async function updateEndpointList() {
     endpointList.value = await MonitoringEndpoints.useGetAllMonitoredEndpoints(historyPeriodStore.historyPeriod.pVal);
     if (!endpointListIsEmpty.value) {
-      sortEndpointList();
       updateGroupSegments();
-      if (endpointListIsGrouped.value) {
-        updateGroupedEndpoints();
-      }
+      endpointListIsGrouped.value ? updateGroupedEndpoints() : sortEndpointList();
     }
   }
 
   function updateSelectedGrouping(groupSize) {
     grouping.value.selectedGrouping = groupSize;
-    updateGroupedEndpoints();
+    groupSize === 0 ? sortEndpointList() : updateGroupedEndpoints();
   }
 
   function updateGroupSegments() {
@@ -77,6 +74,7 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
 
   function updateGroupedEndpoints() {
     grouping.value.groupedEndpoints = MonitoringEndpoints.useGroupEndpoints(getEndpointList.value, grouping.value.selectedGrouping);
+    sortGroupedEndpointList();
   }
 
   async function updateSort(newSortBy = "name", newIsSortAscending = false) {
@@ -103,6 +101,36 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
     }
 
     endpointList.value.sort(comparator);
+  }
+
+  function sortGroupedEndpointList() {
+    const sortByProperty = sortBy.value;
+    let comparator;
+    const endpointShortNameComparator = (a, b) => {
+      return isSortAscending.value ? a.shortName.localeCompare(b.shortName) : b.shortName.localeCompare(a.shortName);
+    };
+
+    if (sortByProperty === "name") {
+      comparator = (a, b) => {
+        const groupNameA = a.group;
+        const groupNameB = b.group;
+        const endpointListGroupA = a.endpoints;
+        const endpointListGroupB = b.endpoints;
+
+        // Sort each group's endpoints before sorting the group name
+        endpointListGroupA.sort(endpointShortNameComparator);
+        endpointListGroupB.sort(endpointShortNameComparator);
+
+        return isSortAscending.value ? groupNameA.localeCompare(groupNameB) : groupNameB.localeCompare(groupNameA);
+      };
+    }
+    // TODO: Determine how sorting should be handled for columns other than endpoint name
+
+    if (grouping.value.groupedEndpoints.length > 1) {
+      grouping.value.groupedEndpoints.sort(comparator);
+    } else if (grouping.value.groupedEndpoints.length === 1) {
+      grouping.value.groupedEndpoints[0].endpoints.sort(endpointShortNameComparator);
+    }
   }
 
   return {

--- a/src/ServicePulse.Host/vue/src/views/MonitoringView.vue
+++ b/src/ServicePulse.Host/vue/src/views/MonitoringView.vue
@@ -2756,12 +2756,6 @@ button[ng-click="vm.toggleSort()"] div {
   background-image: url("../../a/img/sort-down.svg");
 }
 
-.endpoint-group-title {
-  font-size: 14px;
-  font-weight: bold;
-  margin: 20px 0 10px 15px;
-}
-
 .notifications .btn-sm {
   padding: 0px;
 }


### PR DESCRIPTION
Adds sorting to the endpoint name column when the endpoint list is grouped by segments.  This also correctly displays the short name of the endpoint when the list is grouped.