### PR TITLE
Add missing SagaAudit and MessageAudit sections and capitalize properties as expected by the connector plugin

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/configuration/EndpointConnection.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/EndpointConnection.vue
@@ -31,10 +31,12 @@ endpointConfiguration.ConnectToServicePlatform(servicePlatformConnection);
 `;
   const connections = await useServiceControlConnections();
   const config = {
-    heartbeats: connections.serviceControl.settings.Heartbeats,
-    customChecks: connections.serviceControl.settings.CustomChecks,
-    errorQueue: connections.serviceControl.settings.ErrorQueue,
-    metrics: connections.monitoring.settings,
+    Heartbeats: connections.serviceControl.settings.Heartbeats,
+    CustomChecks: connections.serviceControl.settings.CustomChecks,
+    ErrorQueue: connections.serviceControl.settings.ErrorQueue,
+    SagaAudit: connections.serviceControl.settings.SagaAudit,
+    MessageAudit: connections.serviceControl.settings.MessageAudit,
+    Metrics: connections.monitoring.settings,
   };
   let jsonText = JSON.stringify(config, null, 4);
   jsonConfig.value = jsonText;


### PR DESCRIPTION
ServiceControl returns more data, including `SagaAudit` and `MessageAudit` settings, which were not displayed in ServicePulse. Second, the top-level properties should be `PascalCase`, too (it's not a bug; the connector plugin works with `camelCase` properties as well, but for consistency, it's preferable).

- [x] Corresponding ServiceControl PR on `master` https://github.com/Particular/ServiceControl/pull/4063
- [x] Test that this change broke nothing in earlier versions of ServiceControl