### PR TITLE
Edit and Retry Content type check allows more text based payloads

### DIFF
--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -84,26 +84,23 @@ function getContentType() {
 
 function isContentTypeSupported(contentType: string) {
 
-  if (contentType.startsWith("text/"))
-    return true;
+  if (contentType.startsWith("text/")) return true;
 
-  const charsetUtf8 = "; charset=utf-8"; 
+  const charsetUtf8 = "; charset=utf-8";
 
   if (contentType.endsWith(charsetUtf8)) {
-    contentType = contentType.substring(0,contentType.length - charsetUtf8.length)
+    contentType = contentType.substring(0, contentType.length - charsetUtf8.length)
   }
 
-  if (contentType==="application/json")
-    return true;
-    
+  if (contentType === "application/json") return true;
+
   if (contentType.startsWith("application/")) {
     // Some examples:
     // application/atom+xml
     // application/ld+json
     // application/vnd.masstransit+json
-    if (contentType.endsWith("+json") || contentType.endsWith("+xml"))
-      return true;
-    }
+    if (contentType.endsWith("+json") || contentType.endsWith("+xml")) return true;
+  }
 
   return false;
 }

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -87,10 +87,10 @@ function isContentTypeSupported(contentType: string) {
   if (contentType.startsWith("text/"))
     return true;
 
-  var charsetUtf8 = "; charset=utf-8"; 
+  const charsetUtf8 = "; charset=utf-8"; 
 
   if (contentType.endsWith(charsetUtf8)) {
-    contentType = contentType.substring(0,contentType.length-charsetUtf8.length)
+    contentType = contentType.substring(0,contentType.length - charsetUtf8.length)
   }
 
   if (contentType==="application/json")
@@ -101,7 +101,7 @@ function isContentTypeSupported(contentType: string) {
     // application/atom+xml
     // application/ld+json
     // application/vnd.masstransit+json
-    if(contentType.endsWith("+json") || contentType.endsWith("+xml"))
+    if (contentType.endsWith("+json") || contentType.endsWith("+xml"))
       return true;
     }
 

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -191,15 +191,15 @@ onMounted(() => {
                   </div>
                   <div class="row msg-editor-content">
                     <div class="col-sm-12 no-side-padding">
-                      <div class="row alert alert-warning" v-if="localMessage?.isEvent">
+                      <div class="alert alert-warning" v-if="localMessage?.isEvent">
                         <div class="col-sm-12">
                           <i class="fa fa-exclamation-circle"></i> This message is an event. If it was already successfully handled by other subscribers, editing it now has the risk of changing the semantic meaning of the event and may result in
                           altering the system behavior.
                         </div>
                       </div>
-                      <div class="row alert alert-warning" v-if="!localMessage?.isContentTypeSupported || localMessage?.bodyUnavailable">
+                      <div class="alert alert-warning" v-if="!localMessage?.isContentTypeSupported || localMessage?.bodyUnavailable">
                         <div class="col-sm-12">
-                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}) is not supported. Only messages with content types "application/json" and "text/xml" can be
+                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}" is not supported. Only messages with content types "application/json" and "text/xml" can be
                           edited.
                         </div>
                       </div>

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -83,13 +83,12 @@ function getContentType() {
 }
 
 function isContentTypeSupported(contentType: string) {
-
   if (contentType.startsWith("text/")) return true;
 
   const charsetUtf8 = "; charset=utf-8";
 
   if (contentType.endsWith(charsetUtf8)) {
-    contentType = contentType.substring(0, contentType.length - charsetUtf8.length)
+    contentType = contentType.substring(0, contentType.length - charsetUtf8.length);
   }
 
   if (contentType === "application/json") return true;
@@ -200,7 +199,7 @@ onMounted(() => {
                       </div>
                       <div class="row alert alert-warning" v-if="!localMessage?.isContentTypeSupported || localMessage?.bodyUnavailable">
                         <div class="col-sm-12">
-                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}) is not supported. Only messages with content types "application/json" and "text/xml"can be edited.
+                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}) is not supported. Only messages with content types "application/json" and "text/xml" can be edited.
                         </div>
                       </div>
                       <div class="row alert alert-danger" v-if="showEditRetryGenericError">

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -83,7 +83,29 @@ function getContentType() {
 }
 
 function isContentTypeSupported(contentType: string) {
-  return contentType === "application/json" || contentType === "text/xml";
+
+  if (contentType.startsWith("text/"))
+    return true;
+
+  var charsetUtf8 = "; charset=utf-8"; 
+
+  if (contentType.endsWith(charsetUtf8)) {
+    contentType = contentType.substring(0,contentType.length-charsetUtf8.length)
+  }
+
+  if (contentType==="application/json")
+    return true;
+    
+  if (contentType.startsWith("application/")) {
+    // Some examples:
+    // application/atom+xml
+    // application/ld+json
+    // application/vnd.masstransit+json
+    if(contentType.endsWith("+json") || contentType.endsWith("+xml"))
+      return true;
+    }
+
+  return false;
 }
 
 function getMessageIntent() {
@@ -181,7 +203,7 @@ onMounted(() => {
                       </div>
                       <div class="row alert alert-warning" v-if="!localMessage?.isContentTypeSupported || localMessage?.bodyUnavailable">
                         <div class="col-sm-12">
-                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type ({{ localMessage?.bodyContentType }}) is not supported. Only messages with body content serialized as JSON or XML can be edited.
+                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}) is not supported. Only messages with content types "application/json" and "text/xml"can be edited.
                         </div>
                       </div>
                       <div class="row alert alert-danger" v-if="showEditRetryGenericError">

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -199,7 +199,8 @@ onMounted(() => {
                       </div>
                       <div class="row alert alert-warning" v-if="!localMessage?.isContentTypeSupported || localMessage?.bodyUnavailable">
                         <div class="col-sm-12">
-                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}) is not supported. Only messages with content types "application/json" and "text/xml" can be edited.
+                          <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}) is not supported. Only messages with content types "application/json" and "text/xml" can be
+                          edited.
                         </div>
                       </div>
                       <div class="row alert alert-danger" v-if="showEditRetryGenericError">

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -169,7 +169,7 @@ onMounted(() => {
 
 <template>
   <section name="failed_message_editor">
-    <div class="model modal-msg-editor" style="z-index: 1050; display: block">
+    <div class="model modal-msg-editor" style="z-index: 1050; display: block" role="dialog" aria-label="edit and retry message">
       <div class="modal-mask">
         <div class="modal-dialog">
           <div class="modal-content">
@@ -183,9 +183,9 @@ onMounted(() => {
                 <div class="col-sm-12">
                   <div class="row msg-editor-tabs">
                     <div class="col-sm-12 no-side-padding">
-                      <div class="tabs msg-tabs">
-                        <h5 :class="{ active: panel === 1 }" class="nav-item" @click="togglePanel(1)"><a href="javascript:void(0)">Headers</a></h5>
-                        <h5 :class="{ active: panel === 2 }" class="nav-item" @click="togglePanel(2)"><a href="javascript:void(0)">Message body</a></h5>
+                      <div role="tablist" class="tabs msg-tabs">
+                        <h5 role="tab" :class="{ active: panel === 1 }" class="nav-item" @click="togglePanel(1)"><a href="javascript:void(0)">Headers</a></h5>
+                        <h5 role="tab" :class="{ active: panel === 2 }" class="nav-item" @click="togglePanel(2)"><a href="javascript:void(0)">Message body</a></h5>
                       </div>
                     </div>
                   </div>
@@ -198,7 +198,7 @@ onMounted(() => {
                         </div>
                       </div>
                       <div class="alert alert-warning" v-if="!localMessage?.isContentTypeSupported || localMessage?.bodyUnavailable">
-                        <div class="col-sm-12">
+                        <div role="status" aria-label="cannot edit message body" class="col-sm-12">
                           <i class="fa fa-exclamation-circle"></i> Message body cannot be edited because content type "{{ localMessage?.bodyContentType }}" is not supported. Only messages with content types "application/json" and "text/xml" can be
                           edited.
                         </div>
@@ -206,15 +206,15 @@ onMounted(() => {
                       <div class="row alert alert-danger" v-if="showEditRetryGenericError">
                         <div class="col-sm-12"><i class="fa fa-exclamation-triangle"></i> An error occurred while retrying the message, please check the ServiceControl logs for more details on the failure.</div>
                       </div>
-                      <table class="table" v-if="panel === 1">
+                      <table role="tabpanel" class="table" v-if="panel === 1">
                         <tbody>
                           <tr class="interactiveList" v-for="header in localMessage?.headers" :key="header.key">
                             <MessageHeader :header="header"></MessageHeader>
                           </tr>
                         </tbody>
                       </table>
-                      <div v-if="panel === 2 && !localMessage?.bodyUnavailable" style="height: calc(100% - 260px)">
-                        <textarea class="form-control" :disabled="!localMessage?.isContentTypeSupported" v-model="localMessage.messageBody"></textarea>
+                      <div role="tabpanel" v-if="panel === 2 && !localMessage?.bodyUnavailable" style="height: calc(100% - 260px)">
+                        <textarea aria-label="message body" class="form-control" :disabled="!localMessage?.isContentTypeSupported" v-model="localMessage.messageBody"></textarea>
                         <span class="empty-error" v-if="localMessage?.isBodyEmpty"><i class="fa fa-exclamation-triangle"></i> Message body cannot be empty</span>
                         <span class="reset-body" v-if="localMessage?.isBodyChanged"><i class="fa fa-undo" uib-tooltip="Reset changes"></i> <a @click="resetBodyChanges()" href="javascript:void(0)">Reset changes</a></span>
                         <div class="alert alert-info" v-if="localMessage?.panel === 2 && localMessage.bodyUnavailable">{{ localMessage.bodyUnavailable }}</div>

--- a/src/Frontend/test/driver.ts
+++ b/src/Frontend/test/driver.ts
@@ -7,8 +7,14 @@ export type MockEndpointOptions = {
   headers?: { [key: string]: string };
 };
 
+export type MockEndpointDynamicOptions = {
+  body: Record<string, any> | string | number | boolean | null | undefined;
+  status?: number;
+  headers?: { [key: string]: string };
+};
+
 type MockEndpoint = (path: string, options: MockEndpointOptions) => void;
-type makeMockEndpointWithQueryString = (endpoint: string, callBack: (url: URL) => MockEndpointOptions) => void;
+type MockEndpointDynamic = (endpoint: string, callBack: (url: URL, params: { [key: string]: string | readonly string[] }) => MockEndpointDynamicOptions) => void;
 
 export type SetupFactoryOptions = {
   driver: Driver;
@@ -21,7 +27,7 @@ type SetUp = <Factory extends SetupFactory>(factory: Factory) => Promise<ReturnT
 export type Driver = {
   goTo: GoTo;
   mockEndpoint: MockEndpoint;
-  mockEndpointWithQueryString: makeMockEndpointWithQueryString
+  mockEndpointDynamic: MockEndpointDynamic;
   setUp: SetUp;
   disposeApp: DisposeApp;
 };

--- a/src/Frontend/test/driver.ts
+++ b/src/Frontend/test/driver.ts
@@ -8,6 +8,7 @@ export type MockEndpointOptions = {
 };
 
 type MockEndpoint = (path: string, options: MockEndpointOptions) => void;
+type makeMockEndpointWithQueryString = (endpoint: string, callBack: (url: URL) => MockEndpointOptions) => void;
 
 export type SetupFactoryOptions = {
   driver: Driver;
@@ -20,6 +21,7 @@ type SetUp = <Factory extends SetupFactory>(factory: Factory) => Promise<ReturnT
 export type Driver = {
   goTo: GoTo;
   mockEndpoint: MockEndpoint;
+  mockEndpointWithQueryString: makeMockEndpointWithQueryString
   setUp: SetUp;
   disposeApp: DisposeApp;
 };

--- a/src/Frontend/test/drivers/vitest/driver.ts
+++ b/src/Frontend/test/drivers/vitest/driver.ts
@@ -2,7 +2,7 @@ import { it as itVitest, describe } from "vitest";
 import { Driver } from "../../driver";
 import { mount } from "../../../src/mount";
 import makeRouter from "../../../src/router";
-import { mockEndpoint } from "../../utils";
+import { mockEndpoint, mockEndpointWithQueryString } from "../../utils";
 import { mockServer } from "../../mock-server";
 import { App } from "vue";
 
@@ -26,6 +26,7 @@ function makeDriver() {
       app = mount({ router });
     },
     mockEndpoint,
+    mockEndpointWithQueryString,
     setUp(factory) {
       return factory({ driver: this });
     },

--- a/src/Frontend/test/drivers/vitest/driver.ts
+++ b/src/Frontend/test/drivers/vitest/driver.ts
@@ -2,7 +2,7 @@ import { it as itVitest, describe } from "vitest";
 import { Driver } from "../../driver";
 import { mount } from "../../../src/mount";
 import makeRouter from "../../../src/router";
-import { mockEndpoint, mockEndpointWithQueryString } from "../../utils";
+import { mockEndpoint, mockEndpointDynamic } from "../../utils";
 import { mockServer } from "../../mock-server";
 import { App } from "vue";
 
@@ -22,11 +22,11 @@ function makeDriver() {
         throw error;
       }
 
-      document.body.innerHTML = '<div id="app"></div>';
+      document.body.innerHTML = '<div id="app"></div><div id="modalDisplay"></div>';
       app = mount({ router });
     },
     mockEndpoint,
-    mockEndpointWithQueryString,
+    mockEndpointDynamic: mockEndpointDynamic,
     setUp(factory) {
       return factory({ driver: this });
     },

--- a/src/Frontend/test/drivers/vitest/driver.ts
+++ b/src/Frontend/test/drivers/vitest/driver.ts
@@ -31,6 +31,9 @@ function makeDriver() {
       return factory({ driver: this });
     },
     disposeApp() {
+      if (!app) {
+        throw new Error("App is not mounted, make your sure to await driver.goTo().");
+      }
       app.unmount();
     },
   };

--- a/src/Frontend/test/mock-endpoint.ts
+++ b/src/Frontend/test/mock-endpoint.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 import type { SetupWorker } from "msw/browser";
 import { SetupServer } from "msw/node";
-import { MockEndpointOptions } from "./driver";
+import { MockEndpointDynamicOptions, MockEndpointOptions } from "./driver";
 
 export const makeMockEndpoint =
   ({ mockServer }: { mockServer: SetupServer | SetupWorker }) =>
@@ -9,13 +9,13 @@ export const makeMockEndpoint =
     mockServer.use(http[method](endpoint, () => HttpResponse.json(body, { status: status, headers: headers })));
   };
 
-export const makeMockEndpointWithQueryString =
+export const makeMockEndpointDynamic =
   ({ mockServer }: { mockServer: SetupServer | SetupWorker }) =>
-  (endpoint: string, callBack: (url: URL) => MockEndpointOptions) => {
+  (endpoint: string, callBack: (url: URL, params: { [key: string]: string | readonly string[] }) => MockEndpointDynamicOptions) => {
     mockServer.use(
-      http.get(endpoint, ({ request }) => {
+      http.get(endpoint, ({ request, params }) => {
         const url = new URL(request.url.toString());
-        const { body, status = 200, headers = {} } = callBack(url);
+        const { body, status = 200, headers = {} } = callBack(url, params);
         return HttpResponse.json(body, { status: status, headers: headers });
       })
     );

--- a/src/Frontend/test/mock-endpoint.ts
+++ b/src/Frontend/test/mock-endpoint.ts
@@ -5,14 +5,18 @@ import { MockEndpointOptions } from "./driver";
 
 export const makeMockEndpoint =
   ({ mockServer }: { mockServer: SetupServer | SetupWorker }) =>
-  (
-    endpoint: string,
-    {
-      body,
-      method = "get",
-      status = 200,
-      headers = {},
-    }: MockEndpointOptions
-  ) => {
+  (endpoint: string, { body, method = "get", status = 200, headers = {} }: MockEndpointOptions) => {
     mockServer.use(http[method](endpoint, () => HttpResponse.json(body, { status: status, headers: headers })));
+  };
+
+export const makeMockEndpointWithQueryString =
+  ({ mockServer }: { mockServer: SetupServer | SetupWorker }) =>
+  (endpoint: string, callBack: (url: URL) => MockEndpointOptions) => {
+    mockServer.use(
+      http.get(endpoint, ({ request }) => {
+        const url = new URL(request.url.toString());
+        const { body, status = 200, headers = {} } = callBack(url);
+        return HttpResponse.json(body, { status: status, headers: headers });
+      })
+    );
   };

--- a/src/Frontend/test/mocks/browser.ts
+++ b/src/Frontend/test/mocks/browser.ts
@@ -1,17 +1,17 @@
 import { setupWorker } from "msw/browser";
 import { Driver } from "../driver";
-import { makeMockEndpoint, makeMockEndpointWithQueryString } from "../mock-endpoint";
+import { makeMockEndpoint, makeMockEndpointDynamic } from "../mock-endpoint";
 import * as precondition from "../preconditions";
 export const worker = setupWorker();
 const mockEndpoint = makeMockEndpoint({ mockServer: worker });
-const mockEndpointWithQueryString = makeMockEndpointWithQueryString({ mockServer: worker });
+const mockEndpointDynamic = makeMockEndpointDynamic({ mockServer: worker });
 
 const makeDriver = (): Driver => ({
   async goTo() {
     throw new Error("Not implemented");
   },
   mockEndpoint,
-  mockEndpointWithQueryString,
+  mockEndpointDynamic,
   setUp(factory) {
     return factory({ driver: this });
   },

--- a/src/Frontend/test/mocks/browser.ts
+++ b/src/Frontend/test/mocks/browser.ts
@@ -1,15 +1,17 @@
 import { setupWorker } from "msw/browser";
 import { Driver } from "../driver";
-import { makeMockEndpoint } from "../mock-endpoint";
+import { makeMockEndpoint, makeMockEndpointWithQueryString } from "../mock-endpoint";
 import * as precondition from "../preconditions";
 export const worker = setupWorker();
 const mockEndpoint = makeMockEndpoint({ mockServer: worker });
+const mockEndpointWithQueryString = makeMockEndpointWithQueryString({ mockServer: worker });
 
 const makeDriver = (): Driver => ({
   async goTo() {
     throw new Error("Not implemented");
   },
   mockEndpoint,
+  mockEndpointWithQueryString,
   setUp(factory) {
     return factory({ driver: this });
   },
@@ -32,5 +34,14 @@ const driver = makeDriver();
       "Universe.Solarsystem.Earth.Endpoint5",
       "Universe.Solarsystem.Earth.Endpoint6",
     ])
+  );
+
+  await driver.setUp(
+    precondition.hasFailedMessage({
+      withGroupId: "81dca64e-76fc-e1c3-11a2-3069f51c58c8",
+      withMessageId: "40134401-bab9-41aa-9acb-b19c0066f22d",
+      withContentType: "application/json",
+      withBody: {"Index":0,"Data":""},
+    })
   );
 })();

--- a/src/Frontend/test/preconditions/hasNoErrors.ts
+++ b/src/Frontend/test/preconditions/hasNoErrors.ts
@@ -2,7 +2,7 @@ import { SetupFactoryOptions } from "../driver";
 
 const content = JSON.stringify([]);
 
-export const hasNoErrors = ({ driver }: SetupFactoryOptions) => {
+export const errorsDefaultHandler = ({ driver }: SetupFactoryOptions) => {
   const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
   driver.mockEndpoint(`${serviceControlInstanceUrl}errors`, {
     body: content,

--- a/src/Frontend/test/preconditions/index.ts
+++ b/src/Frontend/test/preconditions/index.ts
@@ -6,7 +6,7 @@ export { hasUpToDateServiceControl } from "../preconditions/hasUpToDateServiceCo
 export { hasUpToDateServicePulse } from "../preconditions/hasUpToDateServicePulse";
 export { hasFiveActiveOneFailingHeartbeats } from "../preconditions/hasFiveActiveOneFailingHeartbeats";
 export { hasFourActiveTwoFailingHeartbeats } from "../preconditions/hasFourActiveTwoFailingHeartbeats";
-export { hasNoErrors } from "../preconditions/hasNoErrors";
+export { errorsDefaultHandler } from "../preconditions/hasNoErrors";
 export { hasNoFailingCustomChecks } from "../preconditions/hasNoFailingCustomChecks";
 export { hasNoDisconnectedEndpoints } from "../preconditions/hasNoDisconnectedEndpoints";
 export { hasNoMonitoredEndpoints, hasMonitoredEndpointsList, monitoredEndpointsNamed } from "../preconditions/hasMonitoredEndpoints";
@@ -16,3 +16,4 @@ export * from "./hasEndpointsWithHistoryPeriodData";
 export * from "./hasMonitoredEndpointDetails";
 export { hasNoHeartbeatsEndpoints } from "../preconditions/hasHeartbeatEndpoints";
 export { serviceControlWithMonitoring } from "./serviceControlWithMonitoring";
+export * from "./recoverability";

--- a/src/Frontend/test/preconditions/recoverability.ts
+++ b/src/Frontend/test/preconditions/recoverability.ts
@@ -1,0 +1,244 @@
+import Configuration, { EditAndRetryConfig } from "@/resources/Configuration";
+import { SetupFactoryOptions } from "../driver";
+import RecoverabilityHistoryResponse from "@/resources/RecoverabilityHistoryResponse";
+import FailedMessage from "@/resources/FailedMessage";
+import Message from "@/resources/Message";
+
+export const serviceControlConfigurationDefaultHandler = ({ driver }: SetupFactoryOptions) => {
+  const serviceControlUrl = window.defaultConfig.service_control_url;
+  driver.mockEndpoint(`${serviceControlUrl}configuration`, {
+    body: <Configuration>{
+      host: {
+        service_name: "Particular.ServiceControl",
+        raven_db_path: "",
+        logging: {
+          log_path: "",
+          logging_level: "Info",
+          raven_db_log_level: "Info",
+        },
+      },
+      data_retention: {
+        error_retention_period: "30.00:00:00",
+      },
+      performance_tunning: {
+        http_default_connection_limit: 100,
+        external_integrations_dispatching_batch_size: 100,
+        expiration_process_batch_size: 100,
+        expiration_process_timer_in_seconds: 300,
+      },
+      transport: {
+        transport_type: "MSMQ",
+        error_log_queue: "error.log",
+        error_queue: "error",
+        forward_error_messages: true,
+      },
+      plugins: {
+        heartbeat_grace_period: "00:00:00",
+      },
+    },
+  });
+};
+
+export const recoverabilityClassifiers = ({ driver }: SetupFactoryOptions) => {
+  const serviceControlUrl = window.defaultConfig.service_control_url;
+  driver.mockEndpoint(`${serviceControlUrl}recoverability/classifiers`, {
+    body: <string[]>["Exception Type and Stack Trace", "Message Type", "Endpoint Address", "Endpoint Instance", "Endpoint Name"],
+  });
+};
+
+export const recoverabilityHistoryDefaultHandler = ({ driver }: SetupFactoryOptions) => {
+  const serviceControlUrl = window.defaultConfig.service_control_url;
+  driver.mockEndpoint(`${serviceControlUrl}recoverability/history`, {
+    body: <RecoverabilityHistoryResponse>{
+      id: "RetryOperations/History",
+      historic_operations: [],
+      unacknowledged_operations: [],
+    },
+  });
+};
+
+export const recoverabilityEditConfigDefaultHandler = ({ driver }: SetupFactoryOptions) => {
+  const serviceControlUrl = window.defaultConfig.service_control_url;
+  driver.mockEndpoint(`${serviceControlUrl}edit/config`, {
+    body: <EditAndRetryConfig>{
+      enabled: true,
+      sensitive_headers: [
+        "NServiceBus.Header.RouteTo",
+        "NServiceBus.DestinationSites",
+        "NServiceBus.OriginatingSite",
+        "NServiceBus.To",
+        "NServiceBus.ReplyToAddress",
+        "NServiceBus.ReturnMessage.ErrorCode",
+        "NServiceBus.SagaType",
+        "NServiceBus.OriginatingSagaType",
+        "NServiceBus.TimeSent",
+        "Header",
+      ],
+      locked_headers: [
+        "NServiceBus.MessageId",
+        "NServiceBus.SagaId",
+        "NServiceBus.CorrelationId",
+        "NServiceBus.ControlMessage",
+        "NServiceBus.OriginatingSagaId",
+        "NServiceBus.RelatedTo",
+        "NServiceBus.ConversationId",
+        "NServiceBus.MessageIntent",
+        "NServiceBus.Version",
+        "NServiceBus.IsSagaTimeoutMessage",
+        "NServiceBus.IsDeferredMessage",
+        "NServiceBus.Retries",
+        "NServiceBus.Retries.Timestamp",
+        "NServiceBus.FLRetries",
+        "NServiceBus.ProcessingStarted",
+        "NServiceBus.ProcessingEnded",
+        "NServiceBus.ExceptionInfo.ExceptionType",
+        "NServiceBus.ExceptionInfo.HelpLink",
+        "NServiceBus.ExceptionInfo.Message",
+        "NServiceBus.ExceptionInfo.Source",
+        "NServiceBus.ExceptionInfo.StackTrace",
+        "NServiceBus.TimeOfFailure",
+        "NServiceBus.FailedQ",
+      ],
+    },
+  });
+};
+
+export const hasFailedMessage =
+  ({ withGroupId, withMessageId, withContentType, withBody }: { withGroupId: string; withMessageId: string; withContentType: string; withBody: Record<string, any> | string | number | boolean | null | undefined }) =>
+  ({ driver }: SetupFactoryOptions) => {
+    const serviceControlUrl = window.defaultConfig.service_control_url;
+
+    const failedMessage = <FailedMessage>{
+      id: withGroupId,
+      message_type: "ServiceControl.SmokeTest.SimpleCommand",
+      time_sent: "2024-06-27T06:14:48.895733Z",
+      is_system_message: false,
+      exception: {
+        exception_type: "System.Exception",
+        message: "SimpleHandler: Throwing exceptions enabled in Endpoint1",
+        source: "ServiceControl.SmokeTest",
+        stack_trace:
+          "System.Exception: SimpleHandler: Throwing exceptions enabled in Endpoint1\r\n   at ServiceControl.SmokeTest.SimpleHandler.Handle(SimpleCommand message, IMessageHandlerContext context) in /_/src/ServiceControl.SmokeTest/SimpleHandler.cs:line 26\r\n   at NServiceBus.InvokeHandlerTerminator.Terminate(IInvokeHandlerContext context) in /_/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs:line 33\r\n   at NServiceBus.SagaAudit.AuditInvokedSagaBehavior.Invoke(IInvokeHandlerContext context, Func`1 next) in /_/src/NServiceBus.SagaAudit/AuditInvokedSagaBehavior.cs:line 13\r\n   at NServiceBus.SagaPersistenceBehavior.Invoke(IInvokeHandlerContext context, Func`2 next) in /_/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs:line 41\r\n   at NServiceBus.SagaAudit.CaptureSagaStateBehavior.Invoke(IInvokeHandlerContext context, Func`1 next) in /_/src/NServiceBus.SagaAudit/CaptureSagaStateBehavior.cs:line 33\r\n   at NServiceBus.LoadHandlersConnector.Invoke(IIncomingLogicalMessageContext context, Func`2 stage) in /_/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs:line 44\r\n   at NServiceBus.InvokeSagaNotFoundBehavior.Invoke(IIncomingLogicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs:line 17\r\n   at NServiceBus.DeserializeMessageConnector.Invoke(IIncomingPhysicalMessageContext context, Func`2 stage) in /_/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs:line 32\r\n   at ReceivePerformanceDiagnosticsBehavior.Invoke(IIncomingPhysicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs:line 18\r\n   at NServiceBus.InvokeAuditPipelineBehavior.Invoke(IIncomingPhysicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs:line 19\r\n   at NServiceBus.ProcessingStatisticsBehavior.Invoke(IIncomingPhysicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs:line 25\r\n   at NServiceBus.TransportReceiveToPhysicalMessageConnector.Invoke(ITransportReceiveContext context, Func`2 next) in /_/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs:line 35\r\n   at NServiceBus.RetryAcknowledgementBehavior.Invoke(ITransportReceiveContext context, Func`2 next) in /_/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs:line 25\r\n   at NServiceBus.MainPipelineExecutor.Invoke(MessageContext messageContext, CancellationToken cancellationToken) in /_/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs:line 49\r\n   at NServiceBus.MainPipelineExecutor.Invoke(MessageContext messageContext, CancellationToken cancellationToken) in /_/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs:line 68\r\n   at NServiceBus.LearningTransportMessagePump.ProcessFile(ILearningTransportTransaction transaction, String messageId, CancellationToken messageProcessingCancellationToken) in /_/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs:line 340",
+      },
+      message_id: withMessageId,
+      number_of_processing_attempts: 1,
+      status: "unresolved",
+      sending_endpoint: { name: "Sender", host_id: "abb12931-1352-fd70-02c2-b78f6daab553", host: "mobvm2" },
+      receiving_endpoint: { name: "Endpoint1", host_id: "abb12931-1352-fd70-02c2-b78f6daab553", host: "mobvm2" },
+      queue_address: "Endpoint1",
+      time_of_failure: "2024-06-27T06:14:48.912923Z",
+      last_modified: "2024-06-27T06:14:49.2216249Z",
+      edited: false,
+      edit_of: "",
+    };
+
+    driver.mockEndpointWithQueryString(`${serviceControlUrl}errors`, (url) => {
+      const status = url.searchParams.get("status");
+      if (status === "unresolved") {
+        return {
+          body: [failedMessage],
+          headers: { "Total-Count": "1" },
+        };
+      }
+
+      //For status=archived or status=retryissued
+      return {
+        body: [],
+        headers: { "Total-Count": "0" },
+      };
+    });
+
+    driver.mockEndpoint(`${serviceControlUrl}messages/${withMessageId}/body`, {
+      body: withBody,
+    });
+
+    driver.mockEndpoint(`${serviceControlUrl}messages/search/${withMessageId}`, {
+      body: [
+        <Message>{
+          id: withGroupId,
+          message_id: withMessageId,
+          message_type: "ServiceControl.SmokeTest.SimpleCommand",
+          sending_endpoint: { name: "Sender", host_id: "abb12931-1352-fd70-02c2-b78f6daab553", host: "mobvm2" },
+          receiving_endpoint: { name: "Endpoint1", host_id: "abb12931-1352-fd70-02c2-b78f6daab553", host: "mobvm2" },
+          time_sent: "2024-06-27T06:14:48.895733Z",
+          processed_at: "2024-06-27T06:14:48.912923Z",
+          critical_time: "00:00:00",
+          processing_time: "00:00:00",
+          delivery_time: "00:00:00",
+          is_system_message: false,
+          conversation_id: "7de07fd4-928f-4d1a-be0f-b19c0066f22d",
+          headers: [
+            { key: "NServiceBus.MessageId", value: withMessageId },
+            { key: "NServiceBus.MessageIntent", value: "Send" },
+            { key: "NServiceBus.ConversationId", value: "7de07fd4-928f-4d1a-be0f-b19c0066f22d" },
+            { key: "NServiceBus.CorrelationId", value: withMessageId },
+            { key: "NServiceBus.OriginatingMachine", value: "mobvm2" },
+            { key: "NServiceBus.OriginatingEndpoint", value: "Sender" },
+            { key: "$.diagnostics.originating.hostid", value: "abb129311352fd7002c2b78f6daab553" },
+            { key: "NServiceBus.ContentType", value: withContentType },
+            { key: "NServiceBus.EnclosedMessageTypes", value: "ServiceControl.SmokeTest.SimpleCommand, ServiceControl.SmokeTest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" },
+            { key: "NServiceBus.Version", value: "9.0.0" },
+            { key: "NServiceBus.TimeSent", value: "2024-06-27 06:14:48:895733 Z" },
+            { key: "NServiceBus.ProcessingMachine", value: "mobvm2" },
+            { key: "NServiceBus.ProcessingEndpoint", value: "Endpoint1" },
+            { key: "$.diagnostics.hostid", value: "abb129311352fd7002c2b78f6daab553" },
+            { key: "$.diagnostics.hostdisplayname", value: "mobvm2" },
+            { key: "NServiceBus.FailedQ", value: "Endpoint1" },
+            { key: "NServiceBus.ExceptionInfo.ExceptionType", value: "System.Exception" },
+            { key: "NServiceBus.ExceptionInfo.HelpLink" },
+            { key: "NServiceBus.ExceptionInfo.Message", value: "SimpleHandler: Throwing exceptions enabled in Endpoint1" },
+            { key: "NServiceBus.ExceptionInfo.Source", value: "ServiceControl.SmokeTest" },
+            {
+              key: "NServiceBus.ExceptionInfo.StackTrace",
+              value:
+                "System.Exception: SimpleHandler: Throwing exceptions enabled in Endpoint1\r\n   at ServiceControl.SmokeTest.SimpleHandler.Handle(SimpleCommand message, IMessageHandlerContext context) in /_/src/ServiceControl.SmokeTest/SimpleHandler.cs:line 26\r\n   at NServiceBus.InvokeHandlerTerminator.Terminate(IInvokeHandlerContext context) in /_/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs:line 33\r\n   at NServiceBus.SagaAudit.AuditInvokedSagaBehavior.Invoke(IInvokeHandlerContext context, Func`1 next) in /_/src/NServiceBus.SagaAudit/AuditInvokedSagaBehavior.cs:line 13\r\n   at NServiceBus.SagaPersistenceBehavior.Invoke(IInvokeHandlerContext context, Func`2 next) in /_/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs:line 41\r\n   at NServiceBus.SagaAudit.CaptureSagaStateBehavior.Invoke(IInvokeHandlerContext context, Func`1 next) in /_/src/NServiceBus.SagaAudit/CaptureSagaStateBehavior.cs:line 33\r\n   at NServiceBus.LoadHandlersConnector.Invoke(IIncomingLogicalMessageContext context, Func`2 stage) in /_/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs:line 44\r\n   at NServiceBus.InvokeSagaNotFoundBehavior.Invoke(IIncomingLogicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs:line 17\r\n   at NServiceBus.DeserializeMessageConnector.Invoke(IIncomingPhysicalMessageContext context, Func`2 stage) in /_/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs:line 32\r\n   at ReceivePerformanceDiagnosticsBehavior.Invoke(IIncomingPhysicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs:line 18\r\n   at NServiceBus.InvokeAuditPipelineBehavior.Invoke(IIncomingPhysicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs:line 19\r\n   at NServiceBus.ProcessingStatisticsBehavior.Invoke(IIncomingPhysicalMessageContext context, Func`2 next) in /_/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs:line 25\r\n   at NServiceBus.TransportReceiveToPhysicalMessageConnector.Invoke(ITransportReceiveContext context, Func`2 next) in /_/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs:line 35\r\n   at NServiceBus.RetryAcknowledgementBehavior.Invoke(ITransportReceiveContext context, Func`2 next) in /_/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs:line 25\r\n   at NServiceBus.MainPipelineExecutor.Invoke(MessageContext messageContext, CancellationToken cancellationToken) in /_/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs:line 49\r\n   at NServiceBus.MainPipelineExecutor.Invoke(MessageContext messageContext, CancellationToken cancellationToken) in /_/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs:line 68\r\n   at NServiceBus.LearningTransportMessagePump.ProcessFile(ILearningTransportTransaction transaction, String messageId, CancellationToken messageProcessingCancellationToken) in /_/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs:line 340",
+            },
+            { key: "NServiceBus.TimeOfFailure", value: "2024-06-27 06:14:48:912923 Z" },
+            { key: "NServiceBus.ExceptionInfo.Data.Message type", value: "ServiceControl.SmokeTest.SimpleCommand" },
+            { key: "NServiceBus.ExceptionInfo.Data.Handler type", value: "ServiceControl.SmokeTest.SimpleHandler" },
+            { key: "NServiceBus.ExceptionInfo.Data.Handler start time", value: "2024-06-27 06:14:48:911780 Z" },
+            { key: "NServiceBus.ExceptionInfo.Data.Handler failure time", value: "2024-06-27 06:14:48:911893 Z" },
+            { key: "NServiceBus.ExceptionInfo.Data.Handler canceled", value: "False" },
+            { key: "NServiceBus.ExceptionInfo.Data.Message ID", value: withMessageId },
+            { key: "NServiceBus.ExceptionInfo.Data.Transport message ID", value: "cec43aaf-d3ac-40b9-8c3c-5c210606c016" },
+            { key: "NServiceBus.ExceptionInfo.Data.Pipeline canceled", value: "False" },
+          ],
+          status: "failed",
+          message_intent: "send",
+          body_url: `/messages/${withGroupId}/body?instance_id=aHR0cDovLzEwLjAuMC41OjQ5MjAwL2FwaQ..`,
+          body_size: 21,
+          instance_id: "aHR0cDovLzEwLjAuMC41OjQ5MjAwL2FwaQ..",
+        },
+      ],
+    });
+
+    driver.mockEndpoint(`${serviceControlUrl}errors/last/${withGroupId}`, {
+      body: failedMessage,
+    });
+
+    driver.mockEndpoint(`${serviceControlUrl}recoverability/groups/Endpoint%20Name`, {
+      body: [
+        {
+          id: withGroupId,
+          title: "Endpoint1",
+          type: "Endpoint Name",
+          count: 1,
+          first: "2024-06-27T06:14:48.912923Z",
+          last: "2024-06-27T06:14:48.912923Z",
+          operation_status: "None",
+          operation_progress: 0,
+          need_user_acknowledgement: false,
+        },
+      ],
+    });
+
+    //api/recoverability/groups/${withGroupId}/errors?status=unresolved&page=1&per_page=50&sort=time_of_failure&direction=desc
+    driver.mockEndpoint(`${serviceControlUrl}recoverability/groups/${withGroupId}/errors`, {
+      body: [failedMessage],
+      headers: { "Total-Count": "1" },
+    });
+
+    driver.mockEndpoint(`${serviceControlUrl}recoverability/groups/id/${withGroupId}`, {
+      body: { id: withGroupId, title: "Endpoint1", type: "Endpoint Name", count: 1, first: "2024-06-27T06:14:48.912923Z", last: "2024-06-27T06:14:48.912923Z" },
+    });
+  };

--- a/src/Frontend/test/preconditions/recoverability.ts
+++ b/src/Frontend/test/preconditions/recoverability.ts
@@ -39,6 +39,20 @@ export const serviceControlConfigurationDefaultHandler = ({ driver }: SetupFacto
   });
 };
 
+export const archivedGroupsWithClassifierDefaulthandler = ({ driver }: SetupFactoryOptions) => {
+  const serviceControlUrl = window.defaultConfig.service_control_url;
+  driver.mockEndpoint(`${serviceControlUrl}errors/groups{/:classifier}`, {
+    body: [],
+  });
+};
+
+export const recoverabilityGroupsWithClassifierDefaulthandler = ({ driver }: SetupFactoryOptions) => {
+  const serviceControlUrl = window.defaultConfig.service_control_url;
+  driver.mockEndpoint(`${serviceControlUrl}recoverability/groups{/:classifier}`, {
+    body: [],
+  });
+};
+
 export const recoverabilityClassifiers = ({ driver }: SetupFactoryOptions) => {
   const serviceControlUrl = window.defaultConfig.service_control_url;
   driver.mockEndpoint(`${serviceControlUrl}recoverability/classifiers`, {
@@ -57,49 +71,59 @@ export const recoverabilityHistoryDefaultHandler = ({ driver }: SetupFactoryOpti
   });
 };
 
+const editConfig = <EditAndRetryConfig>{
+  enabled: false,
+  sensitive_headers: [
+    "NServiceBus.Header.RouteTo",
+    "NServiceBus.DestinationSites",
+    "NServiceBus.OriginatingSite",
+    "NServiceBus.To",
+    "NServiceBus.ReplyToAddress",
+    "NServiceBus.ReturnMessage.ErrorCode",
+    "NServiceBus.SagaType",
+    "NServiceBus.OriginatingSagaType",
+    "NServiceBus.TimeSent",
+    "Header",
+  ],
+  locked_headers: [
+    "NServiceBus.MessageId",
+    "NServiceBus.SagaId",
+    "NServiceBus.CorrelationId",
+    "NServiceBus.ControlMessage",
+    "NServiceBus.OriginatingSagaId",
+    "NServiceBus.RelatedTo",
+    "NServiceBus.ConversationId",
+    "NServiceBus.MessageIntent",
+    "NServiceBus.Version",
+    "NServiceBus.IsSagaTimeoutMessage",
+    "NServiceBus.IsDeferredMessage",
+    "NServiceBus.Retries",
+    "NServiceBus.Retries.Timestamp",
+    "NServiceBus.FLRetries",
+    "NServiceBus.ProcessingStarted",
+    "NServiceBus.ProcessingEnded",
+    "NServiceBus.ExceptionInfo.ExceptionType",
+    "NServiceBus.ExceptionInfo.HelpLink",
+    "NServiceBus.ExceptionInfo.Message",
+    "NServiceBus.ExceptionInfo.Source",
+    "NServiceBus.ExceptionInfo.StackTrace",
+    "NServiceBus.TimeOfFailure",
+    "NServiceBus.FailedQ",
+  ],
+};
 export const recoverabilityEditConfigDefaultHandler = ({ driver }: SetupFactoryOptions) => {
   const serviceControlUrl = window.defaultConfig.service_control_url;
   driver.mockEndpoint(`${serviceControlUrl}edit/config`, {
-    body: <EditAndRetryConfig>{
-      enabled: true,
-      sensitive_headers: [
-        "NServiceBus.Header.RouteTo",
-        "NServiceBus.DestinationSites",
-        "NServiceBus.OriginatingSite",
-        "NServiceBus.To",
-        "NServiceBus.ReplyToAddress",
-        "NServiceBus.ReturnMessage.ErrorCode",
-        "NServiceBus.SagaType",
-        "NServiceBus.OriginatingSagaType",
-        "NServiceBus.TimeSent",
-        "Header",
-      ],
-      locked_headers: [
-        "NServiceBus.MessageId",
-        "NServiceBus.SagaId",
-        "NServiceBus.CorrelationId",
-        "NServiceBus.ControlMessage",
-        "NServiceBus.OriginatingSagaId",
-        "NServiceBus.RelatedTo",
-        "NServiceBus.ConversationId",
-        "NServiceBus.MessageIntent",
-        "NServiceBus.Version",
-        "NServiceBus.IsSagaTimeoutMessage",
-        "NServiceBus.IsDeferredMessage",
-        "NServiceBus.Retries",
-        "NServiceBus.Retries.Timestamp",
-        "NServiceBus.FLRetries",
-        "NServiceBus.ProcessingStarted",
-        "NServiceBus.ProcessingEnded",
-        "NServiceBus.ExceptionInfo.ExceptionType",
-        "NServiceBus.ExceptionInfo.HelpLink",
-        "NServiceBus.ExceptionInfo.Message",
-        "NServiceBus.ExceptionInfo.Source",
-        "NServiceBus.ExceptionInfo.StackTrace",
-        "NServiceBus.TimeOfFailure",
-        "NServiceBus.FailedQ",
-      ],
-    },
+    body: editConfig,
+  });
+};
+
+export const enableEditAndRetry = ({ driver }: SetupFactoryOptions) => {
+  const serviceControlUrl = window.defaultConfig.service_control_url;
+  const config = structuredClone(editConfig);
+  config.enabled = true;
+  driver.mockEndpoint(`${serviceControlUrl}edit/config`, {
+    body: config,
   });
 };
 
@@ -132,7 +156,7 @@ export const hasFailedMessage =
       edit_of: "",
     };
 
-    driver.mockEndpointWithQueryString(`${serviceControlUrl}errors`, (url) => {
+    driver.mockEndpointDynamic(`${serviceControlUrl}errors`, (url) => {
       const status = url.searchParams.get("status");
       if (status === "unresolved") {
         return {
@@ -216,7 +240,7 @@ export const hasFailedMessage =
       body: failedMessage,
     });
 
-    driver.mockEndpoint(`${serviceControlUrl}recoverability/groups/Endpoint%20Name`, {
+    driver.mockEndpoint(`${serviceControlUrl}recoverability/groups{/:classifier}`, {
       body: [
         {
           id: withGroupId,

--- a/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
+++ b/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
@@ -1,4 +1,3 @@
-import { monitoredEndpointList } from "@/../test/mocks/monitored-endpoint-template";
 import * as precondition from ".";
 import { SetupFactoryOptions } from "../driver";
 
@@ -21,7 +20,7 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
   await driver.setUp(precondition.hasUpToDateServicePulse);
 
   //http://localhost:33333/api/errors
-  await driver.setUp(precondition.hasNoErrors);
+  await driver.setUp(precondition.errorsDefaultHandler);
 
   //http://localhost:33333/api/customchecks
   await driver.setUp(precondition.hasNoFailingCustomChecks);
@@ -45,11 +44,24 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
   await driver.setUp(precondition.hasNoMonitoredEndpoints);
 
   //http://localhost:33333/recoverability/groups/Endpoint%20Instance
-  await driver.setUp(precondition.endpointRecoverabilityByInstanceDefaultHandler)
+  await driver.setUp(precondition.endpointRecoverabilityByInstanceDefaultHandler);
 
   //http://localhost:33333/recoverability/groups/Endpoint%20Name?classifierFilter=${name} -  the classifierFilter is ignored, this is a default handler for the route.
-  await driver.setUp(precondition.endpointRecoverabilityByNameDefaultHandler);  
+  await driver.setUp(precondition.endpointRecoverabilityByNameDefaultHandler);
 
- //OPTIONS VERB agaisnt monitoring instance http://localhost:33633/ - this is used for enabling deleting an instance from the endpoint details page - instances panel
- await driver.setUp(precondition.serviceControlMonitoringOptions)
+  //OPTIONS VERB agaisnt monitoring instance http://localhost:33633/ - this is used for enabling deleting an instance from the endpoint details page - instances panel
+  await driver.setUp(precondition.serviceControlMonitoringOptions);
+
+  //http://localhost:33333/api/configuration default handler
+  await driver.setUp(precondition.serviceControlConfigurationDefaultHandler);
+
+  //http://localhost:33333/api/recoverability/classifiers default handler
+  await driver.setUp(precondition.recoverabilityClassifiers);
+
+  //http://localhost:33333/api/recoverability/history default handler
+  await driver.setUp(precondition.recoverabilityHistoryDefaultHandler);
+
+  //http://localhost:33333/api/edit/config default handler
+  await driver.setUp(precondition.recoverabilityEditConfigDefaultHandler);
+  
 };

--- a/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
+++ b/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
@@ -63,5 +63,10 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
 
   //http://localhost:33333/api/edit/config default handler
   await driver.setUp(precondition.recoverabilityEditConfigDefaultHandler);
-  
+
+  //http://localhost:33333/api/errors/groups{/:classifier}? default handler
+  await driver.setUp(precondition.archivedGroupsWithClassifierDefaulthandler);  
+
+  //http://localhost:33333/api/recoverability/groups{/:classifier} default handler
+  await driver.setUp(precondition.recoverabilityGroupsWithClassifierDefaulthandler);  
 };

--- a/src/Frontend/test/specs/failedmessages/actions/openEditAndRetryEditor.ts
+++ b/src/Frontend/test/specs/failedmessages/actions/openEditAndRetryEditor.ts
@@ -1,0 +1,6 @@
+import { screen } from "@testing-library/vue";
+import UserEvent from "@testing-library/user-event";
+export async function openEditAndRetryEditor() {
+  const button = await screen.findByRole("button", { name: "Edit & retry" });
+  await UserEvent.click(button);
+}

--- a/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
+++ b/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
@@ -51,11 +51,11 @@ describe("FEATURE: Editing failed messages", () => {
         //When the user opens the message editor
         await driver.goTo("failed-messages/message/81dca64e-76fc-e1c3-11a2-3069f51c58c8");
         await openEditAndRetryEditor();
-        const editor = await getEditAndRetryEditor();
-        await editor.switchToMessageBodyTab();
+        const messageEditor = await getEditAndRetryEditor();
+        await messageEditor.switchToMessageBodyTab();
 
         //Then The message body should be editable
-        expect(editor.bodyFieldIsDisabled()).toBeFalsy();
+        expect(messageEditor.bodyFieldIsDisabled()).toBeFalsy();
       });
     });
 
@@ -77,12 +77,12 @@ describe("FEATURE: Editing failed messages", () => {
         //When the user opens the message editor
         await driver.goTo("failed-messages/message/81dca64e-76fc-e1c3-11a2-3069f51c58c8");
         await openEditAndRetryEditor();
-        const dialog = await getEditAndRetryEditor();
-        await dialog.switchToMessageBodyTab();
+        const messageEditor = await getEditAndRetryEditor();
+        await messageEditor.switchToMessageBodyTab();
 
         //Then The message body should NOT be editable
-        expect(dialog.bodyFieldIsDisabled()).toBeTruthy();        
-        expect(dialog.hasWarningMatchingText(/message body cannot be edited because content type "application\/octet\-stream" is not supported\. only messages with content types "application\/json" and "text\/xml" can be edited\./i)).toBeTruthy();        
+        expect(messageEditor.bodyFieldIsDisabled()).toBeTruthy();        
+        expect(messageEditor.hasWarningMatchingText(/message body cannot be edited because content type "application\/octet\-stream" is not supported\. only messages with content types "application\/json" and "text\/xml" can be edited\./i)).toBeTruthy();        
     });
   });
 });

--- a/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
+++ b/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
@@ -1,0 +1,58 @@
+import { test, describe } from "../../drivers/vitest/driver";
+
+describe("FEATURE: Deleting failed messages", () => {
+  describe("RULE: Editing of a message should only be allowed when ServiceControl 'AllowMessageEditing' is enabled", () => {
+    test.todo(
+      "EXAMPLE: ServiceControl 'AllowMessageEditing' is disabled"
+      /* 
+          Given a failed message is displayed in the Failed Messages list
+          and the ServiceControl 'AllowMessageEditing' is disabled
+          When the user sees the details of the message
+          Then button for editing the message is not shown
+        */
+    );
+
+    test.todo(
+      "EXAMPLE: ServiceControl 'AllowMessageEditing' is enabled"
+      /* 
+            Given a failed message is displayed in the Failed Messages list
+            and the ServiceControl 'AllowMessageEditing' is enabled
+            When the user sees the details of the message
+            Then button for editing the message is shown
+            */
+    );
+  });
+
+  describe("RULE: Only messages with with a content-type that is editable text should be allowed to be edited", () => {
+
+    //Background: ServiceControl 'AllowMessageEditing' is enabled
+
+    [
+        { contentType: "application/atom+xml" }, 
+        { contentType: "application/ld+json" }, 
+        { contentType: "application/vnd.masstransit+json" }
+    ].forEach(({ contentType }) => {
+      test.todo(`EXAMPLE: Editing a message with "${contentType}" content-type`
+
+        /* 
+        Given a failed message is displayed in the Failed Messages list
+        And the message has a content-type of "${contentType}"
+        When the user opens the message editor
+        And swtiches to the message body
+        The message body should be editable */
+      );
+      
+    });
+
+    test.todo(`EXAMPLE: Editing a message with a content-type not recognized as editable text`
+    /*
+    Given a failed message is displayed in the Failed Messages list
+    And the message has a content-type of "application/octet-stream"
+    When the user opens the message editor
+    And swtiches to the message body
+    The message body should NOT be editable 
+    And a legend with the following message should be shown:
+    |Message body cannot be edited because content type "application/octet-stream" is not supported. Only messages with content types "application/json" and "text/xml" can be edited. |*/
+    );
+  });
+});

--- a/src/Frontend/test/specs/failedmessages/questions/getEditAndRetryEditor.ts
+++ b/src/Frontend/test/specs/failedmessages/questions/getEditAndRetryEditor.ts
@@ -1,0 +1,21 @@
+import { screen, within } from "@testing-library/vue";
+import UserEvent from "@testing-library/user-event";
+export async function getEditAndRetryEditor() {
+  const dialog = await screen.findByRole("dialog", { name: "edit and retry message" });
+
+  return {    
+    async switchToMessageBodyTab() {
+      var tab = within(dialog).getByRole("tab", { name: /message body/i });
+      await UserEvent.click(tab);
+    },
+
+    bodyFieldIsDisabled() {
+        return within(dialog).getByRole("textbox", { name: "message body" }).hasAttribute("disabled");
+    },
+
+    hasWarningMatchingText(legendText: RegExp) {
+      const information =  within(dialog).getByRole("status", { name: /cannot edit message body/i });      
+      return within(information).getByText(legendText) !== null;
+    },
+  };
+}

--- a/src/Frontend/test/utils.ts
+++ b/src/Frontend/test/utils.ts
@@ -1,4 +1,4 @@
-import { makeMockEndpoint } from "./mock-endpoint";
+import { makeMockEndpoint, makeMockEndpointWithQueryString } from "./mock-endpoint";
 import userEvent from "@testing-library/user-event";
 
 import { mockServer } from "./mock-server";
@@ -8,3 +8,5 @@ export { expect, test, describe } from "vitest";
 export { userEvent };
 
 export const mockEndpoint = makeMockEndpoint({ mockServer });
+export const mockEndpointWithQueryString = makeMockEndpointWithQueryString({ mockServer });
+

--- a/src/Frontend/test/utils.ts
+++ b/src/Frontend/test/utils.ts
@@ -1,4 +1,4 @@
-import { makeMockEndpoint, makeMockEndpointWithQueryString } from "./mock-endpoint";
+import { makeMockEndpoint, makeMockEndpointDynamic } from "./mock-endpoint";
 import userEvent from "@testing-library/user-event";
 
 import { mockServer } from "./mock-server";
@@ -8,5 +8,5 @@ export { expect, test, describe } from "vitest";
 export { userEvent };
 
 export const mockEndpoint = makeMockEndpoint({ mockServer });
-export const mockEndpointWithQueryString = makeMockEndpointWithQueryString({ mockServer });
+export const mockEndpointDynamic = makeMockEndpointDynamic({ mockServer });
 


### PR DESCRIPTION
Edit and Retry Content type check allows more text based payloads by allowing all text based content types which start with `text/` but also all `application/*+json` and `application/*+xml` payloads