### PR TITLE
Ensure mockServiceWorker.js is not included in the build

### DIFF
--- a/src/Frontend/package.json
+++ b/src/Frontend/package.json
@@ -61,10 +61,5 @@
     "vite-plugin-checker": "^0.6.4",
     "vitest": "^1.2.2",
     "vue-tsc": "^1.8.25"
-  },
-  "msw": {
-    "workerDirectory": [
-      "public"
-    ]
-  }
+  }  
 }

--- a/src/Frontend/package.json
+++ b/src/Frontend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "msw:cleanup": "rm public/mockServiceWorker.js",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "preview": "vite preview",

--- a/src/Frontend/package.json
+++ b/src/Frontend/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "msw:cleanup": "rm public/mockServiceWorker.js",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "preview": "vite preview",

--- a/src/ServicePulse.Host/build.ps1
+++ b/src/ServicePulse.Host/build.ps1
@@ -10,6 +10,7 @@ New-Item -ItemType Directory -Force -Path $AppOutputFolder
 
 cd $FrontendSourceFolder
 npm install
+npm run msw:cleanup
 npm run build
 if ( $? -eq $false ) {
     exit $LastExitCode

--- a/src/ServicePulse.Host/build.ps1
+++ b/src/ServicePulse.Host/build.ps1
@@ -10,7 +10,6 @@ New-Item -ItemType Directory -Force -Path $AppOutputFolder
 
 cd $FrontendSourceFolder
 npm install
-npm run msw:cleanup
 npm run build
 if ( $? -eq $false ) {
     exit $LastExitCode


### PR DESCRIPTION
Remove msw dir setting in package.json file in order to prevent the generation of mockServiceWorker.js when restoring dependencies