### PR TITLE
Proxy improvements

### DIFF
--- a/Container-README.md
+++ b/Container-README.md
@@ -13,9 +13,10 @@ docker run -p 9090:9090 particular/servicepulse:latest
 ### Environment Variables
 
 - **`SERVICECONTROL_URL`**: _Default_: `http://localhost:33333`. The url to your ServiceControl instance
-- **`MONITORING_URL`**: _Default_: `http://localhost:33633`. The url to your monitoring instance
+- **`MONITORING_URL`**: _Default_: `http://localhost:33633`. The url to your Monitoring instance
 - **`DEFAULT_ROUTE`**: _Default_: `/dashboard`. The default page that should be displayed when visiting the site
 - **`SHOW_PENDING_RETRY`** _Default_: `false`. Set to `true` to show details of pending retries
+- **`ENABLE_REVERSE_PROXY`** _Default_: `true`. Set to `false` to disable the proxy that forwards requests to the ServiceControl and Monitoring instances
 
 It may be desireable to run the ServiceControl services in an isolated network. When doing so, ServicePulse must be configured to connect to those services using environment variables:
 

--- a/src/ServicePulse/ConstantsFile.cs
+++ b/src/ServicePulse/ConstantsFile.cs
@@ -4,19 +4,17 @@ using System.Reflection;
 
 class ConstantsFile
 {
-    public static string GetContent()
+    public static string GetContent(Settings settings)
     {
-        var defaultRoute = Environment.GetEnvironmentVariable("DEFAULT_ROUTE") ?? "/dashboard";
         var version = GetVersionInformation();
-        var showPendingRetry = Environment.GetEnvironmentVariable("SHOW_PENDING_RETRY") ?? "false";
 
         var constantsFile = $$"""
 window.defaultConfig = {
-  default_route: '{{defaultRoute}}',
+  default_route: '{{settings.DefaultRoute}}',
   version: '{{version}}',
   service_control_url: '/api/',
   monitoring_urls: ['/monitoring-api/'],
-  showPendingRetry: {{showPendingRetry}},
+  showPendingRetry: {{settings.ShowPendingRetry}},
 }
 """;
 

--- a/src/ServicePulse/ConstantsFile.cs
+++ b/src/ServicePulse/ConstantsFile.cs
@@ -14,7 +14,7 @@ window.defaultConfig = {
   version: '{{version}}',
   service_control_url: '/api/',
   monitoring_urls: ['/monitoring-api/'],
-  showPendingRetry: {{settings.ShowPendingRetry}},
+  showPendingRetry: {{(settings.ShowPendingRetry ? "true" : "false")}},
 }
 """;
 

--- a/src/ServicePulse/ConstantsFile.cs
+++ b/src/ServicePulse/ConstantsFile.cs
@@ -8,12 +8,26 @@ class ConstantsFile
     {
         var version = GetVersionInformation();
 
+        string serviceControlUrl;
+        string monitoringUrl;
+
+        if (settings.EnableReverseProxy)
+        {
+            serviceControlUrl = "/api/";
+            monitoringUrl = "/monitoring-api/";
+        }
+        else
+        {
+            serviceControlUrl = settings.ServiceControlUri.ToString();
+            monitoringUrl = settings.MonitoringUri.ToString();
+        }
+
         var constantsFile = $$"""
 window.defaultConfig = {
   default_route: '{{settings.DefaultRoute}}',
   version: '{{version}}',
-  service_control_url: '/api/',
-  monitoring_urls: ['/monitoring-api/'],
+  service_control_url: '{{serviceControlUrl}}',
+  monitoring_urls: ['{{monitoringUrl}}'],
   showPendingRetry: {{(settings.ShowPendingRetry ? "true" : "false")}},
 }
 """;

--- a/src/ServicePulse/Program.cs
+++ b/src/ServicePulse/Program.cs
@@ -4,7 +4,9 @@ using ServicePulse;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var (routes, clusters) = ReverseProxy.GetConfiguration();
+var settings = Settings.GetFromEnvironmentVariables();
+
+var (routes, clusters) = ReverseProxy.GetConfiguration(settings);
 builder.Services.AddReverseProxy().LoadFromMemory(routes, clusters);
 
 var app = builder.Build();
@@ -20,7 +22,7 @@ app.UseStaticFiles(staticFileOptions);
 
 app.MapReverseProxy();
 
-var constantsFile = ConstantsFile.GetContent();
+var constantsFile = ConstantsFile.GetContent(settings);
 
 app.MapGet("/js/app.constants.js", (HttpContext context) =>
 {

--- a/src/ServicePulse/Program.cs
+++ b/src/ServicePulse/Program.cs
@@ -6,8 +6,11 @@ var builder = WebApplication.CreateBuilder(args);
 
 var settings = Settings.GetFromEnvironmentVariables();
 
-var (routes, clusters) = ReverseProxy.GetConfiguration(settings);
-builder.Services.AddReverseProxy().LoadFromMemory(routes, clusters);
+if (settings.EnableReverseProxy)
+{
+    var (routes, clusters) = ReverseProxy.GetConfiguration(settings);
+    builder.Services.AddReverseProxy().LoadFromMemory(routes, clusters);
+}
 
 var app = builder.Build();
 
@@ -20,7 +23,10 @@ app.UseDefaultFiles(defaultFilesOptions);
 var staticFileOptions = new StaticFileOptions { FileProvider = fileProvider };
 app.UseStaticFiles(staticFileOptions);
 
-app.MapReverseProxy();
+if (settings.EnableReverseProxy)
+{
+    app.MapReverseProxy();
+}
 
 var constantsFile = ConstantsFile.GetContent(settings);
 

--- a/src/ServicePulse/ReverseProxy.cs
+++ b/src/ServicePulse/ReverseProxy.cs
@@ -1,30 +1,18 @@
 ﻿namespace ServicePulse;
 
-using System.Text.Json;
 using Yarp.ReverseProxy.Configuration;
 using Yarp.ReverseProxy.Transforms;
 
 static class ReverseProxy
 {
-    public static (List<RouteConfig> routes, List<ClusterConfig> clusters) GetConfiguration()
+    public static (List<RouteConfig> routes, List<ClusterConfig> clusters) GetConfiguration(Settings settings)
     {
-        var serviceControlUrl = Environment.GetEnvironmentVariable("SERVICECONTROL_URL") ?? "http://localhost:33333";
-        var serviceControlUri = new Uri(serviceControlUrl);
-
-        var monitoringUrls = ParseLegacyMonitoringValue(Environment.GetEnvironmentVariable("MONITORING_URLS"));
-        var monitoringUrl = Environment.GetEnvironmentVariable("MONITORING_URL");
-
-        monitoringUrl ??= monitoringUrls;
-        monitoringUrl ??= "http://localhost:33633";
-
-        var monitoringUri = new Uri(monitoringUrl);
-
         var serviceControlInstance = new ClusterConfig
         {
             ClusterId = "serviceControlInstance",
             Destinations = new Dictionary<string, DestinationConfig>
             {
-                { "instance", new DestinationConfig { Address = serviceControlUri.GetLeftPart(UriPartial.Authority) } }
+                { "instance", new DestinationConfig { Address = settings.ServiceControlUri.GetLeftPart(UriPartial.Authority) } }
             }
         };
 
@@ -33,7 +21,7 @@ static class ReverseProxy
             ClusterId = "monitoringInstance",
             Destinations = new Dictionary<string, DestinationConfig>
             {
-                { "instance", new DestinationConfig { Address = monitoringUri.GetLeftPart(UriPartial.Authority) } }
+                { "instance", new DestinationConfig { Address = settings.MonitoringUri.GetLeftPart(UriPartial.Authority) } }
             }
         };
 
@@ -70,41 +58,5 @@ static class ReverseProxy
         };
 
         return (routes, clusters);
-    }
-
-    static string? ParseLegacyMonitoringValue(string? value)
-    {
-        if (value is null)
-        {
-            return null;
-        }
-
-        var cleanedValue = value.Replace('\'', '"');
-        var json = $$"""{"Addresses":{{cleanedValue}}}""";
-
-        MonitoringUrls? result;
-
-        try
-        {
-            result = JsonSerializer.Deserialize<MonitoringUrls>(json);
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-
-        var addresses = result?.Addresses;
-
-        if (addresses is not null && addresses.Length > 0)
-        {
-            return addresses[0];
-        }
-
-        return null;
-    }
-
-    class MonitoringUrls
-    {
-        public string[] Addresses { get; set; } = [];
     }
 }

--- a/src/ServicePulse/ReverseProxy.cs
+++ b/src/ServicePulse/ReverseProxy.cs
@@ -12,7 +12,7 @@ static class ReverseProxy
             ClusterId = "serviceControlInstance",
             Destinations = new Dictionary<string, DestinationConfig>
             {
-                { "instance", new DestinationConfig { Address = settings.ServiceControlUri.GetLeftPart(UriPartial.Authority) } }
+                { "instance", new DestinationConfig { Address = settings.ServiceControlUri.ToString() } }
             }
         };
 
@@ -21,7 +21,7 @@ static class ReverseProxy
             ClusterId = "monitoringInstance",
             Destinations = new Dictionary<string, DestinationConfig>
             {
-                { "instance", new DestinationConfig { Address = settings.MonitoringUri.GetLeftPart(UriPartial.Authority) } }
+                { "instance", new DestinationConfig { Address = settings.MonitoringUri.ToString() } }
             }
         };
 
@@ -33,7 +33,7 @@ static class ReverseProxy
             {
                 Path = "/api/{**catch-all}"
             }
-        };
+        }.WithTransformPathRemovePrefix("/api");
 
         var monitoringRoute = new RouteConfig()
         {

--- a/src/ServicePulse/Settings.cs
+++ b/src/ServicePulse/Settings.cs
@@ -10,7 +10,7 @@ class Settings
 
     public required string DefaultRoute { get; init; }
 
-    public required string ShowPendingRetry { get; init; }
+    public required bool ShowPendingRetry { get; init; }
 
     public static Settings GetFromEnvironmentVariables()
     {
@@ -27,7 +27,8 @@ class Settings
 
         var defaultRoute = Environment.GetEnvironmentVariable("DEFAULT_ROUTE") ?? "/dashboard";
 
-        var showPendingRetry = Environment.GetEnvironmentVariable("SHOW_PENDING_RETRY") ?? "false";
+        var showPendingRetryValue = Environment.GetEnvironmentVariable("SHOW_PENDING_RETRY");
+        bool.TryParse(showPendingRetryValue, out var showPendingRetry);
 
         return new Settings
         {

--- a/src/ServicePulse/Settings.cs
+++ b/src/ServicePulse/Settings.cs
@@ -12,16 +12,18 @@ class Settings
 
     public required bool ShowPendingRetry { get; init; }
 
+    public required bool EnableReverseProxy { get; init; }
+
     public static Settings GetFromEnvironmentVariables()
     {
-        var serviceControlUrl = Environment.GetEnvironmentVariable("SERVICECONTROL_URL") ?? "http://localhost:33333";
+        var serviceControlUrl = Environment.GetEnvironmentVariable("SERVICECONTROL_URL") ?? "http://localhost:33333/api/";
         var serviceControlUri = new Uri(serviceControlUrl);
 
         var monitoringUrls = ParseLegacyMonitoringValue(Environment.GetEnvironmentVariable("MONITORING_URLS"));
         var monitoringUrl = Environment.GetEnvironmentVariable("MONITORING_URL");
 
         monitoringUrl ??= monitoringUrls;
-        monitoringUrl ??= "http://localhost:33633";
+        monitoringUrl ??= "http://localhost:33633/";
 
         var monitoringUri = new Uri(monitoringUrl);
 
@@ -30,12 +32,20 @@ class Settings
         var showPendingRetryValue = Environment.GetEnvironmentVariable("SHOW_PENDING_RETRY");
         bool.TryParse(showPendingRetryValue, out var showPendingRetry);
 
+        var enableReverseProxyValue = Environment.GetEnvironmentVariable("ENABLE_REVERSE_PROXY");
+
+        if (!bool.TryParse(enableReverseProxyValue, out var enableReverseProxy))
+        {
+            enableReverseProxy = true;
+        }
+
         return new Settings
         {
             ServiceControlUri = serviceControlUri,
             MonitoringUri = monitoringUri,
             DefaultRoute = defaultRoute,
-            ShowPendingRetry = showPendingRetry
+            ShowPendingRetry = showPendingRetry,
+            EnableReverseProxy = enableReverseProxy
         };
     }
 

--- a/src/ServicePulse/Settings.cs
+++ b/src/ServicePulse/Settings.cs
@@ -17,6 +17,17 @@ class Settings
     public static Settings GetFromEnvironmentVariables()
     {
         var serviceControlUrl = Environment.GetEnvironmentVariable("SERVICECONTROL_URL") ?? "http://localhost:33333/api/";
+
+        if (!serviceControlUrl.EndsWith("/", StringComparison.Ordinal))
+        {
+            serviceControlUrl += "/";
+        }
+
+        if (!serviceControlUrl.EndsWith("api/", StringComparison.Ordinal))
+        {
+            serviceControlUrl += "api/";
+        }
+
         var serviceControlUri = new Uri(serviceControlUrl);
 
         var monitoringUrls = ParseLegacyMonitoringValue(Environment.GetEnvironmentVariable("MONITORING_URLS"));

--- a/src/ServicePulse/Settings.cs
+++ b/src/ServicePulse/Settings.cs
@@ -1,0 +1,76 @@
+﻿namespace ServicePulse;
+
+using System.Text.Json;
+
+class Settings
+{
+    public required Uri ServiceControlUri { get; init; }
+
+    public required Uri MonitoringUri { get; init; }
+
+    public required string DefaultRoute { get; init; }
+
+    public required string ShowPendingRetry { get; init; }
+
+    public static Settings GetFromEnvironmentVariables()
+    {
+        var serviceControlUrl = Environment.GetEnvironmentVariable("SERVICECONTROL_URL") ?? "http://localhost:33333";
+        var serviceControlUri = new Uri(serviceControlUrl);
+
+        var monitoringUrls = ParseLegacyMonitoringValue(Environment.GetEnvironmentVariable("MONITORING_URLS"));
+        var monitoringUrl = Environment.GetEnvironmentVariable("MONITORING_URL");
+
+        monitoringUrl ??= monitoringUrls;
+        monitoringUrl ??= "http://localhost:33633";
+
+        var monitoringUri = new Uri(monitoringUrl);
+
+        var defaultRoute = Environment.GetEnvironmentVariable("DEFAULT_ROUTE") ?? "/dashboard";
+
+        var showPendingRetry = Environment.GetEnvironmentVariable("SHOW_PENDING_RETRY") ?? "false";
+
+        return new Settings
+        {
+            ServiceControlUri = serviceControlUri,
+            MonitoringUri = monitoringUri,
+            DefaultRoute = defaultRoute,
+            ShowPendingRetry = showPendingRetry
+        };
+    }
+
+    static string? ParseLegacyMonitoringValue(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var cleanedValue = value.Replace('\'', '"');
+        var json = $$"""{"Addresses":{{cleanedValue}}}""";
+
+        MonitoringUrls? result;
+
+        try
+        {
+            result = JsonSerializer.Deserialize<MonitoringUrls>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        var addresses = result?.Addresses;
+
+        if (addresses is not null && addresses.Length > 0)
+        {
+            return addresses[0];
+        }
+
+        return null;
+    }
+
+    class MonitoringUrls
+    {
+        public string[] Addresses { get; set; } = [];
+    }
+}


### PR DESCRIPTION
This PR adds the following features to the container host:

- The reverse proxy can now be disabled by setting the `ENABLE_REVERSE_PROXY` environment variable to `false`.
- The reverse proxy no longer assumes the structure of the URLs passed via the `SERVICECONTROL_URL` and `MONITORING_URL` settings will use the value as passed in.

NOTE: Regardless of the two changes above, the `SERVICECONTROL_URL` value is still inspected to see if it ends with `/api/` and will append that as needed to ensure a valid URL.

Closes #2076