### PR TITLE
Format large numbers with locale

### DIFF
--- a/src/ServicePulse.Host/vue/src/composables/formatter.ts
+++ b/src/ServicePulse.Host/vue/src/composables/formatter.ts
@@ -50,12 +50,12 @@ export function useFormatLargeNumber(num: number, decimals: number) {
   }
 
   if (num < 1000000) {
-    return round(num, decimals).toString();
+    return round(num, decimals).toLocaleString();
   }
 
   const exp = Math.floor(Math.log(num) / Math.log(1000));
 
-  return `${round(num / Math.pow(1000, exp), decimals)}${suffixes[exp - 1]}`;
+  return `${round(num / Math.pow(1000, exp), decimals).toLocaleString()}${suffixes[exp - 1]}`;
 }
 
 function round(num: number, decimals: number) {


### PR DESCRIPTION
Before (English): 

![image](https://github.com/Particular/ServicePulse/assets/124014/4ba2419c-1926-4e33-b764-0d9f03b5d37c)

After (en-AU):

![image](https://github.com/Particular/ServicePulse/assets/124014/f34655ce-5b15-414b-9a6a-917d86ed084a)

After (de-AT):

![image](https://github.com/Particular/ServicePulse/assets/124014/04ec2a52-2576-4c0f-84e1-80893683a0a4)

After (nl):

![image](https://github.com/Particular/ServicePulse/assets/124014/c45c3559-ad51-4b55-8c12-576604e780fe)
