### PR TITLE
Add default time unit

### DIFF
--- a/src/ServicePulse.Host/vue/src/composables/formatter.ts
+++ b/src/ServicePulse.Host/vue/src/composables/formatter.ts
@@ -11,7 +11,7 @@ export interface ValueWithUnit {
 }
 
 export function useFormatTime(value?: number): ValueWithUnit {
-  const time = { value: "0", unit: "" };
+  const time = { value: "0", unit: "ms" };
   if (value) {
     const duration = moment.duration(value);
 


### PR DESCRIPTION
Instead of 0, it should be 0 ms

Before:

![image](https://github.com/Particular/ServicePulse/assets/124014/f7e6295a-0511-482e-a64b-8df4be9d6490)


After:

![image](https://github.com/Particular/ServicePulse/assets/124014/f541a819-0877-430e-aac3-3525d0eda4f0)
