### PR TITLE
Handle case where current page exceeds total page count

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/PaginationStrip.vue
+++ b/src/ServicePulse.Host/vue/src/components/PaginationStrip.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -21,6 +21,12 @@ const showPagination = computed(() => {
 });
 
 const doublePageBuffer = computed(() => props.pageBuffer * 2);
+
+watch(numberOfPages, (newValue) => {
+  if (newValue < pageNumber.value) {
+    pageNumber.value = 1;
+  }
+});
 
 interface PageData {
   label: string;


### PR DESCRIPTION
This can happen if the number of items per page changes. i.e. If you have 2 pages of 25 items each, and you are on page 2, and then change the number of items per page to 75.