### PR TITLE
When editing a failed message copy from edited headers only keys and values

### DIFF
--- a/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
+++ b/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
@@ -23,10 +23,15 @@ export async function useRetryEditedMessage(
   id: string,
   editedMessage: Ref<{
     messageBody: string;
-    headers: unknown[];
+    headers: any[];
   }>
 ) {
-  const payload = { message_body: editedMessage.value.messageBody, message_headers: editedMessage.value.headers };
+  let editedHeaders: { [key: string]: string } = {};
+  for (let index = 0; index < editedMessage.value.headers.length; index++) {
+    const header = editedMessage.value.headers[index];
+    editedHeaders[header.key] = header.value;
+  }
+  const payload = { message_body: editedMessage.value.messageBody, message_headers: editedHeaders };
   const response = await usePostToServiceControl(`edit/${id}`, payload);
   if (!response.ok) {
     throw new Error(response.statusText);

--- a/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
+++ b/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
@@ -26,12 +26,13 @@ export async function useRetryEditedMessage(
     headers: any[];
   }>
 ) {
-  let editedHeaders: { [key: string]: string } = {};
-  for (let index = 0; index < editedMessage.value.headers.length; index++) {
-    const header = editedMessage.value.headers[index];
-    editedHeaders[header.key] = header.value;
-  }
-  const payload = { message_body: editedMessage.value.messageBody, message_headers: editedHeaders };
+  const payload = {
+    message_body: editedMessage.value.messageBody,
+    message_headers: editedMessage.value.headers.reduce((result, header) => {
+      const { key, value } = header as { key: string; value: string };
+      result[key] = value;
+      return result;
+    }, {} as { [key: string]: string }),
   const response = await usePostToServiceControl(`edit/${id}`, payload);
   if (!response.ok) {
     throw new Error(response.statusText);

--- a/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
+++ b/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
@@ -1,5 +1,7 @@
 import { usePatchToServiceControl, usePostToServiceControl } from "./serviceServiceControlUrls";
 import type { Ref } from "vue";
+import { useIsSupported } from "@/composables/serviceSemVer";
+import { environment } from "@/composables/serviceServiceControl";
 
 export async function useUnarchiveMessage(ids: string[]) {
   const response = await usePatchToServiceControl("errors/unarchive/", ids);
@@ -26,13 +28,19 @@ export async function useRetryEditedMessage(
     headers: any[];
   }>
 ) {
-  const payload = {
-    message_body: editedMessage.value.messageBody,
-    message_headers: editedMessage.value.headers.reduce((result, header) => {
+  let headers = editedMessage.value.headers;
+  if (useIsSupported(environment.sc_version, "5.2.0")) {
+    headers = editedMessage.value.headers.reduce((result, header) => {
       const { key, value } = header as { key: string; value: string };
       result[key] = value;
       return result;
-    }, {} as { [key: string]: string }) };
+    }, {} as { [key: string]: string });
+  }
+ 
+  const payload = {
+    message_body: editedMessage.value.messageBody,
+    message_headers: headers
+  }
   const response = await usePostToServiceControl(`edit/${id}`, payload);
   if (!response.ok) {
     throw new Error(response.statusText);

--- a/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
+++ b/src/ServicePulse.Host/vue/src/composables/serviceFailedMessage.ts
@@ -32,7 +32,7 @@ export async function useRetryEditedMessage(
       const { key, value } = header as { key: string; value: string };
       result[key] = value;
       return result;
-    }, {} as { [key: string]: string }),
+    }, {} as { [key: string]: string }) };
   const response = await usePostToServiceControl(`edit/${id}`, payload);
   if (!response.ok) {
     throw new Error(response.statusText);


### PR DESCRIPTION
The ServiceControl `master` branch switched from `Newtonsoft.Json` to `System.Text.Json`, which is less permissive.

When ServicePulse retries an edited failed message, it posts to ServiceControl the edited body and edited headers alongside a bunch of unrelated header properties (that ServicePulse uses to pilot the edit dialog user interface). `Newtonsoft.Json` happily accepted the incoming headers with additional properties to an `IEnumerable<KeyValuePair<string, string>>`, discarding the additional properties. The most recent ServiceControl version expects a `Dictionary<string, string>` and `System.Text.Json` is not so flexible and throws a deserialization exception.

This PR changes how ServicePulse posts the header by only posting header keys and values without the additional properties.

- [x] Test on ServiceControl `master`
- [x] Test on ServiceControl 5.1.0
- [x] Test on ServiceControl 5.0.5
- [x] Test on ServiceControl 4.33.x
