### PR TITLE
Fixing issue with System.Text.Json high severity vulnerability in our tests

### DIFF
--- a/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
+++ b/src/ServicePulse.Host.Tests/ServicePulse.Host.Tests.csproj
@@ -9,11 +9,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Particular.Approvals" Version="1.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also updated some dependencies

This fixes error NU1903: Warning As Error: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w [D:\a\ServicePulse\ServicePulse\src\ServicePulse.sln]

This is just a dependency of the tests, hence no need to release.