### PR TITLE
Fix to prevent flaky tests

### DIFF
--- a/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
+++ b/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
@@ -3,7 +3,7 @@ export default function useAutoRefresh(refreshAction: () => Promise<void>, timeo
 
   function stopTimer() {
     if (refreshInterval !== null) {
-      clearTimeout(refreshInterval);
+      window?.clearTimeout(refreshInterval);
       refreshInterval = null;
     }
   }

--- a/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
+++ b/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
@@ -10,7 +10,7 @@ export default function useAutoRefresh(refreshAction: () => Promise<void>, timeo
 
   function startTimer() {
     stopTimer();
-    refreshInterval = window.setTimeout(() => {
+    refreshInterval = window?.setTimeout(() => {
       executeAndResetTimer();
     }, timeout);
   }

--- a/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
+++ b/src/ServicePulse.Host/vue/src/composables/autoRefresh.ts
@@ -3,7 +3,7 @@ export default function useAutoRefresh(refreshAction: () => Promise<void>, timeo
 
   function stopTimer() {
     if (refreshInterval !== null) {
-      window.clearTimeout(refreshInterval);
+      clearTimeout(refreshInterval);
       refreshInterval = null;
     }
   }


### PR DESCRIPTION
This is an attempt to prevent flaky application tests. Sometimes, the window object could have been disposed from the test environment by the time window.clearTimeout is invoked. It may be the case that this change is not enough, and invoking the clearTimeout function directly instead of a window.clearTimeout also fails. 

<img width="840" alt="image" src="https://github.com/Particular/ServicePulse/assets/545695/139e670d-7827-444b-a331-316c9ae4f7f1">
