### PR TITLE
Refactor page header component

### DIFF
--- a/src/ServicePulse.Host/vue/src/assets/header-menu-item.css
+++ b/src/ServicePulse.Host/vue/src/assets/header-menu-item.css
@@ -6,3 +6,8 @@
 .navbar > .container-fluid > div {
   margin: 0 1em;
 }
+
+#navbar .router-link-active {
+  background: transparent !important;
+  border-bottom: 5px solid #00a3c4;
+}

--- a/src/ServicePulse.Host/vue/src/components/FeedbackButton.vue
+++ b/src/ServicePulse.Host/vue/src/components/FeedbackButton.vue
@@ -1,0 +1,10 @@
+<template>
+  <a class="btn-feedback" href="https://github.com/Particular/ServicePulse/issues/new" target="_blank">
+    <i class="fa fa-comment" title="Feedback"></i>
+    <span class="navbar-label">Feedback</span>
+  </a>
+</template>
+<style scoped>
+@import "@/assets/navbar.css";
+@import "@/assets/header-menu-item.css";
+</style>

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -7,6 +7,7 @@ import HeartbeatsMenuItem from "./heartbeats/HeartbeatsMenuItem.vue";
 import ConfigurationMenuItem from "./configuration/ConfigurationMenuItem.vue";
 import FailedMessagesMenuItem from "./failedmessages/FailedMessagesMenuItem.vue";
 import MonitoringMenuItem from "./monitoring/MonitoringMenuItem.vue";
+import EventsMenuItem from "./events/EventsMenuItem.vue";
 </script>
 
 <template>
@@ -39,10 +40,7 @@ import MonitoringMenuItem from "./monitoring/MonitoringMenuItem.vue";
             <CustomChecksMenuItem />
           </li>
           <li>
-            <RouterLink :to="routeLinks.events">
-              <i class="fa fa-list-ul icon-white" title="Events"></i>
-              <span class="navbar-label">Events</span>
-            </RouterLink>
+            <EventsMenuItem />
           </li>
           <li>
             <ConfigurationMenuItem />

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { RouterLink } from "vue-router";
 import { useIsMonitoringEnabled } from "@/composables/serviceServiceControlUrls";
 import routeLinks from "@/router/routeLinks";
@@ -12,7 +13,8 @@ import DashboardMenuItem from "@/components/dashboard/DashboardMenuItem.vue";
 import FeedbackButton from "@/components/FeedbackButton.vue";
 
 // prettier-ignore
