### PR TITLE
Fixing endpoint details header icon

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/EndpointDetails.vue
@@ -105,8 +105,8 @@ onMounted(() => {
               <span class="warning" v-if="endpoint.errorCount" v-tooltip :title="endpoint.errorCount + ` failed messages associated with this endpoint. Click to see list.`">
                 <RouterLink :to="routeLinks.failedMessage.group.link(endpoint.serviceControlId)" v-if="endpoint.errorCount" class="warning cursorpointer">
                   <i class="fa fa-envelope"></i>
+                  <span class="badge badge-important ng-binding cursorpointer"> {{ endpoint.errorCount }}</span>
                 </RouterLink>
-                <span class="badge badge-important ng-binding cursorpointer"> {{ endpoint.errorCount }}</span>
               </span>
             </div>
           </div>


### PR DESCRIPTION
The cursor was not a hand when hovering the red circle with the number of failed messages