### PR TITLE
Remove AngularJS and Nginx from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Install the following dependencies if you don't have them installed yet.
 - [Git for Windows](https://gitforwindows.org/)
 - [Node.js](https://nodejs.org/en/download/)
   - **NOTE:** It is good practice when installing or updating node.js on your local environment also to check and make sure that the node.js version for the `ci.yml` and `release.yml` workflows match the version of your local environment. Look for the step `name: Set up Node.js`
-  - **NOTE:** If running docker for Windows, the current user needs to be in the docker-users local group. If your Windows account differs from the installation (admin) account, you must manually add your user to the group. See <https://docs.docker.com/desktop/faqs/windowsfaqs/#why-do-i-see-the-docker-desktop-access-denied-error-message-when-i-try-to-start-docker-desktop>
 
 ### Set development environment
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Install the following dependencies if you don't have them installed yet.
 - [Git for Windows](https://gitforwindows.org/)
 - [Node.js](https://nodejs.org/en/download/)
   - **NOTE:** It is good practice when installing or updating node.js on your local environment also to check and make sure that the node.js version for the `ci.yml` and `release.yml` workflows match the version of your local environment. Look for the step `name: Set up Node.js`
-- [Docker](https://docs.docker.com/get-docker/)
   - **NOTE:** If running docker for Windows, the current user needs to be in the docker-users local group. If your Windows account differs from the installation (admin) account, you must manually add your user to the group. See <https://docs.docker.com/desktop/faqs/windowsfaqs/#why-do-i-see-the-docker-desktop-access-denied-error-message-when-i-try-to-start-docker-desktop>
 
 ### Set development environment

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Install the following dependencies if you don't have them installed yet.
 
 ### Set development environment
 
-> The `ServicePulse\src\run-dev.cmd` batch file will execute steps 1 - 3.
 
 #### Step 0 - Using a suitable IDE for frontend development
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ After doing the above steps, navigate to the URL presented by the execution of t
 - `lint` - checks with eslint all vue, ts, and js files
 - `type-check` - runs TypeScript in no emit mode
 
-> [!NOTE]
-> Webpack observes files and updates the artifacts whenever they are changed; however, at the moment, not every bit of code is processed by Webpack. Only monitoring and configuration-related files are.
 
 ### Configuring automated tests
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Install the following dependencies if you don't have them installed yet.
 
 ### Set development environment
 
-> [!TIP]
 > The `ServicePulse\src\run-dev.cmd` batch file will execute steps 1 - 3.
 
 #### Step 0 - Using a suitable IDE for frontend development

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ Install the following dependencies if you don't have them installed yet.
   - **NOTE:** It is good practice when installing or updating node.js on your local environment also to check and make sure that the node.js version for the `ci.yml` and `release.yml` workflows match the version of your local environment. Look for the step `name: Set up Node.js`
 - [Docker](https://docs.docker.com/get-docker/)
   - **NOTE:** If running docker for Windows, the current user needs to be in the docker-users local group. If your Windows account differs from the installation (admin) account, you must manually add your user to the group. See <https://docs.docker.com/desktop/faqs/windowsfaqs/#why-do-i-see-the-docker-desktop-access-denied-error-message-when-i-try-to-start-docker-desktop>
-- Chutzpah
-  - [Test Adapter for the Test Explorer](https://marketplace.visualstudio.com/items?itemName=vs-publisher-2795.ChutzpahTestAdapterfortheTestExplorer)
-  - [Test Runner Context Menu Extension](https://marketplace.visualstudio.com/items?itemName=vs-publisher-2795.ChutzpahTestRunnerContextMenuExtension)
 
 ### Set development environment
 

--- a/README.md
+++ b/README.md
@@ -8,32 +8,6 @@ See the [ServicePulse documentation](https://docs.particular.net/servicepulse/) 
 
 ## Setting up the project for development
 
-ServicePulse is in the process of migrating from AngularJS to Vue.js, during which both frameworks are used to serve parts of the application. In the development environment, AngularJS and Vue.js HTTP servers are run side-by-side behind a reverse proxy. This enables accessing both applications from the same domain, i.e., `localhost:1331` where uri prefixed with `/a/` are served by AngularJS, and Vue.js handles the rest. This mimics the production deployment where the Vue.js application is deployed in the main folder and AngularJS in the `/a/` subfolder. 
-
-
-```mermaid
-graph LR
-  subgraph ServiceControl
-    ScMonitoring
-    ScError
-  end
-
-  subgraph ServicePulse
-    AngularJs
-    VueJs
-  end
-
-  Browser --> Nginx[Nginx<br>Reverse Proxy]
-  Nginx -- http://host.docker.internal:5174/a/ --> AngularJs[AngularJS<br> Development Server]
-  Nginx -- http://host.docker.internal:5173 --> VueJs[Vue.js<br> Development Server]
-
-  AngularJs --> ScMonitoring[Monitoring Instance]
-  AngularJs --> ScError[Main Instance]
-
-  VueJs --> ScMonitoring
-  VueJs --> ScError
-```
-
 ### Setting up ServiceControl Main and ServiceControl Monitoring instances
 
 ServicePulse mainly presents data provided by [ServiceControl](https://docs.particular.net/servicecontrol) and [ServiceControl Monitoring](https://docs.particular.net/servicecontrol/monitoring-instances/) instances.
@@ -46,13 +20,13 @@ ServicePulse uses [npm](https://www.npmjs.com/) and [Bower](https://bower.io/) a
 
 #### Install dependencies
 
-Install the following dependencies if you don't have them installed yet
+Install the following dependencies if you don't have them installed yet.
 
 - [Git for Windows](https://gitforwindows.org/)
 - [Node.js](https://nodejs.org/en/download/)
-  - **NOTE:** It is good practice when installing or updating node.js on your local environment to also check and make sure that the node.js version for the `ci.yml` and `release.yml` workflows match the version of your local environment. Look for the step `name: Set up Node.js`
+  - **NOTE:** It is good practice when installing or updating node.js on your local environment also to check and make sure that the node.js version for the `ci.yml` and `release.yml` workflows match the version of your local environment. Look for the step `name: Set up Node.js`
 - [Docker](https://docs.docker.com/get-docker/)
-  - **NOTE:** If running docker for windows, the current user needs to be in the docker-users local group. If your windows account is different to the installation (admin) account, then you will need to manually add your user to the group. See https://docs.docker.com/desktop/faqs/windowsfaqs/#why-do-i-see-the-docker-desktop-access-denied-error-message-when-i-try-to-start-docker-desktop
+  - **NOTE:** If running docker for Windows, the current user needs to be in the docker-users local group. If your Windows account differs from the installation (admin) account, you must manually add your user to the group. See <https://docs.docker.com/desktop/faqs/windowsfaqs/#why-do-i-see-the-docker-desktop-access-denied-error-message-when-i-try-to-start-docker-desktop>
 - Chutzpah
   - [Test Adapter for the Test Explorer](https://marketplace.visualstudio.com/items?itemName=vs-publisher-2795.ChutzpahTestAdapterfortheTestExplorer)
   - [Test Runner Context Menu Extension](https://marketplace.visualstudio.com/items?itemName=vs-publisher-2795.ChutzpahTestRunnerContextMenuExtension)
@@ -60,32 +34,14 @@ Install the following dependencies if you don't have them installed yet
 ### Set development environment
 
 > [!TIP]
-> Using the `ServicePulse\src\run-dev.cmd` batch file will execute steps 1 - 3.
+> The `ServicePulse\src\run-dev.cmd` batch file will execute steps 1 - 3.
 
 #### Step 0 - Using a suitable IDE for frontend development
 
-Even though Visual Studio or Rider seem to be adequate IDEs for front-end development, they don't tend to do a good job with the latest front-end frameworks, linting, and formatting.
-Because of that, we have [extra recommendations](/docs/frontend/frontend-ide.md) for you to be even more successful at front-end development.
-
-#### Step 1 - run the Nginx reverse proxy
-
-Open a command window and navigate to `ServicePulse\src\ServicePulse.Host` path (NOTE: On Windows, ensure [cmd](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd) is being used and not [PowerShell](https://learn.microsoft.com/en-us/powershell/)). Run `nginx` that will act as the reverse proxy for AngularJS and Vue.js applications:
-
-```cmd
-docker run -it --rm -p 1331:1331 -v ./nginx.conf:/etc/nginx/nginx.conf:ro --name service-pulse-dev nginx
-```
-
-#### Step 2 - run the AngularJS development server 
-
-Navigate to `ServicePulse\src\ServicePulse.Host\angular` and:
-
-- run `npm install` to install all the npm dependencies
-- run the following command `npm run dev`. This will host a dev server on port 5174 and start watching for changes in `/angular` directory
-
-> [!NOTE]
-> For compatibility with Node.js versions 17 and higher, it's essential to set the `NODE_OPTIONS` environment variable to `--openssl-legacy-provider` when loading and running the angularJS app. This configuration is specified in the `.npmrc` file located at the root of the Angular folder `ServicePulse\src\ServicePulse.Host\angular`. Any npm command executed from the Angular directory, including those in CI/Release workflows, will automatically have the necessary environment variable set.
+Even though Visual Studio or Rider seem to be adequate IDEs for front-end development, they tend to be unreliable with the latest front-end frameworks, linting, and formatting.
+Because of that, we have [extra recommendations](/docs/frontend/frontend-ide.md) to help you be even more successful at front-end development.
  
-#### Step 3 - run the Vue.js development server 
+#### Step 1 - run the Vue.js development server 
 
 Navigate to `ServicePulse\src\ServicePulse.Host\vue` and:
 
@@ -94,40 +50,25 @@ Navigate to `ServicePulse\src\ServicePulse.Host\vue` and:
 
 If `npm run dev` fails with an error related to git submodules not being correctly configured, run the `npm install` command again to ensure all required dependencies are available, and then run `npm run dev`.
 
-#### Step 4 - open the browser
+#### Step 2 - open the browser
 
-After doing the above steps, navigate to `http://localhost:1331` to see the ServicePulse application.
+After doing the above steps, navigate to the URL presented by the execution of the Vue.js application to see the ServicePulse application.
 
 ### Provided npm scripts
 
 #### Vue.js
 
-- `dev` - runs `vite` that starts development server doing hot reload over source files
+- `dev` - runs `vite` that starts the development server doing hot reload over source files
 - `build` - runs build script that outputs files to `..\app` folder
-- `lint` - checks with eslint all vue, ts and js files
+- `lint` - checks with eslint all vue, ts, and js files
 - `type-check` - runs TypeScript in no emit mode
 
-#### AngularJS
-
-- `test` - runs js tests in ServicePulse.Host.Test project
-- `setup` - this command runs few commands
-  - installs the npm packages
-  - runs `webpack`
-- `load` - this command does the same thing that `setup` but webpack is run only once to produce artifacts. This command is used by the builder
-- `serve` - serves js artifacts using `http-server`
-- `webpack` - runs webpack command, which does the following things for the given modules (monitoring, configuration)
-  - joins js together
-  - runs babel transpiler
-  - has a file watcher to run the above whenever file is saved
-- `lint` - checks with eslint all js files
-- `dev` - runs in parallel two scripts `webpack` and `serve`
-
-NOTE:
-Webpack observes files and updates the artifacts whenever they are changed, however at the moment not every bit of code is processed by webpack. Only monitoring and configuration-related files are.
+> [!NOTE]
+> Webpack observes files and updates the artifacts whenever they are changed; however, at the moment, not every bit of code is processed by Webpack. Only monitoring and configuration-related files are.
 
 ### Configuring automated tests
 
-For information on how to run automated tests, please follow [ServicePulse.Host.Tests/Readme](https://github.com/Particular/ServicePulse/blob/master/src/ServicePulse.Host.Tests/README.md).
+For information on running automated tests, please follow [ServicePulse.Host.Tests/Readme](https://github.com/Particular/ServicePulse/blob/master/src/ServicePulse.Host.Tests/README.md).
 
 ## Running from ServicePulse.Host.exe
 
@@ -135,7 +76,7 @@ It is possible to run ServicePulse directly via `ServicePulse.Host.exe`.
 
 ### Step 1 - reserve URL ACL
 
-ServicePulse.Host.exe depends on a self-hosted web server. A URL ACL reservation needs to be set up to start the project. Either run Visual Studio with Administrative privileges or run the following command to add the required URL ACL reservation:
+ServicePulse.Host.exe depends on a self-hosted web server. A URL ACL reservation needs to be set up before the project can run. Either run Visual Studio with Administrative privileges or run the following command to add the required URL ACL reservation:
 
 ```
 add urlacl url=URL
@@ -151,7 +92,8 @@ Execute the build script from the command line:
 PowerShell -File .\build.ps1
 ```
 
-NOTE: It might be necessary to change the PowerShell execution policy using `Set-ExecutionPolicy Unrestricted -scope UserPolicy`
+> [!NOTE]
+> It might be necessary to change the PowerShell execution policy using `Set-ExecutionPolicy Unrestricted -scope UserPolicy`
 
 ### Step 3 - run `ServicePulse.Host.exe`
 
@@ -177,23 +119,23 @@ Dockerfiles for ServicePulse resides within the [`src`](https://github.com/Parti
 
 The docker files are all built as part of the [release workflow](https://github.com/Particular/ServicePulse/blob/master/.github/workflows/release.yml), pushed to the Docker hub, and tagged with the version of ServicePulse being deployed. More details are available in the [documentation](https://docs.particular.net/servicepulse/containerization/).
 
-E.g., If we were deploying version 1.30.1 of ServicePulse, the build configurations after the Deploy step will build the following 2 containers for ServicePulse and tag them `1.30.1`:
+For example, If we were deploying version 1.30.1 of ServicePulse, the build configurations after the Deploy step will build the following 2 containers for ServicePulse and tag them `1.30.1`:
 
 - `particular/servicepulse:1.30.1`
 - `particular/servicepule-windows:1.30.1`
 
-These images are tagged with the specific version of ServicePulse being built and pushed to the corresponding public `particular/servicepulse{-os}` repositories. At this point, the docker images are considered staged. This means that if someone is watching the feed directly, they can install the staged images by explicitly specifying the exact tag, e.g., `docker pull particular/servicepulse:1.30.1`.
+These images are tagged with the specific version of ServicePulse being built and pushed to the corresponding public `particular/servicepulse{-os}` repositories. At this point, the docker images are considered staged. If someone is watching the feed directly, they can install the staged images by explicitly specifying the exact tag, e.g., `docker pull particular/servicepulse:1.30.1`.
 
 ### Promoting docker images to production
 
 When a ServicePulse release is promoted to production, one of the steps is to take the staged images and re-tag them as the following:
 
 - `particular/servicepulse:1.30.1` => `particular/servicepulse:1`
-  - This is so that customers who are only interested in updates within a major can install the specific major only and not worry about breaking changes between major versions being automatically rolled out. Useful for auto upgrading containers in a _production_ environment.
+  - This is so that customers interested in updates within a major can install the specific major only and not worry about breaking changes between major versions being automatically rolled out. Useful for auto-upgrading containers in a _production_ environment.
 - `particular/servicepulse:1.30.1` => `particular/servicepulse:latest`
   - Primarily for developers wanting to use the latest version (`docker-compose up -d --build --force-recreate --renew-anon-volumes`
-  - This is only in the case where the release's major version is the same as the current latest major version.
-    - If a fix is being backported to a previous major then the `:latest` tag will not be updated.
-    - If a release targets the current latest major or is a new major after the previous latest then the `:latest` tag is updated to match the version being released.
+  - This is only true if the release's major version is the same as the current latest major version.
+    - If a fix is being backported to a previous major, then the `:latest` tag will not be updated.
+    - If a release targets the current latest major or is a new major after the previous latest, then the `:latest` tag is updated to match the version being released.
 
 Once the tagging has been completed, the images are considered to be publicly released.


### PR DESCRIPTION
Now that the ServicePulse `master` branch no longer uses AngularJS, there is no need to set up the Nginx proxy and run an AngularJS development server. This PR updates the README to remove those requirements, applies minor wording changes, and fixes some typos.