### PR TITLE
Custom checks with Pinia store

### DIFF
--- a/src/ServicePulse.Host/vue/src/assets/header-menu-item.css
+++ b/src/ServicePulse.Host/vue/src/assets/header-menu-item.css
@@ -1,0 +1,8 @@
+.nav {
+  --bs-link-color: #9d9d9d;
+  --bs-link-hover-color: #fff;
+}
+
+.navbar > .container-fluid > div {
+  margin: 0 1em;
+}

--- a/src/ServicePulse.Host/vue/src/components/EventLogItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/EventLogItem.vue
@@ -17,7 +17,7 @@ function navigateToEvent(eventLogItem: EventLogItem) {
       window.location.assign(routeLinks.heartbeats);
       break;
     case "CustomChecks":
-      window.location.assign(routeLinks.customChecks);
+      router.push(routeLinks.customChecks);
       break;
     case "EndpointControl":
       window.location.assign(routeLinks.heartbeats);

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -88,13 +88,5 @@ const displayDanger = computed(() => {
 
 <style scoped>
 @import "@/assets/navbar.css";
-
-.nav {
-  --bs-link-color: #9d9d9d;
-  --bs-link-hover-color: #fff;
-}
-
-.navbar > .container-fluid > div {
-  margin: 0 1em;
-}
+@import "@/assets/page-header-menu-item.css";
 </style>

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -9,6 +9,7 @@ import { LicenseWarningLevel } from "@/composables/LicenseStatus";
 import { WarningLevel } from "@/components/WarningLevel";
 import routeLinks from "@/router/routeLinks";
 import isRouteSelected from "@/composables/isRouteSelected";
+import CustomChecksMenuItem from "@/components/customchecks/CustomChecksMenuItem.vue";
 
 const displayWarn = computed(() => {
   return licenseStatus.warningLevel === LicenseWarningLevel.Warning;
@@ -57,11 +58,7 @@ const displayDanger = computed(() => {
             </RouterLink>
           </li>
           <li>
-            <RouterLink :to="routeLinks.customChecks">
-              <i class="fa fa-check icon-white" title="Custom Checks"></i>
-              <span class="navbar-label">Custom Checks</span>
-              <span v-if="stats.number_of_failed_checks > 0" class="badge badge-important">{{ stats.number_of_failed_checks }}</span>
-            </RouterLink>
+            <CustomChecksMenuItem />
           </li>
           <li :class="{ active: isRouteSelected(routeLinks.events) }">
             <RouterLink :to="routeLinks.events" exact>

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -88,5 +88,5 @@ const displayDanger = computed(() => {
 
 <style scoped>
 @import "@/assets/navbar.css";
-@import "@/assets/page-header-menu-item.css";
+@import "@/assets/header-menu-item.css";
 </style>

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomCheckView.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomCheckView.vue
@@ -1,20 +1,11 @@
 <script setup lang="ts">
 import CustomCheck from "@/resources/CustomCheck";
 import TimeSince from "@/components/TimeSince.vue";
-import { useDeleteFromServiceControl } from "@/composables/serviceServiceControlUrls";
+import { useCustomChecksStore } from "@/stores/CustomChecksStore";
 
 defineProps<{ customCheck: CustomCheck }>();
 
-const prefix = "customchecks/";
-
-async function dismissCustomCheck(id: string) {
-  // HINT: This is required to handle the difference between ServiceControl 4 and 5
-  let guid = id;
-  if (id.toLowerCase().startsWith(prefix)) {
-    guid = id.substring(prefix.length);
-  }
-  await useDeleteFromServiceControl(`${prefix}${guid}`);
-}
+const store = useCustomChecksStore();
 </script>
 
 <template>
@@ -40,7 +31,7 @@ async function dismissCustomCheck(id: string) {
           </div>
         </div>
         <div>
-          <button type="button" class="btn btn-default" title="Dismiss this custom check so it doesn't show up as an alert" @click="dismissCustomCheck(customCheck.id)">Dismiss</button>
+          <button type="button" class="btn btn-default" title="Dismiss this custom check so it doesn't show up as an alert" @click="store.dismissCustomCheck(customCheck.id)">Dismiss</button>
         </div>
       </div>
     </div>

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomCheckView.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomCheckView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import CustomCheck from "@/resources/CustomCheck";
-import TimeSince from "./TimeSince.vue";
+import TimeSince from "@/components/TimeSince.vue";
 import { useDeleteFromServiceControl } from "@/composables/serviceServiceControlUrls";
 
 defineProps<{ customCheck: CustomCheck }>();
@@ -48,7 +48,7 @@ async function dismissCustomCheck(id: string) {
 </template>
 
 <style scoped>
-@import "./list.css";
+@import "../list.css";
 
 .custom-check-row {
   display: flex;

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomCheckView.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomCheckView.vue
@@ -39,7 +39,7 @@ const store = useCustomChecksStore();
 </template>
 
 <style scoped>
-@import "../list.css";
+@import "@/components/list.css";
 
 .custom-check-row {
   display: flex;

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksDashboardItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksDashboardItem.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DashboardItem from "@/components/DashboardItem.vue";
+import { useCustomChecksStore } from "@/stores/CustomChecksStore";
+import routeLinks from "@/router/routeLinks";
+import { storeToRefs } from "pinia";
+import { useLink } from "vue-router";
+
+const store = useCustomChecksStore();
+const { failingCount } = storeToRefs(store);
+</script>
+
+<template>
+  <DashboardItem :counter="failingCount" :url="useLink({ to: routeLinks.customChecks }).href.value" :iconClass="'fa-check'">Custom Checks</DashboardItem>
+</template>

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
@@ -19,5 +19,5 @@ const { failingCount } = storeToRefs(store);
 
 <style scoped>
 @import "@/assets/navbar.css";
-@import "@/assets/page-header-menu-item.css";
+@import "@/assets/header-menu-item.css";
 </style>

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
@@ -19,13 +19,5 @@ const { failingCount } = storeToRefs(store);
 
 <style scoped>
 @import "@/assets/navbar.css";
-
-.nav {
-  --bs-link-color: #9d9d9d;
-  --bs-link-hover-color: #fff;
-}
-
-.navbar > .container-fluid > div {
-  margin: 0 1em;
-}
+@import "@/assets/page-header-menu-item.css";
 </style>

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import { useCustomChecksStore } from "@/stores/CustomChecksStore";
+import routeLinks from "@/router/routeLinks";
+import isRouteSelected from "@/composables/isRouteSelected";
+import { storeToRefs } from "pinia";
+
+const store = useCustomChecksStore();
+const { failingCount } = storeToRefs(store);
+</script>
+
+<template>
+  <RouterLink :class="{ active: isRouteSelected(routeLinks.customChecks) }" :to="routeLinks.customChecks">
+    <i class="fa fa-check icon-white" title="Custom Checks"></i>
+    <span class="navbar-label">Custom Checks</span>
+    <span v-if="failingCount > 0" class="badge badge-important">{{ failingCount }}</span>
+  </RouterLink>
+</template>
+
+<style scoped>
+@import "@/assets/navbar.css";
+
+.nav {
+  --bs-link-color: #9d9d9d;
+  --bs-link-hover-color: #fff;
+}
+
+.navbar > .container-fluid > div {
+  margin: 0 1em;
+}
+</style>

--- a/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
+++ b/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
@@ -15,7 +15,7 @@ export default function useAutoRefresh(refreshAction: () => Promise<void>, timeo
     }, timeout);
   }
 
-  async function executeAndResetTimer(overrideAction: (() => Promise<void>) | null = null) {
+  async function executeAndResetTimer(overrideAction?: () => Promise<void>) {
     try {
       stopTimer();
       await (overrideAction ?? refreshAction)();

--- a/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
+++ b/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
@@ -1,0 +1,30 @@
+export default function useAutoRefresh(refreshAction: () => Promise<void>, timeout: number) {
+  let refreshInterval: number | null = null;
+
+  function stopTimer() {
+    if (refreshInterval !== null) {
+      window.clearTimeout(refreshInterval);
+      refreshInterval = null;
+    }
+  }
+
+  function startTimer() {
+    stopTimer();
+    refreshInterval = window.setTimeout(() => {
+      executeAndResetTimer();
+    }, timeout);
+  }
+
+  async function executeAndResetTimer(overrideAction: (() => Promise<void>) | null = null) {
+    try {
+      stopTimer();
+      await (overrideAction ?? refreshAction)();
+    } finally {
+      startTimer();
+    }
+  }
+
+  return {
+    executeAndResetTimer,
+  };
+}

--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControl.ts
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControl.ts
@@ -16,7 +16,6 @@ export const stats = reactive({
   failing_endpoints: 0,
   number_of_exception_groups: 0,
   number_of_failed_messages: 0,
-  number_of_failed_checks: 0,
   number_of_failed_heartbeats: 0,
   number_of_archived_messages: 0,
   number_of_pending_retries: 0,
@@ -152,15 +151,13 @@ watch(monitoringConnectionFailure, (newValue, oldValue) => {
 async function useServiceControlStats() {
   const failedHeartBeatsResult = getFailedHeartBeatsCount();
   const failedMessagesResult = getFailedMessagesCount();
-  const failedCustomChecksResult = getFailedCustomChecksCount();
   const archivedMessagesResult = getArchivedMessagesCount();
   const pendingRetriesResult = getPendingRetriesCount();
 
   try {
-    const [failedHeartbeats, failedMessages, failedCustomChecks, archivedMessages, pendingRetries] = await Promise.all([failedHeartBeatsResult, failedMessagesResult, failedCustomChecksResult, archivedMessagesResult, pendingRetriesResult]);
+    const [failedHeartbeats, failedMessages, archivedMessages, pendingRetries] = await Promise.all([failedHeartBeatsResult, failedMessagesResult, archivedMessagesResult, pendingRetriesResult]);
     stats.failing_endpoints = failedHeartbeats;
     stats.number_of_failed_messages = failedMessages;
-    stats.number_of_failed_checks = failedCustomChecks;
     stats.number_of_failed_heartbeats = failedHeartbeats;
     stats.number_of_archived_messages = archivedMessages;
     stats.number_of_pending_retries = pendingRetries;

--- a/src/ServicePulse.Host/vue/src/stores/CustomChecksStore.ts
+++ b/src/ServicePulse.Host/vue/src/stores/CustomChecksStore.ts
@@ -27,6 +27,7 @@ export const useCustomChecksStore = defineStore("CustomChecksStore", () => {
 
   async function dismissCustomCheck(id: string) {
     dataRetriever.executeAndResetTimer(async () => {
+      // NOTE: If it takes more than the refresh interval for ServiceControl to delete the check it will reappear
       failedChecks.value = failedChecks.value.filter((x) => x.id !== id);
       failingCount.value--;
 

--- a/src/ServicePulse.Host/vue/src/stores/CustomChecksStore.ts
+++ b/src/ServicePulse.Host/vue/src/stores/CustomChecksStore.ts
@@ -2,54 +2,41 @@ import { useDeleteFromServiceControl, useTypedFetchFromServiceControl } from "@/
 import CustomCheck from "@/resources/CustomCheck";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { ref, watch } from "vue";
+import useAutoRefresh from "@/composables/autoRefresh";
 
 export const useCustomChecksStore = defineStore("CustomChecksStore", () => {
-  const REFRESH_EVERY = 5000;
-  let refreshInterval: number | null = null;
-
   const prefix = "customchecks/";
 
   const pageNumber = ref(1);
   const failingCount = ref(0);
-
   const failedChecks = ref<CustomCheck[]>([]);
 
-  watch(pageNumber, () => loadData());
-
-  async function loadData() {
+  const dataRetriever = useAutoRefresh(async () => {
     try {
-      if (refreshInterval != null) {
-        window.clearTimeout(refreshInterval);
-      }
       const [response, data] = await useTypedFetchFromServiceControl<CustomCheck[]>(`customchecks?status=fail&page=${pageNumber.value}`);
-      if (response.ok) {
-        failedChecks.value = data;
-        failingCount.value = parseInt(response.headers.get("Total-Count") ?? "0");
-      }
-    } finally {
-      refreshInterval = window.setTimeout(() => loadData(), REFRESH_EVERY);
+      failedChecks.value = data;
+      failingCount.value = parseInt(response.headers.get("Total-Count") ?? "0");
+    } catch (e) {
+      failedChecks.value = [];
+      failingCount.value = 0;
+      throw e;
     }
-  }
+  }, 5000);
+
+  watch(pageNumber, () => dataRetriever.executeAndResetTimer());
 
   async function dismissCustomCheck(id: string) {
-    try {
-      if (refreshInterval != null) {
-        window.clearTimeout(refreshInterval);
-      }
-
-      console.log("updating");
+    dataRetriever.executeAndResetTimer(async () => {
       failedChecks.value = failedChecks.value.filter((x) => x.id !== id);
       failingCount.value--;
 
       // HINT: This is required to handle the difference between ServiceControl 4 and 5
       const guid = id.toLocaleLowerCase().startsWith(prefix) ? id.substring(prefix.length) : id;
       await useDeleteFromServiceControl(`${prefix}${guid}`);
-    } finally {
-      refreshInterval = window.setTimeout(() => loadData(), REFRESH_EVERY);
-    }
+    });
   }
 
-  loadData();
+  dataRetriever.executeAndResetTimer();
 
   return {
     dismissCustomCheck,
@@ -63,4 +50,4 @@ if (import.meta.hot) {
   import.meta.hot.accept(acceptHMRUpdate(useCustomChecksStore, import.meta.hot));
 }
 
-export type MonitoringHistoryPeriodStore = ReturnType<typeof useCustomChecksStore>;
+export type CustomChecksStore = ReturnType<typeof useCustomChecksStore>;

--- a/src/ServicePulse.Host/vue/src/stores/CustomChecksStore.ts
+++ b/src/ServicePulse.Host/vue/src/stores/CustomChecksStore.ts
@@ -1,0 +1,45 @@
+import { useTypedFetchFromServiceControl } from "@/composables/serviceServiceControlUrls";
+import CustomCheck from "@/resources/CustomCheck";
+import { acceptHMRUpdate, defineStore } from "pinia";
+import { ref, watch } from "vue";
+
+export const useCustomChecksStore = defineStore("CustomChecksStore", () => {
+  const REFRESH_EVERY = 5000;
+  let refreshInterval: number | null = null;
+
+  const pageNumber = ref(1);
+  const failingCount = ref(0);
+
+  const failedChecks = ref<CustomCheck[]>([]);
+
+  watch(pageNumber, () => loadData());
+
+  async function loadData() {
+    try {
+      if (refreshInterval != null) {
+        window.clearTimeout(refreshInterval);
+      }
+      const [response, data] = await useTypedFetchFromServiceControl<CustomCheck[]>(`customchecks?status=fail&page=${pageNumber.value}`);
+      if (response.ok) {
+        failedChecks.value = data;
+        failingCount.value = parseInt(response.headers.get("Total-Count") ?? "0");
+      }
+    } finally {
+      refreshInterval = window.setTimeout(() => loadData(), REFRESH_EVERY);
+    }
+  }
+
+  loadData();
+
+  return {
+    pageNumber,
+    failingCount,
+    failedChecks,
+  };
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useCustomChecksStore, import.meta.hot));
+}
+
+export type MonitoringHistoryPeriodStore = ReturnType<typeof useCustomChecksStore>;

--- a/src/ServicePulse.Host/vue/src/views/CustomChecksView.vue
+++ b/src/ServicePulse.Host/vue/src/views/CustomChecksView.vue
@@ -1,15 +1,13 @@
 <script setup lang="ts">
-import { ref } from "vue";
-import DataView, { AdditionalDataViewParameters } from "@/components/DataView.vue";
-import DataViewPageModel from "@/components/DataViewPageModel";
 import NoData from "@/components/NoData.vue";
-import CustomCheck from "@/resources/CustomCheck";
-import CustomCheckView from "@/components/CustomCheckView.vue";
+import CustomCheckView from "@/components/customchecks/CustomCheckView.vue";
+import { useCustomChecksStore } from "@/stores/CustomChecksStore";
+import { storeToRefs } from "pinia";
+import PaginationStrip from "@/components/PaginationStrip.vue";
 
-const pageModel = ref<DataViewPageModel<CustomCheck>>({ data: [], totalCount: 0 });
-const additionalApiParams: AdditionalDataViewParameters = {
-  status: "fail",
-};
+const store = useCustomChecksStore();
+
+const { pageNumber, failingCount, failedChecks } = storeToRefs(store);
 </script>
 
 <template>
@@ -21,19 +19,15 @@ const additionalApiParams: AdditionalDataViewParameters = {
     </div>
 
     <section name="custom_checks">
-      <NoData v-if="pageModel.totalCount === 0" message="No failed custom checks" />
-
-      <DataView api-url="customchecks" :api-params="additionalApiParams" v-model="pageModel" :auto-refresh-seconds="5">
-        <template #data>
+      <NoData v-if="failingCount === 0" message="No failed custom checks" />
+      <div v-else class="row">
+        <div class="col-sm-12">
+          <CustomCheckView v-for="item of failedChecks" :key="item.id" :custom-check="item" />
           <div class="row">
-            <div class="col-sm-12">
-              <div>
-                <CustomCheckView v-for="item of pageModel.data" :key="item.id" :customCheck="item" />
-              </div>
-            </div>
+            <PaginationStrip :items-per-page="10" :total-count="failingCount" v-model="pageNumber" />
           </div>
-        </template>
-      </DataView>
+        </div>
+      </div>
     </section>
   </div>
 </template>

--- a/src/ServicePulse.Host/vue/src/views/DashboardView.vue
+++ b/src/ServicePulse.Host/vue/src/views/DashboardView.vue
@@ -7,6 +7,7 @@ import { connectionState, stats } from "@/composables/serviceServiceControl";
 import { licenseStatus } from "@/composables/serviceLicense";
 import routeLinks from "@/router/routeLinks";
 import { useLink } from "vue-router";
+import CustomChecksDashboardItem from "@/components/customchecks/CustomChecksDashboardItem.vue";
 </script>
 
 <template>
@@ -35,7 +36,7 @@ import { useLink } from "vue-router";
                     <DashboardItem :counter="stats.number_of_failed_messages" :url="useLink({ to: routeLinks.failedMessage.root }).href.value" :iconClass="'fa-envelope'">Failed Messages</DashboardItem>
                   </div>
                   <div class="col-4">
-                    <DashboardItem :counter="stats.number_of_failed_checks" :url="routeLinks.customChecks" :iconClass="'fa-check'">Custom Checks</DashboardItem>
+                    <CustomChecksDashboardItem />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Moves the custom checks data management to a pinia store.

- [x] Custom checks page
- [x] Menu Item
- [x] Dashboard badge
- [ ] ~~Updates ServiceControl connection status~~ Other components are still doing this on a regular cadence so it is fine if one of them stops (for now).
- [x] Handles deletes