### PR TITLE
Use the X-Particular-Reason header to get the response StatusText from ServiceControl versions later than 5.1

### DIFF
--- a/src/Frontend/src/composables/serviceNotifications.ts
+++ b/src/Frontend/src/composables/serviceNotifications.ts
@@ -2,6 +2,8 @@ import { usePostToServiceControl, useTypedFetchFromServiceControl } from "./serv
 
 import type EmailNotifications from "@/resources/EmailNotifications";
 import type UpdateEmailNotificationsSettingsRequest from "@/resources/UpdateEmailNotificationsSettingsRequest";
+import { useIsSupported } from "@/composables/serviceSemVer";
+import { environment } from "@/composables/serviceServiceControl";
 
 export async function useEmailNotifications() {
   try {
@@ -33,8 +35,16 @@ export async function useUpdateEmailNotifications(settings: UpdateEmailNotificat
 export async function useTestEmailNotifications() {
   try {
     const response = await usePostToServiceControl("notifications/email/test");
+
+    let responseStatusText;
+    if (useIsSupported(environment.sc_version, "5.2.0")) {
+      responseStatusText = response.headers.get("X-Particular-Reason");
+    }else{
+      responseStatusText = response.statusText;
+    }
+
     return {
-      message: response.ok ? "success" : "error:" + response.statusText,
+      message: response.ok ? "success" : "error:" + responseStatusText,
     };
   } catch (err) {
     console.log(err);

--- a/src/Frontend/src/composables/serviceNotifications.ts
+++ b/src/Frontend/src/composables/serviceNotifications.ts
@@ -37,9 +37,9 @@ export async function useTestEmailNotifications() {
     const response = await usePostToServiceControl("notifications/email/test");
 
     let responseStatusText;
-    if (useIsSupported(environment.sc_version, "5.2.0")) {
+    if (useIsSupported(environment.sc_version, "5.2")) {
       responseStatusText = response.headers.get("X-Particular-Reason");
-    }else{
+    } else{
       responseStatusText = response.statusText;
     }
 

--- a/src/Frontend/src/composables/serviceRedirects.ts
+++ b/src/Frontend/src/composables/serviceRedirects.ts
@@ -52,7 +52,7 @@ export async function useUpdateRedirects(redirectId: string, sourceEndpoint: str
   let responseStatusText;
   if (useIsSupported(environment.sc_version, "5.2.0")) {
     responseStatusText = response.headers.get("X-Particular-Reason");
-  }else{
+  } else{
     responseStatusText = response.statusText;
   }
 
@@ -73,7 +73,7 @@ export async function useCreateRedirects(sourceEndpoint: string, targetEndpoint:
   let responseStatusText;
   if (useIsSupported(environment.sc_version, "5.2.0")) {
     responseStatusText = response.headers.get("X-Particular-Reason");
-  }else{
+  } else{
     responseStatusText = response.statusText;
   }
 
@@ -90,7 +90,7 @@ export async function useDeleteRedirects(redirectId: string) {
   let responseStatusText;
   if (useIsSupported(environment.sc_version, "5.2.0")) {
     responseStatusText = response.headers.get("X-Particular-Reason");
-  }else{
+  } else{
     responseStatusText = response.statusText;
   }
 

--- a/src/Frontend/src/composables/serviceRedirects.ts
+++ b/src/Frontend/src/composables/serviceRedirects.ts
@@ -1,6 +1,8 @@
 import { useDeleteFromServiceControl, usePostToServiceControl, usePutToServiceControl, useTypedFetchFromServiceControl } from "./serviceServiceControlUrls";
 import type Redirect from "@/resources/Redirect";
 import type QueueAddress from "@/resources/QueueAddress";
+import { useIsSupported } from "@/composables/serviceSemVer";
+import { environment } from "@/composables/serviceServiceControl";
 
 export interface Redirects {
   data: Redirect[];
@@ -46,10 +48,18 @@ export async function useUpdateRedirects(redirectId: string, sourceEndpoint: str
     fromphysicaladdress: sourceEndpoint,
     tophysicaladdress: targetEndpoint,
   });
+
+  let responseStatusText;
+  if (useIsSupported(environment.sc_version, "5.2.0")) {
+    responseStatusText = response.headers.get("X-Particular-Reason");
+  }else{
+    responseStatusText = response.statusText;
+  }
+
   return {
     message: response.ok ? "success" : `error:${response.statusText}`,
     status: response.status,
-    statusText: response.statusText,
+    statusText: responseStatusText,
     data: response,
   };
 }
@@ -59,19 +69,35 @@ export async function useCreateRedirects(sourceEndpoint: string, targetEndpoint:
     fromphysicaladdress: sourceEndpoint,
     tophysicaladdress: targetEndpoint,
   });
+
+  let responseStatusText;
+  if (useIsSupported(environment.sc_version, "5.2.0")) {
+    responseStatusText = response.headers.get("X-Particular-Reason");
+  }else{
+    responseStatusText = response.statusText;
+  }
+
   return {
     message: response.ok ? "success" : `error:${response.statusText}`,
     status: response.status,
-    statusText: response.statusText,
+    statusText: responseStatusText,
   };
 }
 
 export async function useDeleteRedirects(redirectId: string) {
   const response = await useDeleteFromServiceControl(`redirects/${redirectId}`);
+  
+  let responseStatusText;
+  if (useIsSupported(environment.sc_version, "5.2.0")) {
+    responseStatusText = response.headers.get("X-Particular-Reason");
+  }else{
+    responseStatusText = response.statusText;
+  }
+
   return {
     message: response.ok ? "success" : `error:${response.statusText}`,
     status: response.status,
-    statusText: response.statusText,
+    statusText: responseStatusText,
     data: response,
   };
 }


### PR DESCRIPTION
HTTP/2 doesn't support the reason phrase when returning errors in an HTTP response. In ServiceControl, we then stopped using it and, for now, moved to a custom `X-Particular-Reason` header ([see, for example, this controller](https://github.com/Particular/ServiceControl/blob/da452ea82a2cf6aca420d73029c7861cc009c764/src/ServiceControl/MessageRedirects/Api/MessageRedirectsController.cs#L55-L58)). A proper solution is more complex and out of scope for now. 

This PR updates ServicePulse to use the new header.