### PR TITLE
Report build fix: Adding default mocked respones for /licensing/* API calls

### DIFF
--- a/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
+++ b/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
@@ -1,5 +1,8 @@
+import ConnectionTestResults, { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
 import * as precondition from ".";
 import { SetupFactoryOptions } from "../driver";
+import EndpointThroughputSummary from "@/resources/EndpointThroughputSummary";
+import ReportGenerationState from "@/resources/ReportGenerationState";
 
 export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptions) => {
   //Service control requests minimum setup. Todo: encapsulate for reuse.
@@ -42,4 +45,51 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
 
   //http://localhost:33633/monitored-endpoints
   await driver.setUp(precondition.hasNoMonitoredEndpoints);
+
+  //Default handler for /api/licensing/report/available
+  driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/report/available`, {
+    body: <ReportGenerationState>{
+      transport: "LearningTransport",
+      report_can_be_generated: true,
+      reason: "",
+    },
+    method: "get",
+    status: 200,
+  });
+
+  //Default handler for /api/licensing/endpoints
+  driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/endpoints`, {
+    body: [<EndpointThroughputSummary>{
+      name: "",
+      is_known_endpoint: true,
+      user_indicator: "",
+      max_daily_throughput: 10,
+    }],
+    method: "get",
+    status: 200,
+  });
+
+  //Default handler for /api/licensing/settings/test
+  driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/settings/test`, {
+    body: <ConnectionTestResults>{
+      transport: "",
+      audit_connection_result: <ConnectionSettingsTestResult>{
+        connection_successful: true,
+        connection_error_messages: [],
+        diagnostics: "",
+      },
+      monitoring_connection_result: <ConnectionSettingsTestResult>{
+        connection_successful: true,
+        connection_error_messages: [],
+        diagnostics: "",
+      },
+      broker_connection_result: <ConnectionSettingsTestResult>{
+        connection_successful: true,
+        connection_error_messages: [],
+        diagnostics: "",
+      },
+    },
+    method: "get",
+    status: 200,
+  });
 };


### PR DESCRIPTION
Since the acceptance tests setup run the whole application for every single test, every call that can potentially be made to Service Control requires to be mocked. This PR adds default handlers for the /licensing paths (/test, /endpoints, /available) 

Since this commit [1c1640f](https://github.com/Particular/ServicePulse/pull/1746/commits/1c1640f8a20e4c71ef38bc40915e65992742970e) is now initializing the report store from the menuItem, it triggers the Throughput client, which in turn calls /licenses/tests in a timer. This requires having the report paths at least with a default handler. These handlers can be overwritten when writing specific test cases. 