### PR TITLE
Update condition for when broker transport has no throughput connection settings

### DIFF
--- a/src/Frontend/src/views/throughputreport/setup/ConnectionSetupView.vue
+++ b/src/Frontend/src/views/throughputreport/setup/ConnectionSetupView.vue
@@ -18,7 +18,7 @@ onMounted(async () => {
 
 <template>
   <div class="row">
-    <p v-if="isBrokerTransport || useIsMonitoringEnabled()">
+    <p v-if="(settingsInfo?.broker_settings.length ?? 0 > 0) || (!isBrokerTransport && useIsMonitoringEnabled())">
       In order for ServicePulse to collect usage data from {{ store.transportNameForInstructions() }} you need to configure the below settings.<br />
       There are two configuration options, as environment variables or directly in the
       <a href="https://docs.particular.net/servicecontrol/creating-config-file"><code>ServiceControl.exe.config</code></a> file.


### PR DESCRIPTION
This PR updates the conditions on the throughput connection setup page to match the conditions that control the two lower sections.

This change avoids displaying the intro paragraph when neither of the two lower sections will be displayed, which happens when a broker transport has no settings to configure.

The RabbitMQ transport will no longer have separately configurable settings once https://github.com/Particular/ServiceControl/pull/4755 ships as part of a ServiceControl release.



