### PR TITLE
Make Endpoint list default direction for name sorting ascending

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/SortInfo.ts
+++ b/src/ServicePulse.Host/vue/src/components/SortInfo.ts
@@ -1,0 +1,4 @@
+export interface SortInfo {
+  property: string;
+  isAscending: boolean;
+}

--- a/src/ServicePulse.Host/vue/src/components/SortableColumn.vue
+++ b/src/ServicePulse.Host/vue/src/components/SortableColumn.vue
@@ -1,25 +1,22 @@
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { computed } from "vue";
+import type { SortInfo } from "./SortInfo";
 
-const props = defineProps<{
-  sortBy: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    sortBy: string;
+    defaultAscending: boolean;
+  }>(),
+  { defaultAscending: false }
+);
 
-const activeColumn = defineModel({
-  type: String,
-  required: true,
-});
+const activeColumn = defineModel<SortInfo>({ required: true });
 
-const emit = defineEmits(["isAscending"]);
-
-const isAscending = ref(false);
-const isActive = computed(() => activeColumn.value === props.sortBy);
-const sortIcon = computed(() => (isAscending.value ? "sort-up" : "sort-down"));
+const isActive = computed(() => activeColumn.value?.property === props.sortBy);
+const sortIcon = computed(() => (activeColumn.value.isAscending ? "sort-up" : "sort-down"));
 
 function toggleSort() {
-  activeColumn.value = props.sortBy;
-  isAscending.value = isActive.value ? !isAscending.value : false;
-  emit("isAscending", isAscending.value);
+  activeColumn.value = { property: props.sortBy, isAscending: isActive.value ? !activeColumn.value.isAscending : props.defaultAscending };
 }
 </script>
 <template>

--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointList.vue
@@ -1,11 +1,11 @@
 ﻿<script setup lang="ts">
-import { ref } from "vue";
 import SortableColumn from "../../components/SortableColumn.vue";
 import EndpointListRow from "./EndpointListRow.vue";
 import { useMonitoringStore } from "@/stores/MonitoringStore";
+import { storeToRefs } from "pinia";
 
 const monitoringStore = useMonitoringStore();
-const activeColumn = ref("name");
+const { sortBy: activeColumn } = storeToRefs(monitoringStore);
 
 const sortByColumn = Object.freeze({
   ENDPOINTNAME: "name",
@@ -15,10 +15,6 @@ const sortByColumn = Object.freeze({
   PROCESSINGTIME: "processingTime",
   CRITICALTIME: "criticalTime",
 });
-
-function updateSorting(isAscending: boolean) {
-  monitoringStore.updateSort(activeColumn.value, isAscending);
-}
 </script>
 
 <template>
@@ -26,45 +22,25 @@ function updateSorting(isAscending: boolean) {
     <!--Table headings-->
     <div class="table-head-row">
       <div class="table-first-col">
-        <SortableColumn :sort-by="sortByColumn.ENDPOINTNAME" v-model="activeColumn" @isAscending="updateSorting">Endpoint name</SortableColumn>
+        <SortableColumn :sort-by="sortByColumn.ENDPOINTNAME" v-model="activeColumn" :default-ascending="true">Endpoint name</SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn
-          :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.QUEUELENGTH"
-          v-model="activeColumn"
-          @isAscending="updateSorting"
-          v-tooltip
-          title="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint."
+        <SortableColumn :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.QUEUELENGTH" v-model="activeColumn" v-tooltip title="Queue length: The number of messages waiting to be processed in the input queue(s) of the endpoint."
           >Queue Length<template #unit>(MSGS)</template>
         </SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn
-          :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.THROUGHPUT"
-          v-model="activeColumn"
-          @isAscending="updateSorting"
-          v-tooltip
-          title="Throughput: The number of messages per second successfully processed by a receiving endpoint."
+        <SortableColumn :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.THROUGHPUT" v-model="activeColumn" v-tooltip title="Throughput: The number of messages per second successfully processed by a receiving endpoint."
           >Throughput<template #unit>(msgs/s)</template>
         </SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn
-          :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.SCHEDULEDRETRIES"
-          v-model="activeColumn"
-          @isAscending="updateSorting"
-          v-tooltip
-          title="Scheduled retries: The number of messages per second scheduled for retries (immediate or delayed)."
+        <SortableColumn :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.SCHEDULEDRETRIES" v-model="activeColumn" v-tooltip title="Scheduled retries: The number of messages per second scheduled for retries (immediate or delayed)."
           >Scheduled retries <template #unit>(msgs/s)</template>
         </SortableColumn>
       </div>
       <div class="table-col">
-        <SortableColumn
-          :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.PROCESSINGTIME"
-          v-model="activeColumn"
-          @isAscending="updateSorting"
-          v-tooltip
-          title="Processing time: The time taken for a receiving endpoint to successfully process a message."
+        <SortableColumn :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.PROCESSINGTIME" v-model="activeColumn" v-tooltip title="Processing time: The time taken for a receiving endpoint to successfully process a message."
           >Processing Time <template #unit>(t)</template>
         </SortableColumn>
       </div>
@@ -72,7 +48,6 @@ function updateSorting(isAscending: boolean) {
         <SortableColumn
           :sort-by="monitoringStore.endpointListIsGrouped ? '' : sortByColumn.CRITICALTIME"
           v-model="activeColumn"
-          @isAscending="updateSorting"
           v-tooltip
           title="Critical time: The elapsed time from when a message was sent, until it was successfully processed by a receiving endpoint."
           >Critical Time <template #unit>(t)</template>


### PR DESCRIPTION
The default sort order for the endpoint list was descending. This change makes the default sort for the column ascending.

I also created a `SortInfo` interface and passed that around to bind to instead of having two separate states to pass around.