### PR TITLE
Adding ServicePulse version to all requests to ServiceControl instances

### DIFF
--- a/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
+++ b/src/ServicePulse.Host/vue/src/components/configuration/PlatformConnections.vue
@@ -4,6 +4,7 @@ import LicenseExpired from "../LicenseExpired.vue";
 import { licenseStatus } from "@/composables/serviceLicense";
 import { monitoringUrl as configuredMonitoringUrl, serviceControlUrl as configuredServiceControlUrl, updateServiceControlUrls, useIsMonitoringDisabled } from "../../composables/serviceServiceControlUrls";
 import { connectionState, monitoringConnectionState } from "@/composables/serviceServiceControl";
+import servicePulseFetch from "@/composables/servicePulseFetch";
 
 const isExpired = licenseStatus.isExpired;
 
@@ -22,7 +23,7 @@ async function testServiceControlUrl() {
   if (serviceControlUrl.value) {
     testingServiceControl.value = true;
     try {
-      const response = await fetch(serviceControlUrl.value);
+      const response = await servicePulseFetch(serviceControlUrl.value);
       serviceControlValid.value = response.ok && response.headers.has("X-Particular-Version");
     } catch {
       serviceControlValid.value = false;
@@ -41,7 +42,7 @@ async function testMonitoringUrl() {
     }
 
     try {
-      const response = await fetch(monitoringUrl.value + "monitored-endpoints");
+      const response = await servicePulseFetch(monitoringUrl.value + "monitored-endpoints");
       monitoringValid.value = response.ok && response.headers.has("X-Particular-Version");
     } catch {
       monitoringValid.value = false;

--- a/src/ServicePulse.Host/vue/src/composables/servicePulseFetch.ts
+++ b/src/ServicePulse.Host/vue/src/composables/servicePulseFetch.ts
@@ -1,0 +1,9 @@
+const servicePulseFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const requestInit = init ?? {};
+  requestInit.headers = new Headers(requestInit.headers);
+  requestInit.headers.set("Particular-ServicePulse-Version", window.defaultConfig.version);
+
+  return await fetch(input, requestInit);
+};
+
+export default servicePulseFetch;

--- a/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.ts
+++ b/src/ServicePulse.Host/vue/src/composables/serviceServiceControlUrls.ts
@@ -1,4 +1,5 @@
 import { type Ref, ref } from "vue";
+import servicePulseFetch from "@/composables/servicePulseFetch";
 
 const serviceControlUrl = ref<string | null>();
 const monitoringUrl = ref<string | null>();
@@ -48,11 +49,11 @@ export function useIsMonitoringEnabled() {
 }
 
 export function useFetchFromServiceControl(suffix: string) {
-  return fetch(serviceControlUrl.value + suffix);
+  return servicePulseFetch(serviceControlUrl.value + suffix);
 }
 
 export async function useTypedFetchFromServiceControl<T>(suffix: string): Promise<[Response, T]> {
-  const response = await fetch(`${serviceControlUrl.value}${suffix}`);
+  const response = await servicePulseFetch(`${serviceControlUrl.value}${suffix}`);
   if (!response?.ok) throw new Error(response?.statusText ?? "No response");
   const data = await response.json();
 
@@ -64,7 +65,7 @@ export async function useTypedFetchFromMonitoring<T>(suffix: string): Promise<[R
     return [];
   }
 
-  const response = await fetch(`${monitoringUrl.value}${suffix}`);
+  const response = await servicePulseFetch(`${monitoringUrl.value}${suffix}`);
   const data = await response.json();
 
   return [response, data];
@@ -78,7 +79,7 @@ export function usePostToServiceControl(suffix: string, payload: object | null =
     requestOptions.headers = { "Content-Type": "application/json" };
     requestOptions.body = JSON.stringify(payload);
   }
-  return fetch(serviceControlUrl.value + suffix, requestOptions);
+  return servicePulseFetch(serviceControlUrl.value + suffix, requestOptions);
 }
 
 export function usePutToServiceControl(suffix: string, payload: object | null) {
@@ -89,20 +90,20 @@ export function usePutToServiceControl(suffix: string, payload: object | null) {
     requestOptions.headers = { "Content-Type": "application/json" };
     requestOptions.body = JSON.stringify(payload);
   }
-  return fetch(serviceControlUrl.value + suffix, requestOptions);
+  return servicePulseFetch(serviceControlUrl.value + suffix, requestOptions);
 }
 
 export function useDeleteFromServiceControl(suffix: string) {
   const requestOptions: RequestInit = {
     method: "DELETE",
   };
-  return fetch(serviceControlUrl.value + suffix, requestOptions);
+  return servicePulseFetch(serviceControlUrl.value + suffix, requestOptions);
 }
 export function useDeleteFromMonitoring(suffix: string) {
   const requestOptions = {
     method: "DELETE",
   };
-  return fetch(monitoringUrl.value + suffix, requestOptions);
+  return servicePulseFetch(monitoringUrl.value + suffix, requestOptions);
 }
 
 export function useOptionsFromMonitoring() {
@@ -113,7 +114,7 @@ export function useOptionsFromMonitoring() {
   const requestOptions = {
     method: "OPTIONS",
   };
-  return fetch(monitoringUrl.value ?? "", requestOptions);
+  return servicePulseFetch(monitoringUrl.value ?? "", requestOptions);
 }
 
 export function usePatchToServiceControl(suffix: string, payload: object | null) {
@@ -124,7 +125,7 @@ export function usePatchToServiceControl(suffix: string, payload: object | null)
     requestOptions.headers = { "Content-Type": "application/json" };
     requestOptions.body = JSON.stringify(payload);
   }
-  return fetch(serviceControlUrl.value + suffix, requestOptions);
+  return servicePulseFetch(serviceControlUrl.value + suffix, requestOptions);
 }
 
 export function updateServiceControlUrls(newServiceControlUrl: Ref<string | null | undefined>, newMonitoringUrl: Ref<string | null | undefined>) {


### PR DESCRIPTION
This PR adds `Particular-ServicePulse-Version` header to all ServiceControl instance calls.
ServiceControl will use this information as part of https://github.com/Particular/ServiceControl/pull/3965.
The plan is to send this data as part of the report generation that customer produce.