### PR TITLE
Fix CSV export with values containing `\n`, `,` or `"`

### DIFF
--- a/src/Frontend/src/components/failedmessages/FailedMessages.vue
+++ b/src/Frontend/src/components/failedmessages/FailedMessages.vue
@@ -139,12 +139,12 @@ function exportSelected() {
     array.forEach((obj) => {
       result +=
         keys
-          .map((k) =>
-            obj[k]
-              .map(String)
-              .map((v: string) => v.replaceAll('"', '""'))
-              .map((v: string) => `"${v}"`)
-          )
+          .map((k) => {
+            let v = String(obj[k]);
+            v = v.replaceAll('"', '""'); // Escape all double quotes
+            v = `"${v}"`; // Quote all values to deal with CR characters
+            return v;
+          })
           .join(",") + "\n";
     });
 

--- a/src/Frontend/src/components/failedmessages/FailedMessages.vue
+++ b/src/Frontend/src/components/failedmessages/FailedMessages.vue
@@ -137,7 +137,11 @@ function exportSelected() {
     const keys = Object.keys(array[0]);
     let result = keys.join("\t") + "\n";
     array.forEach((obj) => {
-      result += keys.map((k) => obj[k]).join(",") + "\n";
+      result += keys.map((k) => obj[k]
+          .map(String)
+          .map(v => v.replaceAll('"', '""'))
+          .map(v => `"${v}"`)
+      ).join(",") + "\n";
     });
 
     return result;

--- a/src/Frontend/src/components/failedmessages/FailedMessages.vue
+++ b/src/Frontend/src/components/failedmessages/FailedMessages.vue
@@ -129,7 +129,6 @@ async function retrySelected() {
   selectedMessages.forEach((m) => (m.retryInProgress = true));
 }
 
-//TODO: this function doesn't work correctly, since any commas in the exception trace breaks the CSV.
 //Not attempting to use explicit types correctly since this will need to change eventually anyway
 function exportSelected() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/Frontend/src/components/failedmessages/FailedMessages.vue
+++ b/src/Frontend/src/components/failedmessages/FailedMessages.vue
@@ -137,11 +137,15 @@ function exportSelected() {
     const keys = Object.keys(array[0]);
     let result = keys.join("\t") + "\n";
     array.forEach((obj) => {
-      result += keys.map((k) => obj[k]
-          .map(String)
-          .map(v => v.replaceAll('"', '""'))
-          .map(v => `"${v}"`)
-      ).join(",") + "\n";
+      result +=
+        keys
+          .map((k) =>
+            obj[k]
+              .map(String)
+              .map((v: string) => v.replaceAll('"', '""'))
+              .map((v: string) => `"${v}"`)
+          )
+          .join(",") + "\n";
     });
 
     return result;

--- a/src/Frontend/src/components/failedmessages/FailedMessages.vue
+++ b/src/Frontend/src/components/failedmessages/FailedMessages.vue
@@ -142,7 +142,7 @@ function exportSelected() {
           .map((k) => {
             let v = String(obj[k]);
             v = v.replaceAll('"', '""'); // Escape all double quotes
-            v = `"${v}"`; // Quote all values to deal with CR characters
+            if (v.search(/([",\n])/g) >= 0) v = `"${v}"`; // Quote all values to deal with CR characters
             return v;
           })
           .join(delimiter) + "\n";

--- a/src/Frontend/src/components/failedmessages/FailedMessages.vue
+++ b/src/Frontend/src/components/failedmessages/FailedMessages.vue
@@ -133,7 +133,7 @@ async function retrySelected() {
 function exportSelected() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function toCSV(array: any[]) {
-    const delimiter = ',';
+    const delimiter = ",";
     const keys = Object.keys(array[0]);
     let result = keys.join(delimiter) + "\n";
     array.forEach((obj) => {

--- a/src/Frontend/src/components/failedmessages/FailedMessages.vue
+++ b/src/Frontend/src/components/failedmessages/FailedMessages.vue
@@ -134,8 +134,9 @@ async function retrySelected() {
 function exportSelected() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function toCSV(array: any[]) {
+    const delimiter = ',';
     const keys = Object.keys(array[0]);
-    let result = keys.join("\t") + "\n";
+    let result = keys.join(delimiter) + "\n";
     array.forEach((obj) => {
       result +=
         keys
@@ -145,7 +146,7 @@ function exportSelected() {
             v = `"${v}"`; // Quote all values to deal with CR characters
             return v;
           })
-          .join(",") + "\n";
+          .join(delimiter) + "\n";
     });
 
     return result;


### PR DESCRIPTION
Resolves:

- https://github.com/Particular/ServicePulse/issues/2178

CSV export failed to generate a correct CSV as the value can contains `\n`, `,` or `"`.

This change will:

- Put the value in double quotes if `\n`, `,` or `"` characters are in the "cell" value
- Escape `"` characters to `""` which seems to be the most common used method to escape double quote characters