-const menuItems = [
+const menuItems = computed(
+  () => [
   DashboardMenuItem,
   HeartbeatsMenuItem,
   ...(useIsMonitoringEnabled() ? [MonitoringMenuItem] : []),
@@ -21,7 +23,7 @@ const menuItems = [
   EventsMenuItem,
   ConfigurationMenuItem,
   FeedbackButton,
-];
+]);
 </script>
 
 <template>

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -1,22 +1,11 @@
 <script setup lang="ts">
 import { RouterLink } from "vue-router";
-import { computed } from "vue";
-import { connectionState, monitoringConnectionState, stats } from "@/composables/serviceServiceControl";
 import { useIsMonitoringEnabled } from "@/composables/serviceServiceControlUrls";
-import { licenseStatus } from "@/composables/serviceLicense";
-import ExclamationMark from "./ExclamationMark.vue";
-import { LicenseWarningLevel } from "@/composables/LicenseStatus";
-import { WarningLevel } from "@/components/WarningLevel";
+import { stats } from "@/composables/serviceServiceControl";
 import routeLinks from "@/router/routeLinks";
 import CustomChecksMenuItem from "@/components/customchecks/CustomChecksMenuItem.vue";
 import HeartbeatsMenuItem from "./heartbeats/HeartbeatsMenuItem.vue";
-
-const displayWarn = computed(() => {
-  return licenseStatus.warningLevel === LicenseWarningLevel.Warning;
-});
-const displayDanger = computed(() => {
-  return connectionState.unableToConnect || (monitoringConnectionState.unableToConnect && useIsMonitoringEnabled()) || licenseStatus.warningLevel === LicenseWarningLevel.Danger;
-});
+import ConfigurationMenuItem from "./configuration/ConfigurationMenuItem.vue";
 </script>
 
 <template>
@@ -63,12 +52,7 @@ const displayDanger = computed(() => {
             </RouterLink>
           </li>
           <li>
-            <RouterLink :to="routeLinks.configuration.root" exact>
-              <i class="fa fa-cog icon-white" title="Configuration"></i>
-              <span class="navbar-label">Configuration</span>
-              <exclamation-mark :type="WarningLevel.Warning" v-if="displayWarn" />
-              <exclamation-mark :type="WarningLevel.Danger" v-if="displayDanger" />
-            </RouterLink>
+            <ConfigurationMenuItem />
           </li>
           <li>
             <a class="btn-feedback" href="https://github.com/Particular/ServicePulse/issues/new" target="_blank">

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -8,7 +8,6 @@ import ExclamationMark from "./ExclamationMark.vue";
 import { LicenseWarningLevel } from "@/composables/LicenseStatus";
 import { WarningLevel } from "@/components/WarningLevel";
 import routeLinks from "@/router/routeLinks";
-import isRouteSelected from "@/composables/isRouteSelected";
 import CustomChecksMenuItem from "@/components/customchecks/CustomChecksMenuItem.vue";
 
 const displayWarn = computed(() => {
@@ -30,27 +29,27 @@ const displayDanger = computed(() => {
 
       <div id="navbar" class="navbar navbar-expand-lg">
         <ul class="nav navbar-nav navbar-inverse">
-          <li :class="{ active: isRouteSelected(routeLinks.dashboard) }">
+          <li>
             <RouterLink :to="routeLinks.dashboard">
               <i class="fa fa-dashboard icon-white" title="Dashboard"></i>
               <span class="navbar-label">Dashboard</span>
             </RouterLink>
           </li>
-          <li :class="{ active: isRouteSelected(routeLinks.heartbeats.root) }">
+          <li>
             <RouterLink :to="routeLinks.heartbeats.root">
               <i class="fa fa-heartbeat icon-white" title="Heartbeats"></i>
               <span class="navbar-label">Heartbeats</span>
               <span v-if="stats.number_of_failed_heartbeats > 0" class="badge badge-important">{{ stats.number_of_failed_heartbeats }}</span>
             </RouterLink>
           </li>
-          <li v-if="useIsMonitoringEnabled()" :class="{ active: isRouteSelected(routeLinks.monitoring.root) || isRouteSelected(routeLinks.monitoring.endpointDetails.link('endpointName', 1)) }">
+          <li v-if="useIsMonitoringEnabled()">
             <RouterLink :to="routeLinks.monitoring.root">
               <i class="fa pa-monitoring icon-white" title="Monitoring"></i>
               <span class="navbar-label">Monitoring</span>
               <span v-if="stats.number_of_disconnected_endpoints > 0" class="badge badge-important">{{ stats.number_of_disconnected_endpoints }}</span>
             </RouterLink>
           </li>
-          <li :class="{ active: isRouteSelected(routeLinks.failedMessage.root) }">
+          <li>
             <RouterLink :to="routeLinks.failedMessage.root">
               <i class="fa fa-envelope icon-white" title="Failed Messages"></i>
               <span class="navbar-label">Failed Messages</span>
@@ -60,13 +59,13 @@ const displayDanger = computed(() => {
           <li>
             <CustomChecksMenuItem />
           </li>
-          <li :class="{ active: isRouteSelected(routeLinks.events) }">
-            <RouterLink :to="routeLinks.events" exact>
+          <li>
+            <RouterLink :to="routeLinks.events">
               <i class="fa fa-list-ul icon-white" title="Events"></i>
               <span class="navbar-label">Events</span>
             </RouterLink>
           </li>
-          <li :class="{ active: isRouteSelected(routeLinks.configuration.root) }">
+          <li>
             <RouterLink :to="routeLinks.configuration.root" exact>
               <i class="fa fa-cog icon-white" title="Configuration"></i>
               <span class="navbar-label">Configuration</span>

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -3,11 +3,25 @@ import { RouterLink } from "vue-router";
 import { useIsMonitoringEnabled } from "@/composables/serviceServiceControlUrls";
 import routeLinks from "@/router/routeLinks";
 import CustomChecksMenuItem from "@/components/customchecks/CustomChecksMenuItem.vue";
-import HeartbeatsMenuItem from "./heartbeats/HeartbeatsMenuItem.vue";
-import ConfigurationMenuItem from "./configuration/ConfigurationMenuItem.vue";
-import FailedMessagesMenuItem from "./failedmessages/FailedMessagesMenuItem.vue";
-import MonitoringMenuItem from "./monitoring/MonitoringMenuItem.vue";
-import EventsMenuItem from "./events/EventsMenuItem.vue";
+import HeartbeatsMenuItem from "@/components/heartbeats/HeartbeatsMenuItem.vue";
+import ConfigurationMenuItem from "@/components/configuration/ConfigurationMenuItem.vue";
+import FailedMessagesMenuItem from "@/components/failedmessages/FailedMessagesMenuItem.vue";
+import MonitoringMenuItem from "@/components/monitoring/MonitoringMenuItem.vue";
+import EventsMenuItem from "@/components/events/EventsMenuItem.vue";
+import DashboardMenuItem from "@/components/dashboard/DashboardMenuItem.vue";
+import FeedbackButton from "@/components/FeedbackButton.vue";
+
+// prettier-ignore
+const menuItems = [
+  DashboardMenuItem,
+  HeartbeatsMenuItem,
+  ...(useIsMonitoringEnabled() ? [MonitoringMenuItem] : []),
+  FailedMessagesMenuItem,
+  CustomChecksMenuItem,
+  EventsMenuItem,
+  ConfigurationMenuItem,
+  FeedbackButton,
+];
 </script>
 
 <template>
@@ -21,35 +35,8 @@ import EventsMenuItem from "./events/EventsMenuItem.vue";
 
       <div id="navbar" class="navbar navbar-expand-lg">
         <ul class="nav navbar-nav navbar-inverse">
-          <li>
-            <RouterLink :to="routeLinks.dashboard">
-              <i class="fa fa-dashboard icon-white" title="Dashboard"></i>
-              <span class="navbar-label">Dashboard</span>
-            </RouterLink>
-          </li>
-          <li>
-            <HeartbeatsMenuItem />
-          </li>
-          <li v-if="useIsMonitoringEnabled()">
-            <MonitoringMenuItem />
-          </li>
-          <li>
-            <FailedMessagesMenuItem />
-          </li>
-          <li>
-            <CustomChecksMenuItem />
-          </li>
-          <li>
-            <EventsMenuItem />
-          </li>
-          <li>
-            <ConfigurationMenuItem />
-          </li>
-          <li>
-            <a class="btn-feedback" href="https://github.com/Particular/ServicePulse/issues/new" target="_blank">
-              <i class="fa fa-comment" title="Feedback"></i>
-              <span class="navbar-label">Feedback</span>
-            </a>
+          <li v-for="menuItem in menuItems" :key="menuItem?.name">
+            <component :is="menuItem" />
           </li>
         </ul>
       </div>

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { RouterLink } from "vue-router";
 import { useIsMonitoringEnabled } from "@/composables/serviceServiceControlUrls";
-import { stats } from "@/composables/serviceServiceControl";
 import routeLinks from "@/router/routeLinks";
 import CustomChecksMenuItem from "@/components/customchecks/CustomChecksMenuItem.vue";
 import HeartbeatsMenuItem from "./heartbeats/HeartbeatsMenuItem.vue";
 import ConfigurationMenuItem from "./configuration/ConfigurationMenuItem.vue";
 import FailedMessagesMenuItem from "./failedmessages/FailedMessagesMenuItem.vue";
+import MonitoringMenuItem from "./monitoring/MonitoringMenuItem.vue";
 </script>
 
 <template>
@@ -30,11 +30,7 @@ import FailedMessagesMenuItem from "./failedmessages/FailedMessagesMenuItem.vue"
             <HeartbeatsMenuItem />
           </li>
           <li v-if="useIsMonitoringEnabled()">
-            <RouterLink :to="routeLinks.monitoring.root">
-              <i class="fa pa-monitoring icon-white" title="Monitoring"></i>
-              <span class="navbar-label">Monitoring</span>
-              <span v-if="stats.number_of_disconnected_endpoints > 0" class="badge badge-important">{{ stats.number_of_disconnected_endpoints }}</span>
-            </RouterLink>
+            <MonitoringMenuItem />
           </li>
           <li>
             <FailedMessagesMenuItem />

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -6,6 +6,7 @@ import routeLinks from "@/router/routeLinks";
 import CustomChecksMenuItem from "@/components/customchecks/CustomChecksMenuItem.vue";
 import HeartbeatsMenuItem from "./heartbeats/HeartbeatsMenuItem.vue";
 import ConfigurationMenuItem from "./configuration/ConfigurationMenuItem.vue";
+import FailedMessagesMenuItem from "./failedmessages/FailedMessagesMenuItem.vue";
 </script>
 
 <template>
@@ -36,11 +37,7 @@ import ConfigurationMenuItem from "./configuration/ConfigurationMenuItem.vue";
             </RouterLink>
           </li>
           <li>
-            <RouterLink :to="routeLinks.failedMessage.root">
-              <i class="fa fa-envelope icon-white" title="Failed Messages"></i>
-              <span class="navbar-label">Failed Messages</span>
-              <span v-if="stats.number_of_failed_messages > 0" class="badge badge-important">{{ stats.number_of_failed_messages }}</span>
-            </RouterLink>
+            <FailedMessagesMenuItem />
           </li>
           <li>
             <CustomChecksMenuItem />

--- a/src/ServicePulse.Host/vue/src/components/PageHeader.vue
+++ b/src/ServicePulse.Host/vue/src/components/PageHeader.vue
@@ -9,6 +9,7 @@ import { LicenseWarningLevel } from "@/composables/LicenseStatus";
 import { WarningLevel } from "@/components/WarningLevel";
 import routeLinks from "@/router/routeLinks";
 import CustomChecksMenuItem from "@/components/customchecks/CustomChecksMenuItem.vue";
+import HeartbeatsMenuItem from "./heartbeats/HeartbeatsMenuItem.vue";
 
 const displayWarn = computed(() => {
   return licenseStatus.warningLevel === LicenseWarningLevel.Warning;
@@ -36,11 +37,7 @@ const displayDanger = computed(() => {
             </RouterLink>
           </li>
           <li>
-            <RouterLink :to="routeLinks.heartbeats.root">
-              <i class="fa fa-heartbeat icon-white" title="Heartbeats"></i>
-              <span class="navbar-label">Heartbeats</span>
-              <span v-if="stats.number_of_failed_heartbeats > 0" class="badge badge-important">{{ stats.number_of_failed_heartbeats }}</span>
-            </RouterLink>
+            <HeartbeatsMenuItem />
           </li>
           <li v-if="useIsMonitoringEnabled()">
             <RouterLink :to="routeLinks.monitoring.root">

--- a/src/ServicePulse.Host/vue/src/components/configuration/ConfigurationMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/ConfigurationMenuItem.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import { computed } from "vue";
+import { connectionState, monitoringConnectionState, stats } from "@/composables/serviceServiceControl";
+import { useIsMonitoringEnabled } from "@/composables/serviceServiceControlUrls";
+import { licenseStatus } from "@/composables/serviceLicense";
+import ExclamationMark from "@/components/ExclamationMark.vue";
+import { LicenseWarningLevel } from "@/composables/LicenseStatus";
+import { WarningLevel } from "@/components/WarningLevel";
+import routeLinks from "@/router/routeLinks";
+
+const displayWarn = computed(() => {
+  return licenseStatus.warningLevel === LicenseWarningLevel.Warning;
+});
+const displayDanger = computed(() => {
+  return connectionState.unableToConnect || (monitoringConnectionState.unableToConnect && useIsMonitoringEnabled()) || licenseStatus.warningLevel === LicenseWarningLevel.Danger;
+});
+</script>
+
+<template>
+  <RouterLink :to="routeLinks.configuration.root" exact>
+    <i class="fa fa-cog icon-white" title="Configuration"></i>
+    <span class="navbar-label">Configuration</span>
+    <exclamation-mark :type="WarningLevel.Warning" v-if="displayWarn" />
+    <exclamation-mark :type="WarningLevel.Danger" v-if="displayDanger" />
+  </RouterLink>
+</template>
+
+<style scoped>
+@import "@/assets/navbar.css";
+@import "@/assets/header-menu-item.css";
+</style>

--- a/src/ServicePulse.Host/vue/src/components/configuration/ConfigurationMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/ConfigurationMenuItem.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { RouterLink } from "vue-router";
 import { computed } from "vue";
-import { connectionState, monitoringConnectionState, stats } from "@/composables/serviceServiceControl";
+import { connectionState, monitoringConnectionState } from "@/composables/serviceServiceControl";
 import { useIsMonitoringEnabled } from "@/composables/serviceServiceControlUrls";
 import { licenseStatus } from "@/composables/serviceLicense";
 import ExclamationMark from "@/components/ExclamationMark.vue";

--- a/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/customchecks/CustomChecksMenuItem.vue
@@ -2,7 +2,6 @@
 import { RouterLink } from "vue-router";
 import { useCustomChecksStore } from "@/stores/CustomChecksStore";
 import routeLinks from "@/router/routeLinks";
-import isRouteSelected from "@/composables/isRouteSelected";
 import { storeToRefs } from "pinia";
 
 const store = useCustomChecksStore();
@@ -10,7 +9,7 @@ const { failingCount } = storeToRefs(store);
 </script>
 
 <template>
-  <RouterLink :class="{ active: isRouteSelected(routeLinks.customChecks) }" :to="routeLinks.customChecks">
+  <RouterLink :to="routeLinks.customChecks">
     <i class="fa fa-check icon-white" title="Custom Checks"></i>
     <span class="navbar-label">Custom Checks</span>
     <span v-if="failingCount > 0" class="badge badge-important">{{ failingCount }}</span>

--- a/src/ServicePulse.Host/vue/src/components/dashboard/DashboardMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/dashboard/DashboardMenuItem.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import routeLinks from "@/router/routeLinks";
+</script>
+
+<template>
+  <RouterLink :to="routeLinks.dashboard">
+    <i class="fa fa-dashboard icon-white" title="Dashboard"></i>
+    <span class="navbar-label">Dashboard</span>
+  </RouterLink>
+</template>
+
+<style scoped>
+@import "@/assets/navbar.css";
+@import "@/assets/header-menu-item.css";
+</style>

--- a/src/ServicePulse.Host/vue/src/components/events/EventsMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/events/EventsMenuItem.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import routeLinks from "@/router/routeLinks";
+</script>
+
+<template>
+  <RouterLink :to="routeLinks.events">
+    <i class="fa fa-list-ul icon-white" title="Events"></i>
+    <span class="navbar-label">Events</span>
+  </RouterLink>
+</template>
+
+<style scoped>
+@import "@/assets/navbar.css";
+@import "@/assets/header-menu-item.css";
+</style>

--- a/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessagesMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/failedmessages/FailedMessagesMenuItem.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import routeLinks from "@/router/routeLinks";
+import { stats } from "@/composables/serviceServiceControl";
+</script>
+
+<template>
+  <RouterLink :to="routeLinks.failedMessage.root">
+    <i class="fa fa-envelope icon-white" title="Failed Messages"></i>
+    <span class="navbar-label">Failed Messages</span>
+    <span v-if="stats.number_of_failed_messages > 0" class="badge badge-important">{{ stats.number_of_failed_messages }}</span>
+  </RouterLink>
+</template>
+
+<style scoped>
+@import "@/assets/navbar.css";
+@import "@/assets/header-menu-item.css";
+</style>

--- a/src/ServicePulse.Host/vue/src/components/heartbeats/HeartbeatsMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/heartbeats/HeartbeatsMenuItem.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import routeLinks from "@/router/routeLinks";
+import { stats } from "@/composables/serviceServiceControl";
+</script>
+
+<template>
+  <RouterLink :to="routeLinks.heartbeats.root">
+    <i class="fa fa-heartbeat icon-white" title="Heartbeats"></i>
+    <span class="navbar-label">Heartbeats</span>
+    <span v-if="stats.number_of_failed_heartbeats > 0" class="badge badge-important">{{ stats.number_of_failed_heartbeats }}</span>
+  </RouterLink>
+</template>
+
+<style scoped>
+@import "@/assets/navbar.css";
+@import "@/assets/header-menu-item.css";
+</style>

--- a/src/ServicePulse.Host/vue/src/components/monitoring/MonitoringMenuItem.vue
+++ b/src/ServicePulse.Host/vue/src/components/monitoring/MonitoringMenuItem.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import routeLinks from "@/router/routeLinks";
+import { stats } from "@/composables/serviceServiceControl";
+</script>
+
+<template>
+  <RouterLink :to="routeLinks.monitoring.root">
+    <i class="fa pa-monitoring icon-white" title="Monitoring"></i>
+    <span class="navbar-label">Monitoring</span>
+    <span v-if="stats.number_of_disconnected_endpoints > 0" class="badge badge-important">{{ stats.number_of_disconnected_endpoints }}</span>
+  </RouterLink>
+</template>
+
+<style scoped>
+@import "@/assets/navbar.css";
+@import "@/assets/header-menu-item.css";
+</style>


### PR DESCRIPTION
This PR moves all of the nav item elements into their own components and then renders them based on a data-driven list.

It also shifts the CSS for active items to use the built-in vue classes