### PR TITLE
Moved message display to be under /messages

### DIFF
--- a/src/Frontend/package-lock.json
+++ b/src/Frontend/package-lock.json
@@ -207,10 +207,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },

--- a/src/Frontend/src/components/EventLogItem.vue
+++ b/src/Frontend/src/components/EventLogItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import TimeSince from "../components/TimeSince.vue";
 import type EventLogItem from "@/resources/EventLogItem";
 // eslint-disable-next-line no-duplicate-imports
@@ -8,6 +8,7 @@ import routeLinks from "@/router/routeLinks";
 
 defineProps<{ eventLogItem: EventLogItem }>();
 const router = useRouter();
+const route = useRoute();
 
 function navigateToEvent(eventLogItem: EventLogItem) {
   switch (eventLogItem.category) {
@@ -26,7 +27,7 @@ function navigateToEvent(eventLogItem: EventLogItem) {
     case "MessageFailures":
       if (eventLogItem.related_to?.length && eventLogItem.related_to[0].search("message") > 0) {
         const messageId = eventLogItem.related_to[0].substring(9);
-        router.push(routeLinks.failedMessage.message.link(messageId));
+        router.push({ path: routeLinks.messages.message.link(messageId), query: { back: route.path } });
       } else {
         router.push(routeLinks.failedMessage.root);
       }

--- a/src/Frontend/src/components/failedmessages/MessageList.vue
+++ b/src/Frontend/src/components/failedmessages/MessageList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import TimeSince from "../TimeSince.vue";
 import NoData from "../NoData.vue";
 import routeLinks from "@/router/routeLinks";
@@ -17,6 +17,7 @@ export interface IMessageList {
 
 let lastLabelClickedIndex: number | undefined;
 const router = useRouter();
+const route = useRoute();
 const emit = defineEmits(["retryRequested"]);
 const props = withDefaults(
   defineProps<{
@@ -77,7 +78,7 @@ function labelClicked($event: MouseEvent, index: number) {
 }
 
 function navigateToMessage(messageId: string) {
-  router.push(routeLinks.failedMessage.message.link(messageId));
+  router.push({ path: routeLinks.messages.message.link(messageId), query: { back: route.path } });
 }
 
 defineExpose<IMessageList>({

--- a/src/Frontend/src/components/failedmessages/MessageRedirectForBackwardsCompatibility.vue
+++ b/src/Frontend/src/components/failedmessages/MessageRedirectForBackwardsCompatibility.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import routeLinks from "@/router/routeLinks";
+
+const route = useRoute();
+const router = useRouter();
+const id = route.params.id;
+
+onMounted(async () => {
+  await router.push({ path: routeLinks.messages.message.link(id.toString()), query: { back: routeLinks.failedMessage.failedMessages.link } });
+});
+</script>

--- a/src/Frontend/src/components/messages/FlowDiagram.vue
+++ b/src/Frontend/src/components/messages/FlowDiagram.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
-import { useTypedFetchFromServiceControl } from "../../composables/serviceServiceControlUrls";
+import { useTypedFetchFromServiceControl } from "@/composables/serviceServiceControlUrls";
 import { type DefaultEdge, MarkerType, useVueFlow, VueFlow, type Styles, type Node } from "@vue-flow/core";
 import TimeSince from "../TimeSince.vue";
 import routeLinks from "@/router/routeLinks";
 import Message from "@/resources/Message";
 import { NServiceBusHeaders } from "@/resources/Header";
+import { useRoute } from "vue-router";
 
 const props = defineProps<{
   conversationId?: string;
@@ -41,6 +42,8 @@ interface MappedMessage {
 
 const nodeSpacingX = 300;
 const nodeSpacingY = 200;
+
+const route = useRoute();
 
 async function getConversation(conversationId: string) {
   const [, data] = await useTypedFetchFromServiceControl<Message[]>(`conversations/${conversationId}`);
@@ -206,7 +209,7 @@ function typeIcon(type: MessageType) {
             <i class="fa" :class="typeIcon(nodeProps.data.type)" :title="nodeProps.data.type" />
             <div class="lead righ-side-ellipsis" :title="nodeProps.data.nodeName">
               <strong>
-                <RouterLink v-if="nodeProps.data.isError" :to="routeLinks.failedMessage.message.link(nodeProps.data.id)">{{ nodeProps.data.nodeName }}</RouterLink>
+                <RouterLink v-if="nodeProps.data.isError" :to="{ path: routeLinks.messages.message.link(nodeProps.data.id), query: { back: route.path } }">{{ nodeProps.data.nodeName }}</RouterLink>
                 <span v-else>{{ nodeProps.data.nodeName }}</span>
               </strong>
             </div>

--- a/src/Frontend/src/components/messages/MessageView.vue
+++ b/src/Frontend/src/components/messages/MessageView.vue
@@ -443,7 +443,6 @@ onUnmounted(() => {
                 <h5 :class="{ active: panel === 3 }" class="nav-item" @click="togglePanel(3)"><a href="javascript:void(0)">Message body</a></h5>
                 <h5 v-if="!isMassTransitConnected" :class="{ active: panel === 4 }" class="nav-item" @click="togglePanel(4)"><a href="javascript:void(0)">Flow Diagram</a></h5>
               </div>
-              <pre v-if="panel === 0">{{ failedMessage.exception?.message }}</pre>
               <pre v-if="panel === 1">{{ failedMessage.exception?.stack_trace }}</pre>
               <table class="table" v-if="panel === 2 && !failedMessage.headersNotFound">
                 <tbody>

--- a/src/Frontend/src/components/messages/MessageView.vue
+++ b/src/Frontend/src/components/messages/MessageView.vue
@@ -404,9 +404,9 @@ onUnmounted(() => {
                   {{ failedMessage.number_of_processing_attempts - 1 }} Retry Failures
                 </span>
                 <span v-if="failedMessage.edited" v-tippy="`Message was edited`" class="label sidebar-label label-info metadata-label">Edited</span>
-                <span v-if="failedMessage.edited" class="metadata metadata-link"
-                  ><i class="fa fa-history"></i> <RouterLink :to="{ path: routeLinks.messages.message.link(failedMessage.edit_of), query: { back: route.path } }">View previous version</RouterLink></span
-                >
+                <span v-if="failedMessage.edited" class="metadata metadata-link">
+                  <i class="fa fa-history"></i> <RouterLink :to="{ path: routeLinks.messages.message.link(failedMessage.edit_of), query: { back: route.path } }">View previous version</RouterLink>
+                </span>
                 <span v-if="failedMessage.time_of_failure" class="metadata"><i class="fa fa-clock-o"></i> Failed: <time-since :date-utc="failedMessage.time_of_failure"></time-since></span>
                 <span class="metadata"><i class="fa pa-endpoint"></i> Endpoint: {{ failedMessage.receiving_endpoint.name }}</span>
                 <span class="metadata"><i class="fa fa-laptop"></i> Machine: {{ failedMessage.receiving_endpoint.host }}</span>

--- a/src/Frontend/src/composables/serviceServiceControlUrls.ts
+++ b/src/Frontend/src/composables/serviceServiceControlUrls.ts
@@ -53,7 +53,7 @@ export function useFetchFromServiceControl(suffix: string) {
 
 export async function useTypedFetchFromServiceControl<T>(suffix: string): Promise<[Response, T]> {
   const response = await fetch(`${serviceControlUrl.value}${suffix}`);
-  if (!response.ok) throw new Error(response?.statusText ?? "No response");
+  if (!response.ok) throw new Error(response.statusText ?? "No response");
   const data = await response.json();
 
   return [response, data];

--- a/src/Frontend/src/composables/serviceServiceControlUrls.ts
+++ b/src/Frontend/src/composables/serviceServiceControlUrls.ts
@@ -53,7 +53,7 @@ export function useFetchFromServiceControl(suffix: string) {
 
 export async function useTypedFetchFromServiceControl<T>(suffix: string): Promise<[Response, T]> {
   const response = await fetch(`${serviceControlUrl.value}${suffix}`);
-  if (!response?.ok) throw new Error(response?.statusText ?? "No response");
+  if (!response.ok) throw new Error(response?.statusText ?? "No response");
   const data = await response.json();
 
   return [response, data];

--- a/src/Frontend/src/router/config.ts
+++ b/src/Frontend/src/router/config.ts
@@ -96,9 +96,14 @@ const config: RouteItem[] = [
       {
         path: routeLinks.failedMessage.message.template,
         title: "Message",
-        component: () => import("@/components/failedmessages/MessageView.vue"),
+        component: () => import("@/components/failedmessages/MessageRedirectForBackwardsCompatibility.vue"),
       },
     ],
+  },
+  {
+    path: routeLinks.messages.message.template,
+    title: "Message",
+    component: () => import("@/components/messages/MessageView.vue"),
   },
   {
     path: routeLinks.monitoring.root,

--- a/src/Frontend/src/router/routeLinks.ts
+++ b/src/Frontend/src/router/routeLinks.ts
@@ -30,6 +30,13 @@ const failedMessagesLinks = (root: string) => {
   };
 };
 
+const messagesLinks = (root: string) => {
+  return {
+    root,
+    message: { link: (id: string) => `${root}/${id}`, template: "/messages/:id" },
+  };
+};
+
 const configurationLinks = (root: string) => {
   function createLink(template: string) {
     return { link: `${root}/${template}`, template: template };
@@ -96,6 +103,7 @@ const routeLinks = {
   failedMessage: failedMessagesLinks("/failed-messages"),
   customChecks: "/custom-checks",
   events: "/events",
+  messages: messagesLinks("/messages"),
   configuration: configurationLinks("/configuration"),
   throughput: throughputLinks("/usage"),
 };

--- a/src/Frontend/src/views/FailedMessagesView.vue
+++ b/src/Frontend/src/views/FailedMessagesView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { RouterLink, RouterView } from "vue-router";
-import { licenseStatus } from "../composables/serviceLicense";
-import { connectionState, stats } from "../composables/serviceServiceControl";
+import { licenseStatus } from "@/composables/serviceLicense";
+import { connectionState, stats } from "@/composables/serviceServiceControl";
 import LicenseExpired from "../components/LicenseExpired.vue";
 import routeLinks from "@/router/routeLinks";
 import isRouteSelected from "@/composables/isRouteSelected";
@@ -31,10 +31,7 @@ const showPendingRetry = window.defaultConfig.showPendingRetry;
             </h5>
 
             <!--All Failed Messages-->
-            <h5
-              v-if="!licenseStatus.isExpired"
-              :class="{ active: isRouteSelected(routeLinks.failedMessage.failedMessages.link) || isRouteSelected(routeLinks.failedMessage.message.link(`id`)), disabled: !connectionState.connected && !connectionState.connectedRecently }"
-            >
+            <h5 v-if="!licenseStatus.isExpired" :class="{ active: isRouteSelected(routeLinks.failedMessage.failedMessages.link), disabled: !connectionState.connected && !connectionState.connectedRecently }">
               <RouterLink :to="routeLinks.failedMessage.failedMessages.link">All Failed Messages </RouterLink>
               <span v-if="stats.number_of_failed_messages !== 0" class="badge badge-important">{{ stats.number_of_failed_messages }}</span>
             </h5>


### PR DESCRIPTION
This is in preparation for a new "All messages" area.
The goal is to share the same view for successful and failed messages.
This is a first step in this direction.
