### PR TITLE
Refactor tests for usage area to include an specification layer

### DIFF
--- a/src/Frontend/package-lock.json
+++ b/src/Frontend/package-lock.json
@@ -24,6 +24,7 @@
         "vue3-simple-typeahead": "^1.0.11"
       },
       "devDependencies": {
+        "@pinia/testing": "^0.1.3",
         "@rushstack/eslint-patch": "^1.10.3",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.8",
@@ -38,7 +39,6 @@
         "@vitest/coverage-v8": "^2.0.4",
         "@vue/eslint-config-prettier": "^9.0.0",
         "@vue/eslint-config-typescript": "^13.0.0",
-        "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.5.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.57.0",
@@ -47,6 +47,7 @@
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-unused-imports": "^3.2.0",
         "eslint-plugin-vue": "^9.27.0",
+        "flush-promises": "^1.0.2",
         "jsdom": "^24.1.1",
         "msw": "^2.3.3",
         "prettier": "^3.3.3",
@@ -1044,6 +1045,47 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
+    },
+    "node_modules/@pinia/testing": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-0.1.3.tgz",
+      "integrity": "sha512-D2Ds2s69kKFaRf2KCcP1NhNZEg5+we59aRyQalwRm7ygWfLM25nDH66267U3hNvRUOTx8ofL24GzodZkOmB5xw==",
+      "dev": true,
+      "dependencies": {
+        "vue-demi": ">=0.14.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "pinia": ">=2.1.5"
+      }
+    },
+    "node_modules/@pinia/testing/node_modules/vue-demi": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4705,6 +4747,12 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true
+    },
+    "node_modules/flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
       "dev": true
     },
     "node_modules/for-each": {

--- a/src/Frontend/package.json
+++ b/src/Frontend/package.json
@@ -33,6 +33,7 @@
     "vue3-simple-typeahead": "^1.0.11"
   },
   "devDependencies": {
+    "@pinia/testing": "^0.1.3",
     "@rushstack/eslint-patch": "^1.10.3",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.4.8",
@@ -47,7 +48,6 @@
     "@vitest/coverage-v8": "^2.0.4",
     "@vue/eslint-config-prettier": "^9.0.0",
     "@vue/eslint-config-typescript": "^13.0.0",
-    "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.5.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.0",
@@ -56,6 +56,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-unused-imports": "^3.2.0",
     "eslint-plugin-vue": "^9.27.0",
+    "flush-promises": "^1.0.2",
     "jsdom": "^24.1.1",
     "msw": "^2.3.3",
     "prettier": "^3.3.3",

--- a/src/Frontend/public/mockServiceWorker.js
+++ b/src/Frontend/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.1'
+const PACKAGE_VERSION = '2.3.2'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/Frontend/src/components/ConfirmDialog.vue
+++ b/src/Frontend/src/components/ConfirmDialog.vue
@@ -35,7 +35,7 @@ onMounted(() => {
 <template>
   <div class="modal-mask">
     <div class="modal-wrapper">
-      <div class="modal-container">
+      <div class="modal-container" role="dialog" :aria-label="heading">
         <div class="modal-header">
           <div class="modal-title">
             <h3>{{ heading }}</h3>
@@ -46,8 +46,8 @@ onMounted(() => {
           <p v-if="secondParagraph && secondParagraph.length">{{ secondParagraph }}</p>
         </div>
         <div class="modal-footer">
-          <button class="btn btn-primary" @click="confirm">{{ hideCancel ? "Ok" : "Yes" }}</button>
-          <button v-if="!hideCancel" class="btn btn-default" @click="close">No</button>
+          <button class="btn btn-primary" :aria-label="hideCancel ? 'Ok' : 'Yes'" @click="confirm">{{ hideCancel ? "Ok" : "Yes" }}</button>
+          <button v-if="!hideCancel" aria-label="No" class="btn btn-default" @click="close">No</button>
         </div>
       </div>
     </div>

--- a/src/Frontend/src/components/DropDown.vue
+++ b/src/Frontend/src/components/DropDown.vue
@@ -14,11 +14,13 @@ const props = defineProps<{
 
 <template>
   <div class="dropdown">
-    <label v-if="label" class="control-label" style="float: inherit">{{ props.label }}:</label>
-    <button type="button" class="btn btn-dropdown dropdown-toggle sp-btn-menu" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ props.selectItem?.text ?? props.items[0].text }}</button>
+    <label v-if="label" class="control-label" style="float: inherit">{{ label }}:</label>
+    <button type="button" :aria-label="label ?? 'open dropdown menu'" class="btn btn-dropdown dropdown-toggle sp-btn-menu" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      {{ props.selectItem?.text ?? props.items[0].text }}
+    </button>
     <ul class="dropdown-menu">
       <li v-for="item in props.items" :key="item.value">
-        <a href="#" @click.prevent="callback(item)">{{ item.text }}</a>
+        <a href="#" :aria-label="item.text" @click.prevent="callback(item)">{{ item.text }}</a>
       </li>
     </ul>
   </div>

--- a/src/Frontend/src/composables/fileDownloadCreator.ts
+++ b/src/Frontend/src/composables/fileDownloadCreator.ts
@@ -6,7 +6,7 @@
 
 export async function useDownloadFileFromResponse(response: Response, fileType: string, fileName: string) {
   const fileBlob = await response.blob();
-  const url = window.URL.createObjectURL(new Blob([fileBlob], { type: fileType }));
+  const url = URL.createObjectURL(new Blob([fileBlob], { type: fileType }));
   downloadFile(url, fileType, fileName);
 }
 

--- a/src/Frontend/src/stores/ThroughputStore.spec.ts
+++ b/src/Frontend/src/stores/ThroughputStore.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import * as precondition from "../../test/preconditions";
+import { useServiceControl } from "@/composables/serviceServiceControl";
+import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
+import { Transport } from "@/views/throughputreport/transport";
+import { makeDriverForTests } from "@component-test-utils";
+import { serviceControlWithThroughput } from "@/views/throughputreport/serviceControlWithThroughput";
+import { useThroughputStore } from "@/stores/ThroughputStore";
+import { createTestingPinia } from "@pinia/testing";
+import { storeToRefs } from "pinia";
+import flushPromises from "flush-promises";
+import { Driver } from "../../test/driver";
+import { disableMonitoring } from "../../test/drivers/vitest/setup";
+
+describe("ThroughputStore tests", () => {
+  async function setup(preSetup: (driver: Driver) => Promise<void>) {
+    const driver = makeDriverForTests();
+
+    await preSetup(driver);
+    await driver.setUp(serviceControlWithThroughput);
+    await driver.setUp(precondition.hasNoDisconnectedEndpoints);
+    await driver.setUp(precondition.hasServiceControlMonitoringInstance);
+
+    useServiceControlUrls();
+    await useServiceControl();
+
+    const store = storeToRefs(useThroughputStore(createTestingPinia({ stubActions: false })));
+
+    await flushPromises();
+
+    return { driver, ...store };
+  }
+
+  test("when no connection test errors for any source", async () => {
+    const { hasErrors } = await setup(async (driver) => {
+      await driver.setUp(precondition.hasLicensingSettingTest({ transport: Transport.AmazonSQS }));
+    });
+
+    expect(hasErrors.value).toBe(false);
+  });
+
+  describe("when transport is a broker", async () => {
+    const transport = Transport.AmazonSQS;
+
+    test("with broker connection test failure", async () => {
+      const { hasErrors } = await setup(async (driver) => {
+        await driver.setUp(precondition.hasLicensingSettingTest({ transport, broker_connection_result: { connection_successful: false, connection_error_messages: [], diagnostics: "" } }));
+      });
+
+      expect(hasErrors.value).toBe(true);
+    });
+
+    test("with monitoring connection test failure", async () => {
+      const { hasErrors } = await setup(async (driver) => {
+        await driver.setUp(precondition.hasLicensingSettingTest({ transport, monitoring_connection_result: { connection_successful: false, connection_error_messages: [], diagnostics: "" } }));
+      });
+
+      expect(hasErrors.value).toBe(true);
+    });
+
+    test("with audit connection test failure", async () => {
+      const { hasErrors } = await setup(async (driver) => {
+        await driver.setUp(precondition.hasLicensingSettingTest({ transport, audit_connection_result: { connection_successful: false, connection_error_messages: [], diagnostics: "" } }));
+      });
+
+      expect(hasErrors.value).toBe(true);
+    });
+  });
+
+  describe("when transport is not a broker", async () => {
+    const transport = Transport.MSMQ;
+
+    test("with monitoring connection test failure", async () => {
+      const { hasErrors } = await setup(async (driver) => {
+        await driver.setUp(precondition.hasLicensingSettingTest({ transport, monitoring_connection_result: { connection_successful: false, connection_error_messages: [], diagnostics: "" } }));
+      });
+
+      expect(hasErrors.value).toBe(true);
+    });
+
+    test("with audit connection test failure", async () => {
+      const { hasErrors } = await setup(async (driver) => {
+        await driver.setUp(precondition.hasLicensingSettingTest({ transport, audit_connection_result: { connection_successful: false, connection_error_messages: [], diagnostics: "" } }));
+      });
+
+      expect(hasErrors.value).toBe(true);
+    });
+
+    describe("with monitoring disabled", async () => {
+      beforeEach(() => {
+        disableMonitoring();
+      });
+
+      test("with audit connection test failure", async () => {
+        const { hasErrors } = await setup(async (driver) => {
+          await driver.setUp(precondition.hasLicensingSettingTest({ transport, audit_connection_result: { connection_successful: false, connection_error_messages: [], diagnostics: "" } }));
+        });
+
+        expect(hasErrors.value).toBe(true);
+      });
+
+      test("with audit connection test passing", async () => {
+        const { hasErrors } = await setup(async (driver) => {
+          await driver.setUp(precondition.hasLicensingSettingTest({ transport, audit_connection_result: { connection_successful: true, connection_error_messages: [], diagnostics: "" } }));
+        });
+
+        expect(hasErrors.value).toBe(false);
+      });
+    });
+  });
+});

--- a/src/Frontend/src/views/ThroughputReportView.spec.ts
+++ b/src/Frontend/src/views/ThroughputReportView.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import * as precondition from "../../test/preconditions";
 import { useServiceControl } from "@/composables/serviceServiceControl";
 import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
-import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
 import flushPromises from "flush-promises";
 import { createTestingPinia } from "@pinia/testing";
 import { Transport } from "@/views/throughputreport/transport";
@@ -13,6 +12,7 @@ import makeRouter from "@/router";
 import { RouterLinkStub } from "@vue/test-utils";
 import ThroughputReportView from "@/views/ThroughputReportView.vue";
 import Toast from "vue-toastification";
+import { serviceControlWithThroughput } from "@/views/throughputreport/serviceControlWithThroughput";
 
 describe("EndpointsView tests", () => {
   const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
@@ -20,13 +20,7 @@ describe("EndpointsView tests", () => {
   async function setup() {
     const driver = makeDriverForTests();
 
-    await driver.setUp(precondition.hasUpToDateServicePulse);
-    await driver.setUp(precondition.hasUpToDateServiceControl);
-    await driver.setUp(precondition.errorsDefaultHandler);
-    await driver.setUp(precondition.hasNoFailingCustomChecks);
-    await driver.setUp(precondition.hasEventLogItems);
-    await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
-    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+    await driver.setUp(serviceControlWithThroughput);
 
     return driver;
   }

--- a/src/Frontend/src/views/ThroughputReportView.spec.ts
+++ b/src/Frontend/src/views/ThroughputReportView.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+import * as precondition from "../../test/preconditions";
+import { useServiceControl } from "@/composables/serviceServiceControl";
+import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
+import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
+import flushPromises from "flush-promises";
+import { createTestingPinia } from "@pinia/testing";
+import { Transport } from "@/views/throughputreport/transport";
+import { makeDriverForTests, render, screen, userEvent } from "@component-test-utils";
+import { Driver } from "../../test/driver";
+import { disableMonitoring } from "../../test/drivers/vitest/setup";
+import makeRouter from "@/router";
+import { RouterLinkStub } from "@vue/test-utils";
+import ThroughputReportView from "@/views/ThroughputReportView.vue";
+import Toast from "vue-toastification";
+
+describe("EndpointsView tests", () => {
+  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
+
+  async function setup() {
+    const driver = makeDriverForTests();
+
+    await driver.setUp(precondition.hasUpToDateServicePulse);
+    await driver.setUp(precondition.hasUpToDateServiceControl);
+    await driver.setUp(precondition.errorsDefaultHandler);
+    await driver.setUp(precondition.hasNoFailingCustomChecks);
+    await driver.setUp(precondition.hasEventLogItems);
+    await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
+    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+
+    return driver;
+  }
+
+  async function renderComponent(transport: Transport = Transport.MSMQ, preSetup: (driver: Driver) => Promise<void> = () => Promise.resolve()) {
+    disableMonitoring();
+
+    const driver = await setup();
+    await preSetup(driver);
+
+    useServiceControlUrls();
+    await useServiceControl();
+    const el = document.createElement("div");
+    el.id = "modalDisplay";
+    document.body.appendChild(el);
+
+    const { debug } = render(ThroughputReportView, {
+      container: document.body,
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+        plugins: [makeRouter(), Toast, createTestingPinia({ stubActions: false })],
+      },
+    });
+    await flushPromises();
+
+    return { debug, driver };
+  }
+
+  describe("when minimum requirements", () => {
+    test("are met", async () => {
+      await renderComponent(Transport.AmazonSQS, async (driver) => {
+        await driver.setUp(precondition.hasLicensingReportAvailable());
+      });
+
+      expect(screen.queryByText(/the minimum version of servicecontrol required to enable the usage feature is/i)).not.toBeInTheDocument();
+    });
+
+    test("are not met, requirements warning is displayed", async () => {
+      await renderComponent(Transport.AmazonSQS, async (driver) => {
+        await driver.setUp(precondition.hasServiceControlMainInstance("1.0.0"));
+        await driver.setUp(precondition.hasLicensingReportAvailable());
+      });
+
+      expect(screen.getByText(/the minimum version of servicecontrol required to enable the usage feature is/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when report", () => {
+    test("is available", async (driver) => {
+      await renderComponent(Transport.AmazonSQS, async (driver) => {
+        await driver.setUp(precondition.hasLicensingReportAvailable());
+      });
+      expect(screen.getByRole("button", { name: /Download Report/i })).toBeEnabled();
+    });
+
+    test("is unavailable", async (driver) => {
+      const reason = "report testing that is not available";
+      await renderComponent(Transport.AmazonSQS, async (driver) => {
+        await driver.setUp(precondition.hasLicensingReportAvailable({ report_can_be_generated: false, reason: reason }));
+      });
+
+      expect(screen.getByRole("button", { name: /Download Report/i })).toBeDisabled();
+      expect(screen.getByText(reason)).toBeInTheDocument();
+    });
+  });
+
+  describe("when download report is clicked", () => {
+    test("and no warnings, download happens", async (driver) => {
+      URL.createObjectURL = () => "";
+      const fileName = "hello_john.json";
+
+      await renderComponent(Transport.AmazonSQS, async (driver) => {
+        await driver.setUp(precondition.hasLicensingReportAvailable());
+        await driver.setUp(precondition.hasLicensingEndpoints([{ name: "foo", is_known_endpoint: false, user_indicator: "something", max_daily_throughput: 0 }]));
+        driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/report/file`, {
+          body: {},
+          headers: {
+            "Content-Disposition": `attachment; filename="${fileName}"`,
+          },
+        });
+      });
+
+      const use = userEvent.setup();
+
+      await use.click(screen.getByRole("button", { name: /Download Report/i }));
+      expect(screen.queryAllByText(new RegExp(`Please email '${fileName}' to your account manager`)).length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("and there are warnings, dialog is displayed", async (driver) => {
+      await renderComponent(Transport.AmazonSQS, async (driver) => {
+        await driver.setUp(precondition.hasLicensingReportAvailable());
+        await driver.setUp(precondition.hasLicensingEndpoints([{ name: "foo", is_known_endpoint: false, user_indicator: "", max_daily_throughput: 0 }]));
+      });
+
+      const use = userEvent.setup();
+
+      await use.click(screen.getByRole("button", { name: /Download Report/i }));
+      expect(screen.getByText("Not all endpoints/queues have an Endpoint Type set")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Frontend/src/views/ThroughputReportView.vue
+++ b/src/Frontend/src/views/ThroughputReportView.vue
@@ -46,7 +46,7 @@ async function downloadReport() {
           </div>
           <div class="col-sm-6 text-end">
             <span class="reason" v-if="!reportState?.report_can_be_generated">{{ reportState?.reason }}</span>
-            <button type="button" class="btn btn-primary actions" @click="generateReport()" :disabled="!reportState?.report_can_be_generated"><i class="fa fa-download"></i> Download Report</button>
+            <button type="button" aria-label="Download Report" class="btn btn-primary actions" @click="generateReport()" :disabled="!reportState?.report_can_be_generated"><i class="fa fa-download"></i> Download Report</button>
             <Teleport to="#modalDisplay">
               <ConfirmDialog v-if="showWarning" heading="Not all endpoints/queues have an Endpoint Type set" body="Are you sure you want to continue?" @cancel="showWarning = false" @confirm="downloadReport" />
             </Teleport>

--- a/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
@@ -14,7 +14,7 @@ import { RouterLinkStub } from "@vue/test-utils";
 import EndpointsView from "./EndpointsView.vue";
 
 describe("EndpointsView tests", () => {
-  async function setup() {
+  async function setup(transport: Transport) {
     const driver = makeDriverForTests();
 
     await driver.setUp(precondition.hasUpToDateServicePulse);
@@ -24,7 +24,7 @@ describe("EndpointsView tests", () => {
     await driver.setUp(precondition.hasEventLogItems);
     await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
     await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
-    await driver.setUp(precondition.hasLicensingSettingTest({ transport: Transport.MSMQ }));
+    await driver.setUp(precondition.hasLicensingSettingTest({ transport }));
 
     return driver;
   }
@@ -32,7 +32,7 @@ describe("EndpointsView tests", () => {
   async function renderComponent(transport: Transport = Transport.MSMQ, preSetup: (driver: Driver) => Promise<void> = () => Promise.resolve()) {
     disableMonitoring();
 
-    const driver = await setup();
+    const driver = await setup(transport);
     await preSetup(driver);
 
     useServiceControlUrls();
@@ -64,5 +64,17 @@ describe("EndpointsView tests", () => {
     await use.click(screen.getByRole("link", { name: /Hide Endpoint Types meaning/i }));
 
     expect(screen.queryByText(/Show Endpoint Types meaning/i)).toBeInTheDocument();
+  });
+
+  test("broker displays the two tabs", async () => {
+    await renderComponent(Transport.AmazonSQS);
+
+    expect(screen.getByText(/Detected Broker Queues/i)).toBeInTheDocument();
+  });
+
+  test("non broker displays only one tabs", async () => {
+    await renderComponent();
+
+    expect(screen.queryByText(/Detected Broker Queues/i)).not.toBeInTheDocument();
   });
 });

--- a/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import * as precondition from "../../../test/preconditions";
 import { useServiceControl } from "@/composables/serviceServiceControl";
 import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
-import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
 import flushPromises from "flush-promises";
 import { createTestingPinia } from "@pinia/testing";
 import { Transport } from "@/views/throughputreport/transport";
@@ -12,18 +11,13 @@ import { disableMonitoring } from "../../../test/drivers/vitest/setup";
 import makeRouter from "@/router";
 import { RouterLinkStub } from "@vue/test-utils";
 import EndpointsView from "./EndpointsView.vue";
+import { serviceControlWithThroughput } from "@/views/throughputreport/serviceControlWithThroughput";
 
 describe("EndpointsView tests", () => {
   async function setup(transport: Transport) {
     const driver = makeDriverForTests();
 
-    await driver.setUp(precondition.hasUpToDateServicePulse);
-    await driver.setUp(precondition.hasUpToDateServiceControl);
-    await driver.setUp(precondition.errorsDefaultHandler);
-    await driver.setUp(precondition.hasNoFailingCustomChecks);
-    await driver.setUp(precondition.hasEventLogItems);
-    await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
-    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+    await driver.setUp(serviceControlWithThroughput);
     await driver.setUp(precondition.hasLicensingSettingTest({ transport }));
 
     return driver;

--- a/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import * as precondition from "../../../test/preconditions";
+import { useServiceControl } from "@/composables/serviceServiceControl";
+import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
+import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
+import flushPromises from "flush-promises";
+import { createTestingPinia } from "@pinia/testing";
+import { Transport } from "@/views/throughputreport/transport";
+import { makeDriverForTests, render, screen, userEvent } from "@component-test-utils";
+import { Driver } from "../../../test/driver";
+import { disableMonitoring } from "../../../test/drivers/vitest/setup";
+import SetupView from "./SetupView.vue";
+import ConnectionTestResults, { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
+import makeRouter from "@/router";
+import { RouterLinkStub } from "@vue/test-utils";
+import EndpointsView from "./EndpointsView.vue";
+
+describe("EndpointsView tests", () => {
+  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
+
+  async function setup() {
+    const driver = makeDriverForTests();
+
+    await driver.setUp(precondition.hasUpToDateServicePulse);
+    await driver.setUp(precondition.hasUpToDateServiceControl);
+    await driver.setUp(precondition.errorsDefaultHandler);
+    await driver.setUp(precondition.hasNoFailingCustomChecks);
+    await driver.setUp(precondition.hasEventLogItems);
+    await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
+    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
+      body: <ConnectionTestResults>{
+        transport: Transport.MSMQ,
+        audit_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Audit diagnostics",
+        },
+        monitoring_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Monitoring diagnostics",
+        },
+        broker_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Broker diagnostics",
+        },
+      },
+    });
+
+    return driver;
+  }
+
+  async function renderComponent(transport: Transport = Transport.MSMQ, preSetup: (driver: Driver) => Promise<void> = () => Promise.resolve()) {
+    disableMonitoring();
+
+    const driver = await setup();
+    await preSetup(driver);
+
+    useServiceControlUrls();
+    await useServiceControl();
+    const { debug } = render(EndpointsView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+        plugins: [makeRouter(), createTestingPinia({ stubActions: false })],
+      },
+    });
+    await flushPromises();
+
+    return { debug, driver };
+  }
+
+  test("instructions by default are showing", async () => {
+    await renderComponent();
+
+    expect(screen.queryByText(/Hide Endpoint Types meaning/i)).toBeInTheDocument();
+  });
+
+  test("hide instructions", async () => {
+    await renderComponent();
+
+    const use = userEvent.setup();
+
+    await use.click(screen.getByRole("link", { name: /Hide Endpoint Types meaning/i }));
+
+    expect(screen.queryByText(/Show Endpoint Types meaning/i)).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
@@ -9,15 +9,11 @@ import { Transport } from "@/views/throughputreport/transport";
 import { makeDriverForTests, render, screen, userEvent } from "@component-test-utils";
 import { Driver } from "../../../test/driver";
 import { disableMonitoring } from "../../../test/drivers/vitest/setup";
-import SetupView from "./SetupView.vue";
-import ConnectionTestResults, { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
 import makeRouter from "@/router";
 import { RouterLinkStub } from "@vue/test-utils";
 import EndpointsView from "./EndpointsView.vue";
 
 describe("EndpointsView tests", () => {
-  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
-
   async function setup() {
     const driver = makeDriverForTests();
 
@@ -28,26 +24,7 @@ describe("EndpointsView tests", () => {
     await driver.setUp(precondition.hasEventLogItems);
     await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
     await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
-    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
-      body: <ConnectionTestResults>{
-        transport: Transport.MSMQ,
-        audit_connection_result: <ConnectionSettingsTestResult>{
-          connection_successful: true,
-          connection_error_messages: [],
-          diagnostics: "Audit diagnostics",
-        },
-        monitoring_connection_result: <ConnectionSettingsTestResult>{
-          connection_successful: true,
-          connection_error_messages: [],
-          diagnostics: "Monitoring diagnostics",
-        },
-        broker_connection_result: <ConnectionSettingsTestResult>{
-          connection_successful: true,
-          connection_error_messages: [],
-          diagnostics: "Broker diagnostics",
-        },
-      },
-    });
+    await driver.setUp(precondition.hasLicensingSettingTest({ transport: Transport.MSMQ }));
 
     return driver;
   }

--- a/src/Frontend/src/views/throughputreport/EndpointsView.vue
+++ b/src/Frontend/src/views/throughputreport/EndpointsView.vue
@@ -43,7 +43,7 @@ function toggleOptionsLegendVisible() {
           <h5 class="nav-item" :class="{ active: isRouteSelected(routeLinks.throughput.endpoints.detectedEndpoints.link) }">
             <RouterLink :to="routeLinks.throughput.endpoints.detectedEndpoints.link">Detected Endpoints</RouterLink>
           </h5>
-          <h5 v-if="isBrokerTransport" class="nav-item" :class="{ active: isRouteSelected(routeLinks.throughput.endpoints.detectedBrokerQueues.link) }">
+          <h5 v-if="isBrokerTransport" class="nav-item" role="tab" :class="{ active: isRouteSelected(routeLinks.throughput.endpoints.detectedBrokerQueues.link) }">
             <RouterLink :to="routeLinks.throughput.endpoints.detectedBrokerQueues.link">Detected Broker Queues</RouterLink>
           </h5>
         </div>

--- a/src/Frontend/src/views/throughputreport/EndpointsView.vue
+++ b/src/Frontend/src/views/throughputreport/EndpointsView.vue
@@ -29,7 +29,7 @@ function toggleOptionsLegendVisible() {
         Set an Endpoint Type for all detected endpoints and broker queues with the most appropriate option.<br />
         Use the filters to bulk set the Endpoint Types on similar named endpoints/queues.<br />
         If the names of the endpoints/queues contain confidential or proprietary information, make sure you set up <RouterLink :to="routeLinks.throughput.setup.mask.link">masking in Configuration</RouterLink>.<br />
-        <a href="#" @click.prevent="toggleOptionsLegendVisible()">{{ showLegend ? "Hide" : "Show" }} Endpoint Types meaning.</a>
+        <a href="#" :aria-label="`${showLegend ? 'Hide' : 'Show'} Endpoint Types meaning`" @click.prevent="toggleOptionsLegendVisible()">{{ showLegend ? "Hide" : "Show" }} Endpoint Types meaning.</a>
       </p>
       <div v-show="showLegend" class="alert alert-info">
         <div v-for="[key, value] in legendOptions" :key="key">

--- a/src/Frontend/src/views/throughputreport/SetupView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/SetupView.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "vitest";
+import * as precondition from "../../../test/preconditions";
+import { useServiceControl } from "@/composables/serviceServiceControl";
+import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
+import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
+import flushPromises from "flush-promises";
+import { createTestingPinia } from "@pinia/testing";
+import { Transport } from "@/views/throughputreport/transport";
+import { makeDriverForTests, render, screen } from "@component-test-utils";
+import { Driver } from "../../../test/driver";
+import { disableMonitoring } from "../../../test/drivers/vitest/setup";
+import SetupView from "./SetupView.vue";
+import ConnectionTestResults, { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
+import makeRouter from "@/router";
+import { RouterLinkStub } from "@vue/test-utils";
+
+describe("SetupView tests", () => {
+  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
+
+  async function setup() {
+    const driver = makeDriverForTests();
+
+    await driver.setUp(precondition.hasUpToDateServicePulse);
+    await driver.setUp(precondition.hasUpToDateServiceControl);
+    await driver.setUp(precondition.errorsDefaultHandler);
+    await driver.setUp(precondition.hasNoFailingCustomChecks);
+    await driver.setUp(precondition.hasEventLogItems);
+    await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
+    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+
+    return driver;
+  }
+
+  async function renderComponent(transport: Transport = Transport.MSMQ, preSetup: (driver: Driver) => Promise<void> = () => Promise.resolve()) {
+    const driver = await setup();
+
+    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
+      body: <ConnectionTestResults>{
+        transport,
+        audit_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Audit diagnostics",
+        },
+        monitoring_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Monitoring diagnostics",
+        },
+        broker_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Broker diagnostics",
+        },
+      },
+    });
+
+    await preSetup(driver);
+
+    useServiceControlUrls();
+    await useServiceControl();
+    const { debug } = render(SetupView, {
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+        plugins: [makeRouter(), createTestingPinia({ stubActions: false })],
+      },
+    });
+    await flushPromises();
+
+    return { debug, driver };
+  }
+
+  describe("when minimum requirements", () => {
+    test("are met", async () => {
+      disableMonitoring();
+
+      await renderComponent();
+
+      expect(screen.queryByText(/the minimum version of servicecontrol required to enable the usage feature is \./i)).not.toBeInTheDocument();
+    });
+
+    test("are not met, requirements warning is displayed", async () => {
+      disableMonitoring();
+
+      await renderComponent(Transport.MSMQ, async (driver) => {
+        await driver.setUp(precondition.hasServiceControlMainInstance("1.0.0"));
+      });
+
+      expect(screen.getByText(/the minimum version of servicecontrol required to enable the usage feature is \./i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when not a broker", () => {
+    test("without monitoring", async () => {
+      disableMonitoring();
+      await renderComponent();
+
+      expect(screen.getByText(/Successfully connected to Audit instance/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Successfully connected to Monitoring/i)).not.toBeInTheDocument();
+    });
+
+    test("with monitoring", async () => {
+      await renderComponent(Transport.MSMQ, async (driver) => {
+        await driver.setUp(precondition.serviceControlWithMonitoring);
+        await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+        driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
+          body: <ConnectionTestResults>{
+            transport: Transport.MSMQ,
+            audit_connection_result: <ConnectionSettingsTestResult>{
+              connection_successful: true,
+              connection_error_messages: [],
+              diagnostics: "Audit diagnostics",
+            },
+            monitoring_connection_result: <ConnectionSettingsTestResult>{
+              connection_successful: true,
+              connection_error_messages: [],
+              diagnostics: "Monitoring diagnostics",
+            },
+            broker_connection_result: <ConnectionSettingsTestResult>{
+              connection_successful: true,
+              connection_error_messages: [],
+              diagnostics: "Broker diagnostics",
+            },
+          },
+        });
+      });
+
+      expect(screen.getByText(/Successfully connected to Audit instance/i)).toBeInTheDocument();
+      expect(screen.getByText(/Successfully connected to Monitoring/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when a broker", () => {
+    test("display success", async () => {
+      disableMonitoring();
+      await renderComponent(Transport.AmazonSQS);
+
+      expect(screen.getByText(/Successfully connected to Amazon SQS for usage collection/i)).toBeInTheDocument();
+    });
+
+    test("display failure", async () => {
+      disableMonitoring();
+      await renderComponent(Transport.AmazonSQS, async (driver) => {
+        driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
+          body: <ConnectionTestResults>{
+            transport: Transport.AmazonSQS,
+            audit_connection_result: <ConnectionSettingsTestResult>{
+              connection_successful: true,
+              connection_error_messages: [],
+              diagnostics: "Audit diagnostics",
+            },
+            monitoring_connection_result: <ConnectionSettingsTestResult>{
+              connection_successful: true,
+              connection_error_messages: [],
+              diagnostics: "Monitoring diagnostics",
+            },
+            broker_connection_result: <ConnectionSettingsTestResult>{
+              connection_successful: false,
+              connection_error_messages: [],
+              diagnostics: "Broker diagnostics",
+            },
+          },
+        });
+      });
+
+      expect(screen.getByText(/The connection to Amazon SQS was not successful/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Frontend/src/views/throughputreport/SetupView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/SetupView.spec.ts
@@ -13,18 +13,13 @@ import SetupView from "./SetupView.vue";
 import { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
 import makeRouter from "@/router";
 import { RouterLinkStub } from "@vue/test-utils";
+import { serviceControlWithThroughput } from "@/views/throughputreport/serviceControlWithThroughput";
 
 describe("SetupView tests", () => {
   async function setup() {
     const driver = makeDriverForTests();
 
-    await driver.setUp(precondition.hasUpToDateServicePulse);
-    await driver.setUp(precondition.hasUpToDateServiceControl);
-    await driver.setUp(precondition.errorsDefaultHandler);
-    await driver.setUp(precondition.hasNoFailingCustomChecks);
-    await driver.setUp(precondition.hasEventLogItems);
-    await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
-    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+    await driver.setUp(serviceControlWithThroughput);
 
     return driver;
   }

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedBrokerQueuesView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedBrokerQueuesView.vue
@@ -2,21 +2,12 @@
 import DetectedListView from "@/views/throughputreport/endpoints/DetectedListView.vue";
 import { DataSource } from "@/views/throughputreport/endpoints/dataSource";
 import { UserIndicator } from "@/views/throughputreport/endpoints/userIndicator";
-import { onMounted, ref } from "vue";
-import throughputClient from "@/views/throughputreport/throughputClient";
 import routeLinks from "@/router/routeLinks";
-import ReportGenerationState from "@/resources/ReportGenerationState";
 import { useThroughputStore } from "@/stores/ThroughputStore";
 import { storeToRefs } from "pinia";
 
-const reportAvailable = ref<ReportGenerationState | null>(null);
-
 const store = useThroughputStore();
 const { testResults } = storeToRefs(store);
-
-onMounted(async () => {
-  reportAvailable.value = await throughputClient.reportAvailable();
-});
 </script>
 
 <template>

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedBrokerQueuesView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedBrokerQueuesView.vue
@@ -21,6 +21,7 @@ const { testResults } = storeToRefs(store);
     </div>
   </template>
   <DetectedListView
+    ariaLabel="Detected broker queues"
     :indicator-options="[UserIndicator.NServiceBusEndpoint, UserIndicator.NotNServiceBusEndpoint, UserIndicator.SendOnlyOrTransactionSessionEndpoint, UserIndicator.NServiceBusEndpointNoLongerInUse, UserIndicator.PlannedToDecommission]"
     :source="DataSource.Broker"
     column-title="Queue Name"

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedEndpointsView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedEndpointsView.vue
@@ -22,6 +22,7 @@ const { isBrokerTransport, hasErrors } = storeToRefs(useThroughputStore());
     </template>
   </template>
   <DetectedListView
+    ariaLabel="Detected endpoints"
     :indicator-options="[UserIndicator.NServiceBusEndpoint, UserIndicator.SendOnlyOrTransactionSessionEndpoint, UserIndicator.NServiceBusEndpointNoLongerInUse, UserIndicator.PlannedToDecommission]"
     :source="DataSource.WellKnownEndpoint"
     column-title="Endpoint Name"

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.spec.ts
@@ -5,11 +5,12 @@ import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
 import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
 import flushPromises from "flush-promises";
 import { Transport } from "@/views/throughputreport/transport";
-import { makeDriverForTests, render, screen } from "@component-test-utils";
+import { makeDriverForTests, render, screen, userEvent } from "@component-test-utils";
 import { Driver } from "../../../../test/driver";
 import { disableMonitoring } from "../../../../test/drivers/vitest/setup";
 import DetectedListView, { DetectedListViewProps } from "@/views/throughputreport/endpoints/DetectedListView.vue";
 import { DataSource } from "@/views/throughputreport/endpoints/dataSource";
+import { UserIndicator } from "@/views/throughputreport/endpoints/userIndicator";
 
 describe("DetectedListView tests", () => {
   async function setup() {
@@ -87,6 +88,168 @@ describe("DetectedListView tests", () => {
 
       expect(screen.getByText(/I am an endpoint/i)).toBeInTheDocument();
       expect(screen.queryByText(/I am a queue/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("filtering scenarios", async () => {
+    function getFilterNameElement() {
+      return screen.getByRole("searchbox", { name: /Filter by name/i }) as HTMLTextAreaElement;
+    }
+
+    function getFilterNameTypeElement() {
+      return screen.getByRole("combobox", { name: /Filter name type/i }) as HTMLSelectElement;
+    }
+
+    function getFilterUnsetCheckboxElement() {
+      return screen.getByRole("checkbox", { name: /Show only not set Endpoint Types/i }) as HTMLInputElement;
+    }
+
+    test("by name", async () => {
+      await renderComponent({ source: DataSource.WellKnownEndpoint }, async (driver) => {
+        await driver.setUp(
+          precondition.hasLicensingEndpoints([
+            ...[...Array(10).keys()].map((i) => ({ name: `Alpha${i}`, is_known_endpoint: true, user_indicator: "", max_daily_throughput: i })),
+            ...[...Array(10).keys()].map((i) => ({ name: `${i}Beta`, is_known_endpoint: true, user_indicator: "", max_daily_throughput: i })),
+            ...[...Array(10).keys()].map((i) => ({ name: `${i}Delta${i}`, is_known_endpoint: true, user_indicator: "", max_daily_throughput: i })),
+          ])
+        );
+      });
+
+      const user = userEvent.setup();
+      const filterNameElement = getFilterNameElement();
+      await user.type(filterNameElement, "Alpha");
+
+      expect(screen.queryAllByText(/Alpha\d/i).length).toBe(10);
+      expect(screen.queryAllByText(/\dBeta/i).length).toBe(0);
+      expect(screen.queryAllByText(/\dDelta\d/i).length).toBe(0);
+
+      const filterNameTypeElement = getFilterNameTypeElement();
+      await user.selectOptions(filterNameTypeElement, "Ends with");
+      await user.clear(filterNameElement);
+      await user.type(filterNameElement, "Beta");
+
+      expect(screen.queryAllByText(/\dBeta/i).length).toBe(10);
+      expect(screen.queryAllByText(/Alpha\d/i).length).toBe(0);
+      expect(screen.queryAllByText(/\dDelta\d/i).length).toBe(0);
+
+      await user.selectOptions(filterNameTypeElement, "Contains");
+      await user.clear(filterNameElement);
+      await user.type(filterNameElement, "Delta");
+
+      expect(screen.queryAllByText(/\dDelta\d/i).length).toBe(10);
+      expect(screen.queryAllByText(/\dBeta/i).length).toBe(0);
+      expect(screen.queryAllByText(/Alpha\d/i).length).toBe(0);
+    });
+
+    test("by unset only", async () => {
+      await renderComponent({ source: DataSource.Broker, indicatorOptions: [UserIndicator.NServiceBusEndpoint] }, async (driver) => {
+        await driver.setUp(
+          precondition.hasLicensingEndpoints([
+            ...[...Array(10).keys()].map((i) => ({ name: `Alpha${i}`, is_known_endpoint: false, user_indicator: "", max_daily_throughput: i })),
+            ...[...Array(10).keys()].map((i) => ({ name: `${i}Beta`, is_known_endpoint: false, user_indicator: UserIndicator.NServiceBusEndpoint, max_daily_throughput: i })),
+            ...[...Array(10).keys()].map((i) => ({ name: `${i}Delta${i}`, is_known_endpoint: false, user_indicator: "", max_daily_throughput: i })),
+          ])
+        );
+      });
+
+      const user = userEvent.setup();
+      const filterCheckboxElement = getFilterUnsetCheckboxElement();
+      await user.click(filterCheckboxElement);
+
+      expect(screen.queryAllByText(/Alpha\d/i).length).toBe(10);
+      expect(screen.queryAllByText(/\dBeta/i).length).toBe(0);
+      expect(screen.queryAllByText(/\dDelta\d/i).length).toBe(10);
+    });
+
+    test("by combination of all", async () => {
+      const columnTitle = "Special column name";
+      await renderComponent({ source: DataSource.Broker, indicatorOptions: [UserIndicator.NServiceBusEndpoint], columnTitle: columnTitle }, async (driver) => {
+        await driver.setUp(
+          precondition.hasLicensingEndpoints([
+            ...[...Array(5).keys()].map((i) => ({ name: `${i}Beta`, is_known_endpoint: false, user_indicator: UserIndicator.PlannedToDecommission, max_daily_throughput: i })),
+            ...[...Array(8).keys()].map((i) => ({ name: `${i}Beta`, is_known_endpoint: false, user_indicator: UserIndicator.PlannedToDecommission, max_daily_throughput: i })),
+            ...[...Array(2).keys()].map((i) => ({ name: `${i}Delta${i}`, is_known_endpoint: false, user_indicator: UserIndicator.PlannedToDecommission, max_daily_throughput: i })),
+            { name: "boo", is_known_endpoint: false, user_indicator: "", max_daily_throughput: 11 },
+          ])
+        );
+      });
+
+      const user = userEvent.setup();
+      const filterCheckboxElement = getFilterUnsetCheckboxElement();
+      await user.click(filterCheckboxElement);
+
+      const filterNameTypeElement = getFilterNameTypeElement();
+      const filterNameElement = getFilterNameElement();
+      await user.selectOptions(filterNameTypeElement, "Begins with");
+      await user.clear(filterNameElement);
+      await user.type(filterNameElement, "boo");
+
+      const th = screen.getByText(columnTitle);
+      const table = th.parentElement?.parentElement?.parentElement as HTMLTableElement;
+
+      expect(table.rows.length).toBe(1 + 1 /* includes headers */);
+    });
+  });
+
+  describe("sorting by", async () => {
+    test("throughput", async () => {
+      const columnTitle = "Special column name";
+      const dataLength = 5;
+
+      await renderComponent({ source: DataSource.Broker, indicatorOptions: [UserIndicator.NServiceBusEndpoint], columnTitle: columnTitle }, async (driver) => {
+        await driver.setUp(precondition.hasLicensingEndpoints([...[...Array(dataLength).keys()].map((i) => ({ name: `${i}Beta`, is_known_endpoint: false, user_indicator: UserIndicator.PlannedToDecommission, max_daily_throughput: i }))]));
+      });
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /Sort by/i }));
+      await user.click(screen.getByRole("link", { name: "throughput" }));
+
+      const th = screen.getByText(columnTitle);
+      const table = th.parentElement?.parentElement?.parentElement as HTMLTableElement;
+
+      let throughput = 0;
+      for (const row of [...table.rows].slice(1)) {
+        expect(row.cells[1].textContent).toBe(`${throughput++}`);
+      }
+
+      await user.click(screen.getByRole("button", { name: /Sort by/i }));
+      await user.click(screen.getByRole("link", { name: "throughput (Descending)" }));
+
+      throughput = dataLength - 1;
+      for (const row of [...table.rows].slice(1)) {
+        expect(row.cells[1].textContent).toBe(`${throughput--}`);
+      }
+    });
+
+    test("name", async () => {
+      const columnTitle = "Special column name";
+      const names = ["basilisk", "octopus", "hamster", "anteater", "porcupine", "gazelle", "seal", "lynx", "crocodile", "mountain goat", "yak", "polar bear", "horse", "gorilla", "zebu", "salamander", "alligator", "vicuna", "goat", "bunny"];
+
+      await renderComponent({ source: DataSource.Broker, indicatorOptions: [UserIndicator.NServiceBusEndpoint], columnTitle: columnTitle }, async (driver) => {
+        await driver.setUp(precondition.hasLicensingEndpoints([...[...names].map((name, idx) => ({ name, is_known_endpoint: false, user_indicator: UserIndicator.PlannedToDecommission, max_daily_throughput: idx }))]));
+      });
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /Sort by/i }));
+      await user.click(screen.getByRole("link", { name: "name" }));
+
+      const th = screen.getByText(columnTitle);
+      const table = th.parentElement?.parentElement?.parentElement as HTMLTableElement;
+
+      let orderedNames = names.sort((a, b) => a.localeCompare(b));
+      let idx = 0;
+      for (const row of [...table.rows].slice(1)) {
+        expect(row.cells[0].textContent).toBe(orderedNames[idx++]);
+      }
+
+      await user.click(screen.getByRole("button", { name: /Sort by/i }));
+      await user.click(screen.getByRole("link", { name: "name (Descending)" }));
+
+      orderedNames = orderedNames.sort((a, b) => -a.localeCompare(b));
+      idx = 0;
+      for (const row of [...table.rows].slice(1)) {
+        expect(row.cells[0].textContent).toBe(orderedNames[idx++]);
+      }
     });
   });
 });

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+import * as precondition from "../../../../test/preconditions";
+import { useServiceControl } from "@/composables/serviceServiceControl";
+import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
+import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
+import flushPromises from "flush-promises";
+import { Transport } from "@/views/throughputreport/transport";
+import { makeDriverForTests, render, screen } from "@component-test-utils";
+import { Driver } from "../../../../test/driver";
+import { disableMonitoring } from "../../../../test/drivers/vitest/setup";
+import DetectedListView, { DetectedListViewProps } from "@/views/throughputreport/endpoints/DetectedListView.vue";
+import { DataSource } from "@/views/throughputreport/endpoints/dataSource";
+
+describe("DetectedListView tests", () => {
+  async function setup() {
+    const driver = makeDriverForTests();
+
+    await driver.setUp(precondition.hasUpToDateServicePulse);
+    await driver.setUp(precondition.hasUpToDateServiceControl);
+    await driver.setUp(precondition.errorsDefaultHandler);
+    await driver.setUp(precondition.hasNoFailingCustomChecks);
+    await driver.setUp(precondition.hasEventLogItems);
+    await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
+    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+    await driver.setUp(precondition.hasLicensingSettingTest({ transport: Transport.AmazonSQS }));
+
+    return driver;
+  }
+
+  async function renderComponent(props: Partial<DetectedListViewProps> = {}, preSetup: (driver: Driver) => Promise<void> = () => Promise.resolve()) {
+    disableMonitoring();
+
+    const driver = await setup();
+    await preSetup(driver);
+
+    useServiceControlUrls();
+    await useServiceControl();
+    const el = document.createElement("div");
+    el.id = "modalDisplay";
+    document.body.appendChild(el);
+    const { debug } = render(DetectedListView, {
+      global: {
+        directives: {
+          tooltip: {},
+        },
+      },
+      container: document.body,
+      props: {
+        ...{
+          columnTitle: "Name",
+          showEndpointTypePlaceholder: true,
+          indicatorOptions: [],
+          source: DataSource.Broker,
+        },
+        ...props,
+      },
+    });
+    await flushPromises();
+
+    return { debug, driver };
+  }
+
+  describe("We only display", () => {
+    test("queues when broker is selected", async () => {
+      await renderComponent({}, async (driver) => {
+        await driver.setUp(
+          precondition.hasLicensingEndpoints([
+            { name: "I am a queue", is_known_endpoint: false, user_indicator: "", max_daily_throughput: 10 },
+            { name: "I am an endpoint", is_known_endpoint: true, user_indicator: "", max_daily_throughput: 100 },
+          ])
+        );
+      });
+
+      expect(screen.getByText(/I am a queue/i)).toBeInTheDocument();
+      expect(screen.queryByText(/I am an endpoint/i)).not.toBeInTheDocument();
+    });
+
+    test("endpoints when well known endpoint is selected", async () => {
+      await renderComponent({ source: DataSource.WellKnownEndpoint }, async (driver) => {
+        await driver.setUp(
+          precondition.hasLicensingEndpoints([
+            { name: "I am a queue", is_known_endpoint: false, user_indicator: "", max_daily_throughput: 10 },
+            { name: "I am an endpoint", is_known_endpoint: true, user_indicator: "", max_daily_throughput: 100 },
+          ])
+        );
+      });
+
+      expect(screen.getByText(/I am an endpoint/i)).toBeInTheDocument();
+      expect(screen.queryByText(/I am a queue/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
@@ -195,10 +195,12 @@ async function save() {
         </td>
         <td class="col" style="width: 350px; padding-left: 0">
           <div class="dropdown">
-            <button class="btn btn-secondary dropdown-toggle" :disabled="filteredData.length === 0" type="button" data-bs-toggle="dropdown" aria-expanded="false">Set Endpoint Type for all items below</button>
+            <button class="btn btn-secondary dropdown-toggle" aria-label="Set Endpoint Type for all items below" :disabled="filteredData.length === 0" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Set Endpoint Type for all items below
+            </button>
             <ul class="dropdown-menu">
               <li v-for="indicator in props.indicatorOptions" :key="indicator">
-                <a href="#" @click.prevent="showBulkUpdateIndicatorWarning(indicator)">{{ userIndicatorMapper.get(indicator) }}</a>
+                <a href="#" :aria-label="userIndicatorMapper.get(indicator)" @click.prevent="showBulkUpdateIndicatorWarning(indicator)">{{ userIndicatorMapper.get(indicator) }}</a>
               </li>
             </ul>
           </div>

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
@@ -35,6 +35,7 @@ const sortData: SortData[] = [
 });
 
 export interface DetectedListViewProps {
+  ariaLabel: string;
   columnTitle: string;
   showEndpointTypePlaceholder: boolean;
   indicatorOptions: UserIndicator[];
@@ -217,7 +218,7 @@ async function save() {
       @confirm="proceedWithChangesWarning"
     />
   </Teleport>
-  <table class="table">
+  <table class="table" :aria-label="ariaLabel">
     <thead>
       <tr>
         <th scope="col">{{ props.columnTitle }}</th>

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
@@ -165,18 +165,18 @@ async function save() {
       <div class="col">
         <div class="text-search-container">
           <div>
-            <select class="form-select text-search format-text" @change="searchTypeChanged">
+            <select class="form-select text-search format-text" aria-label="Filter name type" @change="searchTypeChanged">
               <option v-for="item in filterNameOptions" :value="item.text" :key="item.text">{{ item.text }}</option>
             </select>
           </div>
           <div>
-            <input type="search" class="form-control format-text" :value="filterData.name" @input="nameFilterChanged" placeholder="Filter by name..." />
+            <input type="search" aria-label="Filter by name" class="form-control format-text" :value="filterData.name" @input="nameFilterChanged" placeholder="Filter by name..." />
           </div>
         </div>
       </div>
       <div class="col" style="align-content: center">
         <div>
-          <input type="checkbox" class="check-label" id="showUnsetOnly" @input="showUnsetChanged" />
+          <input type="checkbox" aria-label="Show only not set Endpoint Types" class="check-label" id="showUnsetOnly" @input="showUnsetChanged" />
           <label for="showUnsetOnly">Show only not set Endpoint Types</label>
         </div>
       </div>

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
@@ -34,12 +34,14 @@ const sortData: SortData[] = [
   ];
 });
 
-const props = defineProps<{
+export interface DetectedListViewProps {
   columnTitle: string;
   showEndpointTypePlaceholder: boolean;
   indicatorOptions: UserIndicator[];
   source: DataSource;
-}>();
+}
+
+const props = defineProps<DetectedListViewProps>();
 
 const data = ref<EndpointThroughputSummary[]>([]);
 const dataChanges = ref(new Map<string, { indicator: string }>());

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.vue
@@ -231,11 +231,11 @@ async function save() {
         <td colspan="3" class="text-center"><slot name="nodata"></slot></td>
       </tr>
       <tr v-for="row in filteredData" :key="row.name">
-        <td class="col">
+        <td class="col" aria-label="name">
           {{ row.name }}
         </td>
-        <td class="col text-end formatThroughputColumn" style="width: 250px">{{ row.max_daily_throughput.toLocaleString() }}</td>
-        <td class="col" style="width: 350px">
+        <td class="col text-end formatThroughputColumn" style="width: 250px" aria-label="maximum daily throughput">{{ row.max_daily_throughput.toLocaleString() }}</td>
+        <td class="col" style="width: 350px" aria-label="endpoint type">
           <select class="form-select endpointType format-text" @change="(event) => updateIndicator(event, row.name)">
             <option v-if="props.showEndpointTypePlaceholder" value="">Pick the most appropriate option</option>
             <option v-for="item in props.indicatorOptions" :key="item" :value="item" :selected="(dataChanges.get(row.name)?.indicator ?? getDefaultEndpointType(row)) === item">{{ userIndicatorMapper.get(item) }}</option>

--- a/src/Frontend/src/views/throughputreport/serviceControlWithThroughput.ts
+++ b/src/Frontend/src/views/throughputreport/serviceControlWithThroughput.ts
@@ -1,0 +1,13 @@
+import { SetupFactoryOptions } from "../../../test/driver";
+import * as precondition from "../../../test/preconditions";
+import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
+
+export const serviceControlWithThroughput = async ({ driver }: SetupFactoryOptions) => {
+  await driver.setUp(precondition.hasUpToDateServicePulse);
+  await driver.setUp(precondition.hasUpToDateServiceControl);
+  await driver.setUp(precondition.errorsDefaultHandler);
+  await driver.setUp(precondition.hasNoFailingCustomChecks);
+  await driver.setUp(precondition.hasEventLogItems);
+  await driver.setUp(precondition.hasNoHeartbeatsEndpoints);
+  await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
+};

--- a/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.spec.ts
@@ -6,15 +6,12 @@ import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroug
 import flushPromises from "flush-promises";
 import DiagnosticsView from "./DiagnosticsView.vue";
 import { createTestingPinia } from "@pinia/testing";
-import ConnectionTestResults, { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
 import { Transport } from "@/views/throughputreport/transport";
 import { makeDriverForTests, userEvent, render, screen } from "@component-test-utils";
 import { Driver } from "../../../../test/driver";
 import { disableMonitoring } from "../../../../test/drivers/vitest/setup";
 
 describe("DiagnosticsView tests", () => {
-  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
-
   async function setup() {
     const driver = makeDriverForTests();
 
@@ -31,26 +28,26 @@ describe("DiagnosticsView tests", () => {
 
     await preSetup(driver);
 
-    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
-      body: <ConnectionTestResults>{
+    await driver.setUp(
+      precondition.hasLicensingSettingTest({
         transport,
-        audit_connection_result: <ConnectionSettingsTestResult>{
+        audit_connection_result: {
           connection_successful: true,
           connection_error_messages: [],
           diagnostics: "Audit diagnostics",
         },
-        monitoring_connection_result: <ConnectionSettingsTestResult>{
+        monitoring_connection_result: {
           connection_successful: true,
           connection_error_messages: [],
           diagnostics: "Monitoring diagnostics",
         },
-        broker_connection_result: <ConnectionSettingsTestResult>{
+        broker_connection_result: {
           connection_successful: true,
           connection_error_messages: [],
           diagnostics: "Broker diagnostics",
         },
-      },
-    });
+      })
+    );
 
     useServiceControlUrls();
     await useServiceControl();
@@ -103,26 +100,26 @@ describe("DiagnosticsView tests", () => {
     const use = userEvent.setup();
     await use.click(screen.getByRole("button", { name: /Refresh Connection Test/i }));
 
-    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
-      body: <ConnectionTestResults>{
+    await driver.setUp(
+      precondition.hasLicensingSettingTest({
         transport: Transport.AmazonSQS,
-        audit_connection_result: <ConnectionSettingsTestResult>{
+        audit_connection_result: {
           connection_successful: true,
           connection_error_messages: [],
           diagnostics: "Audit refreshed diagnostics",
         },
-        monitoring_connection_result: <ConnectionSettingsTestResult>{
+        monitoring_connection_result: {
           connection_successful: true,
           connection_error_messages: [],
           diagnostics: "Monitoring refreshed diagnostics",
         },
-        broker_connection_result: <ConnectionSettingsTestResult>{
+        broker_connection_result: {
           connection_successful: true,
           connection_error_messages: [],
           diagnostics: "Broker refreshed diagnostics",
         },
-      },
-    });
+      })
+    );
 
     await use.click(screen.getByRole("button", { name: /Refresh Connection Test/i }));
     expect(screen.getByText(/Audit refreshed diagnostics/i)).toBeInTheDocument();

--- a/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.spec.ts
@@ -1,0 +1,119 @@
+import { test } from "../../../../test/drivers/vitest/driver";
+import { describe, expect } from "vitest";
+import * as precondition from "../../../../test/preconditions";
+import { useServiceControl } from "@/composables/serviceServiceControl";
+import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
+import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
+import flushPromises from "flush-promises";
+import { Driver } from "../../../../test/driver";
+import { render, screen } from "@testing-library/vue";
+import DiagnosticsView from "./DiagnosticsView.vue";
+import { createTestingPinia } from "@pinia/testing";
+import ConnectionTestResults, { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
+import { Transport } from "@/views/throughputreport/transport";
+import { userEvent } from "@component-test-utils";
+
+describe("DiagnosticsView tests", () => {
+  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
+
+  async function setup(driver: Driver) {
+    await driver.setUp(({ driver }) => precondition.hasServiceControlMainInstance({ driver }, minimumSCVersionForThroughput));
+    await driver.setUp(precondition.hasUpToDateServicePulse);
+    await driver.setUp(precondition.hasUpToDateServiceControl);
+    await driver.setUp(precondition.hasNoErrors);
+  }
+
+  async function renderComponent(driver: Driver, transport: Transport = Transport.MSMQ) {
+    await setup(driver);
+    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
+      body: <ConnectionTestResults>{
+        transport,
+        audit_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Audit diagnostics",
+        },
+        monitoring_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Monitoring diagnostics",
+        },
+        broker_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Broker diagnostics",
+        },
+      },
+    });
+    useServiceControlUrls();
+    await useServiceControl();
+    const { debug } = render(DiagnosticsView, { global: { plugins: [createTestingPinia({ stubActions: false })] } });
+    await flushPromises();
+    return { debug };
+  }
+
+  test("renders audit diagnostics when not a broker and monitoring is not enabled", async ({ driver }) => {
+    window.defaultConfig.monitoring_urls = ["!"];
+    await renderComponent(driver);
+    const use = userEvent.setup();
+    await use.click(screen.getByRole("button", { name: /Refresh Connection Test/i }));
+    expect(screen.getByText(/Audit diagnostics/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Broker diagnostics/i)).toBeNull();
+    expect(screen.queryByText(/Monitoring diagnostics/i)).toBeNull();
+  });
+
+  test("renders audit and broker diagnostics with monitoring not enabled", async ({ driver }) => {
+    window.defaultConfig.monitoring_urls = ["!"];
+    await renderComponent(driver, Transport.AmazonSQS);
+    const use = userEvent.setup();
+    await use.click(screen.getByRole("button", { name: /Refresh Connection Test/i }));
+    expect(screen.getByText(/Audit diagnostics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Broker diagnostics/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Monitoring diagnostics/i)).toBeNull();
+  });
+
+  test("renders audit, broker and monitoring diagnostics when all enabled", async ({ driver }) => {
+    await driver.setUp(precondition.hasServiceControlMonitoringInstance);
+    await driver.setUp(precondition.hasNoDisconnectedEndpoints);
+    await renderComponent(driver, Transport.AmazonSQS);
+    const use = userEvent.setup();
+    await use.click(screen.getByRole("button", { name: /Refresh Connection Test/i }));
+    expect(screen.getByText(/Audit diagnostics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Broker diagnostics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Monitoring diagnostics/i)).toBeInTheDocument();
+  });
+
+  test("refreshes diagnostics", async ({ driver }) => {
+    await driver.setUp(precondition.hasServiceControlMonitoringInstance);
+    await driver.setUp(precondition.hasNoDisconnectedEndpoints);
+    await renderComponent(driver, Transport.AmazonSQS);
+    const use = userEvent.setup();
+    await use.click(screen.getByRole("button", { name: /Refresh Connection Test/i }));
+
+    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/test`, {
+      body: <ConnectionTestResults>{
+        transport: Transport.AmazonSQS,
+        audit_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Audit refreshed diagnostics",
+        },
+        monitoring_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Monitoring refreshed diagnostics",
+        },
+        broker_connection_result: <ConnectionSettingsTestResult>{
+          connection_successful: true,
+          connection_error_messages: [],
+          diagnostics: "Broker refreshed diagnostics",
+        },
+      },
+    });
+
+    await use.click(screen.getByRole("button", { name: /Refresh Connection Test/i }));
+    expect(screen.getByText(/Audit refreshed diagnostics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Broker refreshed diagnostics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Monitoring refreshed diagnostics/i)).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.vue
+++ b/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.vue
@@ -23,13 +23,13 @@ async function testConnection() {
       <div class="sp-loader" />
     </template>
     <template v-else>
-      <ConnectionResultView v-if="isBrokerTransport" title="Broker" :result="testResults?.broker_connection_result!" />
-      <ConnectionResultView title="Audit" :result="testResults?.audit_connection_result!">
+      <ConnectionResultView v-if="isBrokerTransport && testResults !== null" title="Broker" :result="testResults.broker_connection_result" />
+      <ConnectionResultView v-if="testResults !== null" title="Audit" :result="testResults.audit_connection_result">
         <template #instructions>
           <a href="https://docs.particular.net/servicecontrol/servicecontrol-instances/remotes#configuration" target="_blank">Learn how to configure audit instances</a>
         </template>
       </ConnectionResultView>
-      <ConnectionResultView v-if="useIsMonitoringEnabled()" title="Monitoring" :result="testResults?.monitoring_connection_result!">
+      <ConnectionResultView v-if="useIsMonitoringEnabled() && testResults !== null" title="Monitoring" :result="testResults.monitoring_connection_result">
         <template #instructions>
           <a href="https://docs.particular.net/servicecontrol/monitoring-instances/installation/creating-config-file" target="_blank">Learn how to configure monitor instances</a>
         </template>
@@ -38,7 +38,7 @@ async function testConnection() {
   </div>
   <div class="row">
     <div class="col-6">
-      <button class="btn btn-primary actions" type="button" :disabled="loading" @click="testConnection()">Refresh Connection Test</button>
+      <button class="btn btn-primary actions" type="button" :disabled="loading" @click="testConnection()" aria-label="Refresh Connection Test">Refresh Connection Test</button>
     </div>
   </div>
 </template>

--- a/src/Frontend/src/views/throughputreport/setup/MasksView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/setup/MasksView.spec.ts
@@ -1,0 +1,71 @@
+import { test } from "../../../../test/drivers/vitest/driver";
+import { userEvent } from "@component-test-utils";
+import MasksView from "@/views/throughputreport/setup/MasksView.vue";
+import { describe, expect } from "vitest";
+import * as precondition from "../../../../test/preconditions";
+import { useServiceControl } from "@/composables/serviceServiceControl";
+import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
+import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
+import flushPromises from "flush-promises";
+import { Driver } from "../../../../test/driver";
+import Toast from "vue-toastification";
+import { render, screen } from "@testing-library/vue";
+
+describe("MaskView tests", () => {
+  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
+
+  async function setup(driver: Driver) {
+    window.defaultConfig.monitoring_urls = ["!"];
+    await driver.setUp(({ driver }) => precondition.hasServiceControlMainInstance({ driver }, minimumSCVersionForThroughput));
+    await driver.setUp(precondition.hasUpToDateServicePulse);
+    await driver.setUp(precondition.hasUpToDateServiceControl);
+    await driver.setUp(precondition.hasNoErrors);
+  }
+
+  async function renderComponent(driver: Driver, body: string[] = []) {
+    await setup(driver);
+    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/masks`, { body });
+    useServiceControlUrls();
+    await useServiceControl();
+    const { debug } = render(MasksView, { global: { plugins: [Toast] } });
+    await flushPromises();
+    return { debug };
+  }
+
+  function getTextAreaElement() {
+    return screen.getByRole("textbox", { name: /List of words to mask/i }) as HTMLTextAreaElement;
+  }
+
+  test("renders empty list", async ({ driver }) => {
+    await renderComponent(driver);
+
+    expect(getTextAreaElement().value).toBe("");
+  });
+
+  test("renders mask list loaded from server", async ({ driver }) => {
+    await renderComponent(driver, ["first", "second"]);
+
+    expect(getTextAreaElement().value).toBe("first\nsecond");
+  });
+
+  test("update mask list", async ({ driver }) => {
+    await renderComponent(driver, ["first", "second"]);
+
+    const use = userEvent.setup();
+    await use.type(getTextAreaElement(), "\nthree\nfour\nfive");
+
+    expect(getTextAreaElement().value).toBe("first\nsecond\nthree\nfour\nfive");
+  });
+
+  test("save mask list", async ({ driver }) => {
+    await renderComponent(driver, ["first", "second"]);
+
+    const use = userEvent.setup();
+    await use.type(getTextAreaElement(), "\nthree\nfour\nfive");
+
+    driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/masks/update`, { body: undefined, method: "post" });
+    await use.click(screen.getByRole("button", { name: /Save/i }));
+
+    expect(screen.queryAllByText(/Masks Saved/i).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/Frontend/src/views/throughputreport/setup/MasksView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/setup/MasksView.spec.ts
@@ -1,55 +1,58 @@
-import { test } from "../../../../test/drivers/vitest/driver";
-import { userEvent } from "@component-test-utils";
+import { makeDriverForTests, userEvent, render, screen } from "@component-test-utils";
 import MasksView from "@/views/throughputreport/setup/MasksView.vue";
-import { describe, expect } from "vitest";
+import { describe, expect, test } from "vitest";
 import * as precondition from "../../../../test/preconditions";
 import { useServiceControl } from "@/composables/serviceServiceControl";
 import { useServiceControlUrls } from "@/composables/serviceServiceControlUrls";
 import { minimumSCVersionForThroughput } from "@/views/throughputreport/isThroughputSupported";
 import flushPromises from "flush-promises";
-import { Driver } from "../../../../test/driver";
 import Toast from "vue-toastification";
-import { render, screen } from "@testing-library/vue";
+import { disableMonitoring } from "../../../../test/drivers/vitest/setup";
 
 describe("MaskView tests", () => {
   const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
 
-  async function setup(driver: Driver) {
-    window.defaultConfig.monitoring_urls = ["!"];
-    await driver.setUp(({ driver }) => precondition.hasServiceControlMainInstance({ driver }, minimumSCVersionForThroughput));
+  async function setup() {
+    const driver = makeDriverForTests();
+
+    disableMonitoring();
+
+    await driver.setUp(precondition.hasServiceControlMainInstance(minimumSCVersionForThroughput));
     await driver.setUp(precondition.hasUpToDateServicePulse);
     await driver.setUp(precondition.hasUpToDateServiceControl);
-    await driver.setUp(precondition.hasNoErrors);
+    await driver.setUp(precondition.errorsDefaultHandler);
+
+    return driver;
   }
 
-  async function renderComponent(driver: Driver, body: string[] = []) {
-    await setup(driver);
+  async function renderComponent(body: string[] = []) {
+    const driver = await setup();
     driver.mockEndpoint(`${serviceControlInstanceUrl}licensing/settings/masks`, { body });
     useServiceControlUrls();
     await useServiceControl();
     const { debug } = render(MasksView, { global: { plugins: [Toast] } });
     await flushPromises();
-    return { debug };
+    return { debug, driver };
   }
 
   function getTextAreaElement() {
     return screen.getByRole("textbox", { name: /List of words to mask/i }) as HTMLTextAreaElement;
   }
 
-  test("renders empty list", async ({ driver }) => {
-    await renderComponent(driver);
+  test("renders empty list", async () => {
+    await renderComponent();
 
     expect(getTextAreaElement().value).toBe("");
   });
 
-  test("renders mask list loaded from server", async ({ driver }) => {
-    await renderComponent(driver, ["first", "second"]);
+  test("renders mask list loaded from server", async () => {
+    await renderComponent(["first", "second"]);
 
     expect(getTextAreaElement().value).toBe("first\nsecond");
   });
 
-  test("update mask list", async ({ driver }) => {
-    await renderComponent(driver, ["first", "second"]);
+  test("update mask list", async () => {
+    await renderComponent(["first", "second"]);
 
     const use = userEvent.setup();
     await use.type(getTextAreaElement(), "\nthree\nfour\nfive");
@@ -57,8 +60,8 @@ describe("MaskView tests", () => {
     expect(getTextAreaElement().value).toBe("first\nsecond\nthree\nfour\nfive");
   });
 
-  test("save mask list", async ({ driver }) => {
-    await renderComponent(driver, ["first", "second"]);
+  test("save mask list", async () => {
+    const { driver } = await renderComponent(["first", "second"]);
 
     const use = userEvent.setup();
     await use.type(getTextAreaElement(), "\nthree\nfour\nfive");

--- a/src/Frontend/src/views/throughputreport/setup/MasksView.vue
+++ b/src/Frontend/src/views/throughputreport/setup/MasksView.vue
@@ -39,14 +39,14 @@ async function updateMasks() {
   <div class="row">
     <div class="col-6">
       <label class="form-label">List of words to mask</label>
-      <textarea class="form-control" rows="3" :value="masks" @input="masksChanged"></textarea>
+      <textarea class="form-control" aria-label="List of words to mask" rows="3" :value="masks" @input="masksChanged"></textarea>
       <div class="form-text">One word per line.</div>
     </div>
   </div>
   <div class="row">
     <div class="col-6">
       <br />
-      <button class="btn btn-primary" type="button" @click="updateMasks">Save</button>
+      <button class="btn btn-primary" type="button" @click="updateMasks" aria-label="Save">Save</button>
     </div>
   </div>
 </template>

--- a/src/Frontend/src/views/throughputreport/throughputreport.spec.ts
+++ b/src/Frontend/src/views/throughputreport/throughputreport.spec.ts
@@ -1,0 +1,67 @@
+import { describe, test } from "vitest";
+
+describe("FEATURE: Detection of minimum supported version of ServiceControl", () => {
+  describe("RULE:", () => {
+    test.todo("EXAMPE:");
+  });
+});
+
+describe("FEATURE: Detection of a invalid or missing configuration", () => {
+    describe("RULE:", () => {
+        test.todo("EXAMPE:");
+      });
+});
+
+
+describe("FEATURE: Listing of detected endpoints", () => {
+    describe("RULE:", () => {
+        test.todo("EXAMPE:");
+      });
+});
+
+describe("FEATURE: Listing of detected broker queues", () => {
+    describe("RULE:", () => {
+        test.todo("EXAMPE:");
+      });
+});
+
+describe("FEATURE: Sorting detected endpoints and broker queues", () => {
+    describe("RULE:", () => {
+        test.todo("EXAMPE:");
+      });
+});
+
+describe("FEATURE: Filtering of detected endpoints or broker queues", () => {
+    describe("RULE: The user should be able to filter by the endpoints that hasn't been assigned an endpoint type yet ", () => {
+        test.todo("EXAMPE:");
+    });
+
+    describe("RULE: The user should be able to filter endpoints by the name, starting with, containing and ending with a given text", () => {
+        test.todo("EXAMPE: filtering starting with 'Universe.'");
+        test.todo("EXAMPE: filtering containing with 'Solarsystem'");
+        test.todo("EXAMPE: filtering ending with 'Endpoint1'");
+    });
+});
+
+describe("FEATURE: Assigment of endpoint type", () => {
+    describe("RULE: The user should be able to assing the endpoint type to an individual endpoint or broker queue", () => {
+        test.todo("EXAMPE:");
+    });
+});
+
+describe("FEATURE: Bulk operations", () => {
+    describe("RULE: The user should be able to assign the endpoint type in bulk to all endpoints or to filtered set of endpoints", () => {
+        test.todo("EXAMPE:");
+    });
+});
+
+describe.todo(`
+    Write specs for FEATURES: 
+    Azure config detection, 
+    Congifuration > Setup,
+    Congifuration > Diagnostics,
+    Congifuration > Mask report data,
+    Download report,
+    Having a mim of data for 24 hours,
+    Inteval checking of invalid or missing configuration,
+    `)

--- a/src/Frontend/test/drivers/vitest/driver.ts
+++ b/src/Frontend/test/drivers/vitest/driver.ts
@@ -31,9 +31,7 @@ function makeDriver() {
       return factory({ driver: this });
     },
     disposeApp() {
-      if (app !== undefined) {
-        app.unmount();
-      }
+      app.unmount();
     },
   };
   return driver;

--- a/src/Frontend/test/drivers/vitest/driver.ts
+++ b/src/Frontend/test/drivers/vitest/driver.ts
@@ -1,6 +1,6 @@
 import { it as itVitest, describe } from "vitest";
 import { Driver } from "../../driver";
-import { mount } from "../../../src/mount";
+import { mount } from "@/mount";
 import makeRouter from "../../../src/router";
 import { mockEndpoint, mockEndpointDynamic } from "../../utils";
 import { mockServer } from "../../mock-server";
@@ -31,10 +31,9 @@ function makeDriver() {
       return factory({ driver: this });
     },
     disposeApp() {
-      if (!app) {
-        throw new Error("App is not mounted, make your sure to await driver.goTo().");
+      if (app !== undefined) {
+        app.unmount();
       }
-      app.unmount();
     },
   };
   return driver;

--- a/src/Frontend/test/drivers/vitest/setup.ts
+++ b/src/Frontend/test/drivers/vitest/setup.ts
@@ -18,8 +18,9 @@ beforeEach(() => {
 
 beforeAll(() => {
   mockServer.listen({
-    onUnhandledRequest: (request) => {
+    onUnhandledRequest: (request, { error }) => {
       console.log("Unhandled %s %s", request.method, request.url);
+      error();
     },
   });
 });

--- a/src/Frontend/test/drivers/vitest/setup.ts
+++ b/src/Frontend/test/drivers/vitest/setup.ts
@@ -10,6 +10,10 @@ const defaultConfig = {
   showPendingRetry: false,
 };
 
+export function disableMonitoring() {
+  vi.stubGlobal("defaultConfig", { ...defaultConfig, ...{ monitoring_urls: ["!"] } });
+}
+
 vi.stubGlobal("defaultConfig", defaultConfig);
 
 beforeEach(() => {

--- a/src/Frontend/test/preconditions/hasLicensingEndpoints.ts
+++ b/src/Frontend/test/preconditions/hasLicensingEndpoints.ts
@@ -1,0 +1,22 @@
+import { SetupFactoryOptions } from "../driver";
+import EndpointThroughputSummary from "@/resources/EndpointThroughputSummary";
+
+export const hasLicensingEndpoints =
+  (
+    body: EndpointThroughputSummary[] = [
+      <EndpointThroughputSummary>{
+        name: "Sender",
+        is_known_endpoint: true,
+        user_indicator: "",
+        max_daily_throughput: 10,
+      },
+    ]
+  ) =>
+  ({ driver }: SetupFactoryOptions) => {
+    driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/endpoints`, {
+      body,
+      method: "get",
+      status: 200,
+    });
+    return [];
+  };

--- a/src/Frontend/test/preconditions/hasLicensingReportAvailable.ts
+++ b/src/Frontend/test/preconditions/hasLicensingReportAvailable.ts
@@ -1,0 +1,19 @@
+import ReportGenerationState from "@/resources/ReportGenerationState";
+import { SetupFactoryOptions } from "../driver";
+
+export const hasLicensingReportAvailable =
+  (body: Partial<ReportGenerationState> = {}) =>
+  ({ driver }: SetupFactoryOptions) => {
+    driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/report/available`, {
+      body: {
+        ...(<ReportGenerationState>{
+          transport: "LearningTransport",
+          report_can_be_generated: true,
+          reason: "",
+        }),
+        ...body,
+      },
+      method: "get",
+      status: 200,
+    });
+  };

--- a/src/Frontend/test/preconditions/hasLicensingSettingTest.ts
+++ b/src/Frontend/test/preconditions/hasLicensingSettingTest.ts
@@ -1,0 +1,32 @@
+import ConnectionTestResults, { ConnectionSettingsTestResult } from "@/resources/ConnectionTestResults";
+import { SetupFactoryOptions } from "../driver";
+
+export const hasLicensingSettingTest =
+  (body: Partial<ConnectionTestResults> = {}) =>
+  ({ driver }: SetupFactoryOptions) => {
+    driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/settings/test`, {
+      body: {
+        ...(<ConnectionTestResults>{
+          transport: "",
+          audit_connection_result: <ConnectionSettingsTestResult>{
+            connection_successful: true,
+            connection_error_messages: [],
+            diagnostics: "",
+          },
+          monitoring_connection_result: <ConnectionSettingsTestResult>{
+            connection_successful: true,
+            connection_error_messages: [],
+            diagnostics: "",
+          },
+          broker_connection_result: <ConnectionSettingsTestResult>{
+            connection_successful: true,
+            connection_error_messages: [],
+            diagnostics: "",
+          },
+        }),
+        ...body,
+      },
+      method: "get",
+      status: 200,
+    });
+  };

--- a/src/Frontend/test/preconditions/hasServiceControlMainInstance.ts
+++ b/src/Frontend/test/preconditions/hasServiceControlMainInstance.ts
@@ -1,11 +1,11 @@
 import { serviceControlMainInstance } from "../mocks/service-control-instance-template";
 import { SetupFactoryOptions } from "../driver";
 
-export const hasServiceControlMainInstance = ({ driver }: SetupFactoryOptions) => {
+export const hasServiceControlMainInstance = ({ driver }: SetupFactoryOptions, serviceControlVersion = "5.0.4") => {
   const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
   driver.mockEndpoint(serviceControlInstanceUrl, {
     body: serviceControlMainInstance,
-    headers: { "X-Particular-Version": "5.0.4" },
+    headers: { "X-Particular-Version": serviceControlVersion },
   });
   return serviceControlMainInstance;
 };

--- a/src/Frontend/test/preconditions/hasServiceControlMainInstance.ts
+++ b/src/Frontend/test/preconditions/hasServiceControlMainInstance.ts
@@ -1,11 +1,13 @@
 import { serviceControlMainInstance } from "../mocks/service-control-instance-template";
 import { SetupFactoryOptions } from "../driver";
 
-export const hasServiceControlMainInstance = ({ driver }: SetupFactoryOptions, serviceControlVersion = "5.0.4") => {
-  const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
-  driver.mockEndpoint(serviceControlInstanceUrl, {
-    body: serviceControlMainInstance,
-    headers: { "X-Particular-Version": serviceControlVersion },
-  });
-  return serviceControlMainInstance;
-};
+export const hasServiceControlMainInstance =
+  (serviceControlVersion = "5.0.4") =>
+  ({ driver }: SetupFactoryOptions) => {
+    const serviceControlInstanceUrl = window.defaultConfig.service_control_url;
+    driver.mockEndpoint(serviceControlInstanceUrl, {
+      body: serviceControlMainInstance,
+      headers: { "X-Particular-Version": serviceControlVersion },
+    });
+    return serviceControlMainInstance;
+  };

--- a/src/Frontend/test/preconditions/index.ts
+++ b/src/Frontend/test/preconditions/index.ts
@@ -1,3 +1,5 @@
+import { hasLicensingSettingTest } from "./hasLicensingSettingTest";
+
 export * from "../preconditions/hasLicense";
 export { hasServiceControlMainInstance } from "../preconditions/hasServiceControlMainInstance";
 export { hasServiceControlMonitoringInstance } from "../preconditions/hasServiceControlMonitoringInstance";
@@ -17,3 +19,6 @@ export * from "./hasMonitoredEndpointDetails";
 export { hasNoHeartbeatsEndpoints } from "../preconditions/hasHeartbeatEndpoints";
 export { serviceControlWithMonitoring } from "./serviceControlWithMonitoring";
 export * from "./recoverability";
+export { hasLicensingReportAvailable } from "../preconditions/hasLicensingReportAvailable";
+export { hasLicensingSettingTest } from "../preconditions/hasLicensingSettingTest";
+export { hasLicensingEndpoints } from "../preconditions/hasLicensingEndpoints";

--- a/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
+++ b/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
@@ -74,51 +74,11 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
   await driver.setUp(precondition.recoverabilityGroupsWithClassifierDefaulthandler);
 
   //Default handler for /api/licensing/report/available
-  driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/report/available`, {
-    body: <ReportGenerationState>{
-      transport: "LearningTransport",
-      report_can_be_generated: true,
-      reason: "",
-    },
-    method: "get",
-    status: 200,
-  });
+  await driver.setUp(precondition.hasLicensingReportAvailable());
 
   //Default handler for /api/licensing/endpoints
-  driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/endpoints`, {
-    body: [
-      <EndpointThroughputSummary>{
-        name: "",
-        is_known_endpoint: true,
-        user_indicator: "",
-        max_daily_throughput: 10,
-      },
-    ],
-    method: "get",
-    status: 200,
-  });
+  await driver.setUp(precondition.hasLicensingEndpoints());
 
   //Default handler for /api/licensing/settings/test
-  driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/settings/test`, {
-    body: <ConnectionTestResults>{
-      transport: "",
-      audit_connection_result: <ConnectionSettingsTestResult>{
-        connection_successful: true,
-        connection_error_messages: [],
-        diagnostics: "",
-      },
-      monitoring_connection_result: <ConnectionSettingsTestResult>{
-        connection_successful: true,
-        connection_error_messages: [],
-        diagnostics: "",
-      },
-      broker_connection_result: <ConnectionSettingsTestResult>{
-        connection_successful: true,
-        connection_error_messages: [],
-        diagnostics: "",
-      },
-    },
-    method: "get",
-    status: 200,
-  });
+  await driver.setUp(precondition.hasLicensingSettingTest());
 };

--- a/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
+++ b/src/Frontend/test/preconditions/serviceControlWithMonitoring.ts
@@ -11,7 +11,7 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
   await driver.setUp(precondition.hasActiveLicense);
 
   //http://localhost:33333/api/
-  await driver.setUp(precondition.hasServiceControlMainInstance);
+  await driver.setUp(precondition.hasServiceControlMainInstance());
 
   //http://localhost:33633
   await driver.setUp(precondition.hasServiceControlMonitoringInstance);
@@ -68,11 +68,11 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
   await driver.setUp(precondition.recoverabilityEditConfigDefaultHandler);
 
   //http://localhost:33333/api/errors/groups{/:classifier}? default handler
-  await driver.setUp(precondition.archivedGroupsWithClassifierDefaulthandler);  
+  await driver.setUp(precondition.archivedGroupsWithClassifierDefaulthandler);
 
   //http://localhost:33333/api/recoverability/groups{/:classifier} default handler
   await driver.setUp(precondition.recoverabilityGroupsWithClassifierDefaulthandler);
-  
+
   //Default handler for /api/licensing/report/available
   driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/report/available`, {
     body: <ReportGenerationState>{
@@ -86,12 +86,14 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
 
   //Default handler for /api/licensing/endpoints
   driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/endpoints`, {
-    body: [<EndpointThroughputSummary>{
-      name: "",
-      is_known_endpoint: true,
-      user_indicator: "",
-      max_daily_throughput: 10,
-    }],
+    body: [
+      <EndpointThroughputSummary>{
+        name: "",
+        is_known_endpoint: true,
+        user_indicator: "",
+        max_daily_throughput: 10,
+      },
+    ],
     method: "get",
     status: 200,
   });
@@ -119,5 +121,4 @@ export const serviceControlWithMonitoring = async ({ driver }: SetupFactoryOptio
     method: "get",
     status: 200,
   });
-
 };

--- a/src/Frontend/test/utils.ts
+++ b/src/Frontend/test/utils.ts
@@ -2,6 +2,7 @@ import { makeMockEndpoint, makeMockEndpointDynamic } from "./mock-endpoint";
 import userEvent from "@testing-library/user-event";
 
 import { mockServer } from "./mock-server";
+import { Driver } from "./driver";
 
 export { render, screen } from "@testing-library/vue";
 export { expect, test, describe } from "vitest";
@@ -10,3 +11,18 @@ export { userEvent };
 export const mockEndpoint = makeMockEndpoint({ mockServer });
 export const mockEndpointDynamic = makeMockEndpointDynamic({ mockServer });
 
+export function makeDriverForTests(): Driver {
+  return {
+    async goTo() {
+      throw "Not implemented";
+    },
+    mockEndpoint,
+    mockEndpointDynamic,
+    setUp(factory) {
+      return factory({ driver: this });
+    },
+    disposeApp() {
+      throw "Not implemented";
+    },
+  };
+}


### PR DESCRIPTION
This PR reorganizes and refactors the component tests into a hierarchy of Features, Rules, and Examples. It also introduces a DSL to create a separation between the specification layer and the automation layer, with the hope of having a test suite that doesn't get in the way when a developer desires to change the implementation details of the system under test. 

PoA:
- [ ] Distill the specification into a spec file with a hierarchy of features, rules, and examples - Doing
- [ ] Reorganize existing component tests into the applicable examples (scenarios) - Pending
- [ ] Refactor tests to introduce a DSL - Pending
- [ ] Implement examples (tests) that don't have equivalent tests from the component tests - Pending
- [ ] Optional: implement the same distilled specification but using the acceptance tests setup (for illustration purposes only) - Pending