### PR TITLE
Fix the retry redirect error message to not mention audited messages

### DIFF
--- a/src/Frontend/src/components/configuration/RetryRedirectEdit.vue
+++ b/src/Frontend/src/components/configuration/RetryRedirectEdit.vue
@@ -127,12 +127,12 @@ function close() {
 
                   <template v-if="noKnownQueues">
                     <div :class="{ 'has-error': noKnownQueues }">
-                      <p class="control-label">No known queues found. You can provide a not-known queue name, but if you don't provide a valid address, the redirected message will be lost.</p>
+                      <p class="control-label">No known queues found. You can enter a queue name manually, but if you don't provide a valid address, the redirected message will be lost.</p>
                     </div>
                   </template>
                   <template v-if="notKnownQueue">
                     <div :class="{ 'has-error': notKnownQueue }">
-                      <p class="control-label">Target queue does not match any known queue. You can provide a not-known queue name, but if you don't provide a valid address, the redirected message will be lost.</p>
+                      <p class="control-label">Target queue does not match any known queue. You can enter a queue name manually, but if you don't provide a valid address, the redirected message will be lost.</p>
                     </div>
                   </template>
                 </div>

--- a/src/Frontend/src/components/configuration/RetryRedirectEdit.vue
+++ b/src/Frontend/src/components/configuration/RetryRedirectEdit.vue
@@ -127,12 +127,12 @@ function close() {
 
                   <template v-if="noKnownQueues">
                     <div :class="{ 'has-error': noKnownQueues }">
-                      <p class="control-label">No known queues found. You can provide a non-audited queue name, but if you don't provide a valid address, the redirected message will be lost.</p>
+                      <p class="control-label">No known queues found. You can provide a not-known queue name, but if you don't provide a valid address, the redirected message will be lost.</p>
                     </div>
                   </template>
                   <template v-if="notKnownQueue">
                     <div :class="{ 'has-error': notKnownQueue }">
-                      <p class="control-label">Target queue does not match any known queue. You can provide a non-audited queue name, but if you don't provide a valid address, the redirected message will be lost.</p>
+                      <p class="control-label">Target queue does not match any known queue. You can provide a not-known queue name, but if you don't provide a valid address, the redirected message will be lost.</p>
                     </div>
                   </template>
                 </div>


### PR DESCRIPTION
When using retry redirects, ServicePulse warns when the "To physical address" endpoint is unknown. The error message talks about audited messages and is misleading. ServicePulse only queries for queues where a message failed. This PR fixes the error message.

![image](https://github.com/Particular/ServicePulse/assets/1325611/ac51d6d2-efbd-4108-a03d-9755783f7b13)
