### PR TITLE
Adding frontend test summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Run application tests
         run: npm run test:application
         working-directory: src/Frontend
+      - name: Frontend Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: |
+            ./test-component.tap
+            ./test-application.tap
+        if: always()
       # .NET Build and run tests
       - name: Build
         run: dotnet build src --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
         uses: test-summary/action@v2
         with:
           paths: |
-            src/Frontend/test-component.tap
-            src/Frontend/test-application.tap
+            src/Frontend/test-component.xml
+            src/Frontend/test-application.xml
         if: always()
       # .NET Build and run tests
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
         uses: test-summary/action@v2
         with:
           paths: |
-            ./test-component.tap
-            ./test-application.tap
+            src/Frontend/test-component.tap
+            src/Frontend/test-application.tap
         if: always()
       # .NET Build and run tests
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Frontend Test Summary
         uses: test-summary/action@v2
         with:
+          show: "all"
           paths: |
             src/Frontend/test-component.xml
             src/Frontend/test-application.xml

--- a/src/Frontend/package.json
+++ b/src/Frontend/package.json
@@ -11,9 +11,9 @@
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "preview": "vite preview",
-    "test:component": "vitest ./src",
+    "test:component": "vitest --reporter=default --reporter=tap --outputFile=./test-component.tap ./src",
     "test:coverage": "vitest run --coverage",
-    "test:application:vitest": "npx vitest ./test/specs",
+    "test:application:vitest": "npx vitest --reporter=default --reporter=tap --outputFile=./test-application.tap ./test/specs",
     "test:application": "npm run test:application:vitest"
   },
   "dependencies": {

--- a/src/Frontend/package.json
+++ b/src/Frontend/package.json
@@ -11,9 +11,9 @@
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "preview": "vite preview",
-    "test:component": "vitest --reporter=default --reporter=tap --outputFile=./test-component.tap ./src",
+    "test:component": "vitest --reporter=default --reporter=junit --outputFile=test-component.xml ./src",
     "test:coverage": "vitest run --coverage",
-    "test:application:vitest": "npx vitest --reporter=default --reporter=tap --outputFile=./test-application.tap ./test/specs",
+    "test:application:vitest": "npx vitest --reporter=default --reporter=junit --outputFile=test-application.xml ./test/specs",
     "test:application": "npm run test:application:vitest"
   },
   "dependencies": {


### PR DESCRIPTION
Added a summary for the front-end tests.
You can see the result in https://github.com/Particular/ServicePulse/actions/runs/9954116874.
At the moment, I have [configured it](https://github.com/test-summary/action?tab=readme-ov-file#options) to show `all`, but I think `fail` is enough; otherwise, it's too long.