### PR TITLE
Fixes [Vue warn]: Missing required prop: "defaultAscending"

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/SortableColumn.vue
+++ b/src/ServicePulse.Host/vue/src/components/SortableColumn.vue
@@ -5,7 +5,7 @@ import type { SortInfo } from "./SortInfo";
 const props = withDefaults(
   defineProps<{
     sortBy: string;
-    defaultAscending: boolean;
+    defaultAscending?: boolean;
   }>(),
   { defaultAscending: false }
 );


### PR DESCRIPTION
> By saying the prop is required, you expect the user to always provide a value, so making it have a default value defeats the purpose of the prop being required.

According to:
- https://github.com/vuejs/vue/issues/7720#issuecomment-369172012

<img width="919" alt="image" src="https://github.com/Particular/ServicePulse/assets/545695/146cf045-05e2-4607-b12e-dc92bc1b3123">
