### PR TITLE
grouping patch updates for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 1000
+  groups:
+    patch-updates:
+          applies-to: version-updates
+          update-types:
+          - "minor"
+          - "patch"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,5 @@ updates:
     patch-updates:
           applies-to: version-updates
           update-types:
-          - "minor"
           - "patch"
 


### PR DESCRIPTION
We adding grouping for npm packages, so that it reduces the amount of PRs to deal with.
In this PR we are bundling all patch fixes in a single PR for all packages. 