### PR TITLE
Remove unnecessary monitoring-endpoint calls

### DIFF
--- a/src/Frontend/src/composables/serviceServiceControl.ts
+++ b/src/Frontend/src/composables/serviceServiceControl.ts
@@ -8,6 +8,7 @@ import type RootUrls from "@/resources/RootUrls";
 import type FailedMessage from "@/resources/FailedMessage";
 import type MonitoredEndpoint from "@/resources/MonitoredEndpoint";
 import { FailedMessageStatus } from "@/resources/FailedMessage";
+import { useMonitoringStore } from "@/stores/MonitoringStore";
 
 export const stats = reactive({
   active_endpoints: 0,
@@ -160,10 +161,9 @@ async function useServiceControlStats() {
 }
 
 async function useServiceControlMonitoringStats() {
-  const monitoredEndpointsResult = getMonitoredEndpoints();
   const disconnectedEndpointsCountResult = getDisconnectedEndpointsCount();
 
-  const [, disconnectedEndpoints] = await Promise.all([monitoredEndpointsResult, disconnectedEndpointsCountResult]);
+  const [disconnectedEndpoints] = await Promise.all([disconnectedEndpointsCountResult]);
   //Do something here with the argument to the callback in the future if we are using them
   stats.number_of_disconnected_endpoints = disconnectedEndpoints;
 }
@@ -183,11 +183,14 @@ export async function useServiceControlConnections() {
   return connections;
 }
 
-watch(() => environment.is_compatible_with_sc, (newValue) => {  
-  if (newValue == false) {
-    useShowToast(TYPE.ERROR, "Error", `You are using Service Control version ${environment.sc_version}. Please, upgrade to version ${environment.minimum_supported_sc_version} or higher to unlock new functionality in ServicePulse.`);
-  }  
-});
+watch(
+  () => environment.is_compatible_with_sc,
+  (newValue) => {
+    if (newValue == false) {
+      useShowToast(TYPE.ERROR, "Error", `You are using Service Control version ${environment.sc_version}. Please, upgrade to version ${environment.minimum_supported_sc_version} or higher to unlock new functionality in ServicePulse.`);
+    }
+  }
+);
 
 async function getServiceControlVersion() {
   const productsResult = useServiceProductUrls();

--- a/src/Frontend/src/composables/serviceServiceControl.ts
+++ b/src/Frontend/src/composables/serviceServiceControl.ts
@@ -8,7 +8,6 @@ import type RootUrls from "@/resources/RootUrls";
 import type FailedMessage from "@/resources/FailedMessage";
 import type MonitoredEndpoint from "@/resources/MonitoredEndpoint";
 import { FailedMessageStatus } from "@/resources/FailedMessage";
-import { useMonitoringStore } from "@/stores/MonitoringStore";
 
 export const stats = reactive({
   active_endpoints: 0,

--- a/src/Frontend/src/stores/MonitoringStore.ts
+++ b/src/Frontend/src/stores/MonitoringStore.ts
@@ -27,7 +27,6 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
   const endpointList = ref<Endpoint[]>([]);
   const disconnectedEndpointCount = ref(0);
   const filterString = ref("");
-  const isInitialized = ref(false);
   const endpointListCount = computed<number>(() => endpointList.value.length);
   const endpointListIsEmpty = computed<boolean>(() => endpointListCount.value === 0);
   const endpointListIsGrouped = computed<boolean>(() => grouping.value.selectedGrouping !== 0);
@@ -39,12 +38,6 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
   });
 
   //STORE ACTIONS
-  async function initializeStore() {
-    await updateFilterString();
-    await updateEndpointList();
-    isInitialized.value = true;
-  }
-
   async function updateFilterString(filter: string | null = null) {
     filterString.value = filter ?? route.query.filter?.toString() ?? "";
 
@@ -54,7 +47,6 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
     } else {
       await router.replace({ query: { ...route.query, filter: filterString.value } }); // Update or add filter query parameter to url
     }
-    await updateEndpointList();
     updateGroupedEndpoints();
   }
 
@@ -133,7 +125,6 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
     disconnectedEndpointCount,
     filterString,
     sortBy,
-    isInitialized,
 
     //getters
     endpointListCount,
@@ -142,7 +133,6 @@ export const useMonitoringStore = defineStore("MonitoringStore", () => {
     getEndpointList,
 
     //actions
-    initializeStore,
     updateSelectedGrouping,
     updateEndpointList,
     updateFilterString,

--- a/src/Frontend/src/views/MonitoringView.vue
+++ b/src/Frontend/src/views/MonitoringView.vue
@@ -40,7 +40,7 @@ onUnmounted(() => {
 });
 
 onMounted(async () => {
-  await monitoringStore.initializeStore();
+  await monitoringStore.updateFilterString();
   await changeRefreshInterval(monitoringHistoryPeriodStore.historyPeriod.refreshIntervalVal);
 });
 </script>
@@ -50,7 +50,7 @@ onMounted(async () => {
   <template v-if="!licenseStatus.isExpired">
     <div class="container monitoring-view">
       <ServiceControlNotAvailable />
-      <template v-if="connectionState.connected && monitoringStore.isInitialized">
+      <template v-if="connectionState.connected">
         <MonitoringNoData v-if="noData"></MonitoringNoData>
         <template v-if="!noData">
           <MonitoringHead />


### PR DESCRIPTION
This removes a call to get monitored-endpoints from `useServiceControlMonitoringStats()`, since the results are never used there is no reason to set an interval to call this function every 5 seconds on app start up.

Also, refactored the monitoring store, removing the `initializeStore()` function

In the master branch you can see that even when the history period is set to 10 minutes (so the refresh should be 10 seconds) the fetch is happening 3 times right after the page is reloaded. And there is also a fetch to `history=1`, which was being done on a 5 second interval by the `useServiceControlMonitoringStats()` on app startup.
<img width="608" alt="image" src="https://github.com/Particular/ServicePulse/assets/87037242/3477fa46-f71f-412e-863b-12838208b37e">

After removing the fetch calls from the from `useServiceControlMonitoringStats()` the 3 initial fetch calls are removed and the fetch call to `history=1` is also not being called.
<img width="593" alt="image" src="https://github.com/Particular/ServicePulse/assets/87037242/178ce13c-b77a-4c6d-a19e-f360055e1926">