### PR TITLE
Adding CodeMirror editor for code highlighting and editing

### DIFF
--- a/src/Frontend/package-lock.json
+++ b/src/Frontend/package-lock.json
@@ -8,22 +8,26 @@
       "name": "service-pulse",
       "version": "1.0.0",
       "dependencies": {
+        "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-xml": "^6.1.0",
+        "@codemirror/legacy-modes": "^6.5.0",
         "@tinyhttp/content-disposition": "^2.2.2",
         "@vue-flow/core": "^1.41.5",
-        "@wdns/vue-code-block": "^2.3.3",
         "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.3",
-        "highlight.js": "^11.10.0",
+        "codemirror": "^6.0.1",
         "lossless-json": "^4.0.2",
         "memoize-one": "^6.0.0",
         "moment": "^2.30.1",
         "pinia": "^2.2.8",
         "vue": "^3.5.13",
+        "vue-codemirror6": "^1.3.12",
         "vue-router": "^4.4.5",
         "vue-tippy": "^6.5.0",
         "vue-toastification": "^2.0.0-rc.5",
         "vue3-cookies": "^1.0.6",
-        "vue3-simple-typeahead": "^1.0.11"
+        "vue3-simple-typeahead": "^1.0.11",
+        "xml-formatter": "^3.6.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -265,6 +269,119 @@
       "dependencies": {
         "@types/tough-cookie": "^4.0.5",
         "tough-cookie": "^4.1.4"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.0.tgz",
+      "integrity": "sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
+      "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.10.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
+      "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.0.tgz",
+      "integrity": "sha512-dNw5pwTqtR1giYjaJyEajunLqxGavZqV0XRtVZyMJnNOD2HmK9DMUmuCAr6RMFGRJ4l8OeQDjpI/us+R09mQsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.4.tgz",
+      "integrity": "sha512-u4q7PnZlJUojeRe8FJa/njJcMctISGgPQ4PnWsd9268R4ZTtU+tfFYmwkBvgcrK2+QQ8tYFVALVb5fVJykKc5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
+      "integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.36.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.4.tgz",
+      "integrity": "sha512-ZQ0V5ovw/miKEXTvjgzRyjnrk9TwriUB1k4R5p7uNnHR9Hus+D1SXHGdJshijEzPFjU25xea/7nhIeSqYFKdbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1087,6 +1204,58 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.37.1",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.1.tgz",
@@ -1185,32 +1354,6 @@
       },
       "peerDependencies": {
         "pinia": ">=2.2.6"
-      }
-    },
-    "node_modules/@pinia/testing/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2266,31 +2409,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vueuse/metadata": {
       "version": "10.11.0",
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.0.tgz",
@@ -2308,52 +2426,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wdns/vue-code-block": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@wdns/vue-code-block/-/vue-code-block-2.3.3.tgz",
-      "integrity": "sha512-eOsCTatfi/8/zcgk7yzjuu+t4Ms4Te9SwYUE5PA/+JYcgp+JXAnYBgvqwPFVoTVKq3IpQCiGZg2zMblssvUCUQ==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/webdevnerdstuff"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/WebDevNerdStuff"
-        }
-      ],
-      "dependencies": {
-        "highlight.js": "^11.8.0",
-        "prismjs": "^1.29.0",
-        "ua-parser-js": "^1.0.38",
-        "vue": "^3.4.31"
       }
     },
     "node_modules/abbrev": {
@@ -2802,6 +2874,21 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2866,6 +2953,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -4094,14 +4187,6 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true
-    },
-    "node_modules/highlight.js": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
-      "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -5336,31 +5421,6 @@
         }
       }
     },
-    "node_modules/pinia/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -5471,15 +5531,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/proto-list": {
@@ -5964,6 +6015,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6228,28 +6285,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
-      "integrity": "sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/undici-types": {
@@ -6600,11 +6635,59 @@
         }
       }
     },
+    "node_modules/vue-codemirror6": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/vue-codemirror6/-/vue-codemirror6-1.3.12.tgz",
+      "integrity": "sha512-rLy87f7ufU4X2DDxEFGvikCe4wyl02uPYPcLtviVT+7IwY+vD/090euP7ZuoAswr1d3k/j8oEQnTr9UxoK1+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/commands": "^6.8.0",
+        "@codemirror/language": "^6.10.8",
+        "@codemirror/lint": "^6.8.4",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.36.3",
+        "codemirror": "^6.0.1",
+        "style-mod": "^4.1.2",
+        "vue-demi": "latest"
+      },
+      "engines": {
+        "pnpm": ">=10.3.0"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.14 || ^3.4"
+      }
+    },
     "node_modules/vue-component-type-helpers": {
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.0.26.tgz",
       "integrity": "sha512-sO9qQ8oC520SW6kqlls0iqDak53gsTVSrYylajgjmkt1c0vcgjsGSy1KzlDrbEx8pm02IEYhlUkU5hCYf8rwtg==",
       "dev": true
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.3",
@@ -6699,6 +6782,12 @@
       "peerDependencies": {
         "vue": "^3.0.5"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -6972,6 +7061,18 @@
         }
       }
     },
+    "node_modules/xml-formatter": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.6.4.tgz",
+      "integrity": "sha512-vkvTNw4u9mp72lMmJHw771NE9EJLX0kfwIcP+ZEo9eJ6HmotX23vmykyROyIQ9Y3a+ckdUdhxIE2ZO66rYuPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parser-xo": "^4.1.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -6979,6 +7080,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-parser-xo": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.1.3.tgz",
+      "integrity": "sha512-U6eN5Pyrlek9ottHVpT9e8YUax75oVYXbnYxU+utzDC7i+OyWj9ynsNMiZNQZvpuazbG0O7iLAs9FkcFmzlgSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/xmlchars": {

--- a/src/Frontend/package.json
+++ b/src/Frontend/package.json
@@ -17,22 +17,26 @@
     "test:application": "npm run test:application:vitest"
   },
   "dependencies": {
+    "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-xml": "^6.1.0",
+    "@codemirror/legacy-modes": "^6.5.0",
     "@tinyhttp/content-disposition": "^2.2.2",
     "@vue-flow/core": "^1.41.5",
-    "@wdns/vue-code-block": "^2.3.3",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
-    "highlight.js": "^11.10.0",
+    "codemirror": "^6.0.1",
     "lossless-json": "^4.0.2",
     "memoize-one": "^6.0.0",
     "moment": "^2.30.1",
     "pinia": "^2.2.8",
     "vue": "^3.5.13",
+    "vue-codemirror6": "^1.3.12",
     "vue-router": "^4.4.5",
     "vue-tippy": "^6.5.0",
     "vue-toastification": "^2.0.0-rc.5",
     "vue3-cookies": "^1.0.6",
-    "vue3-simple-typeahead": "^1.0.11"
+    "vue3-simple-typeahead": "^1.0.11",
+    "xml-formatter": "^3.6.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/src/Frontend/src/components/CodeEditor.vue
+++ b/src/Frontend/src/components/CodeEditor.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import CodeMirror from "vue-codemirror6";
+import { json } from "@codemirror/lang-json";
+import { xml } from "@codemirror/lang-xml";
+import { StreamLanguage } from "@codemirror/language";
+import { powerShell } from "@codemirror/legacy-modes/mode/powershell";
+import { shell } from "@codemirror/legacy-modes/mode/shell";
+import { csharp } from "@codemirror/legacy-modes/mode/clike";
+import { Extension } from "@codemirror/state";
+import { CodeLanguage } from "@/components/codeEditorTypes";
+import CopyToClipboard from "@/components/CopyToClipboard.vue";
+import { computed } from "vue";
+
+const code = defineModel<string>({ required: true });
+const props = withDefaults(
+  defineProps<{
+    language?: CodeLanguage;
+    readOnly?: boolean;
+    showGutter?: boolean;
+    showCopyToClipboard?: boolean;
+  }>(),
+  { readOnly: true, showGutter: true, showCopyToClipboard: true }
+);
+
+const extensions = computed(() => {
+  const extensions: Extension[] = [];
+
+  switch (props.language) {
+    case "json":
+      extensions.push(json());
+      break;
+    case "xml":
+      extensions.push(xml());
+      break;
+    case "shell":
+      extensions.push(StreamLanguage.define(shell));
+      break;
+    case "powershell":
+      extensions.push(StreamLanguage.define(powerShell));
+      break;
+    case "csharp":
+      extensions.push(StreamLanguage.define(csharp));
+      break;
+  }
+
+  return extensions;
+});
+</script>
+
+<template>
+  <div class="wrapper">
+    <div v-if="props.showCopyToClipboard" class="toolbar">
+      <CopyToClipboard :value="code" />
+    </div>
+    <CodeMirror v-model="code" :extensions="extensions" :basic="props.showGutter" :minimal="!props.showGutter" :readonly="props.readOnly" :gutter="!props.readOnly"></CodeMirror>
+  </div>
+</template>
+
+<style scoped>
+.wrapper {
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+}
+.toolbar {
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+}
+</style>

--- a/src/Frontend/src/components/CodeEditor.vue
+++ b/src/Frontend/src/components/CodeEditor.vue
@@ -18,6 +18,7 @@ const props = withDefaults(
     readOnly?: boolean;
     showGutter?: boolean;
     showCopyToClipboard?: boolean;
+    ariaLabel?: string;
   }>(),
   { readOnly: true, showGutter: true, showCopyToClipboard: true }
 );
@@ -48,7 +49,7 @@ const extensions = computed(() => {
 </script>
 
 <template>
-  <div class="wrapper">
+  <div class="wrapper" :aria-label="ariaLabel">
     <div v-if="props.showCopyToClipboard" class="toolbar">
       <CopyToClipboard :value="code" />
     </div>

--- a/src/Frontend/src/components/CopyToClipboard.vue
+++ b/src/Frontend/src/components/CopyToClipboard.vue
@@ -19,6 +19,6 @@ async function copyToClipboard() {
 
 <template>
   <Tippy content="Copied" ref="tippyRef" trigger="manual">
-    <button type="button" class="btn btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> Copy to clipboard</button>
+    <button type="button" class="btn btn-secondary btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> Copy to clipboard</button>
   </Tippy>
 </template>

--- a/src/Frontend/src/components/CopyToClipboard.vue
+++ b/src/Frontend/src/components/CopyToClipboard.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { Tippy, TippyComponent } from "vue-tippy";
+import { useTemplateRef } from "vue";
+
+const props = defineProps<{
+  value: string;
+}>();
+
+const tippyRef = useTemplateRef<TippyComponent | null>("tippyRef");
+let timeoutId: number;
+
+async function copyToClipboard() {
+  await navigator.clipboard.writeText(props.value);
+  window.clearTimeout(timeoutId);
+  tippyRef.value?.show();
+  timeoutId = window.setTimeout(() => tippyRef.value?.hide(), 3000);
+}
+</script>
+
+<template>
+  <Tippy content="Copied" ref="tippyRef" trigger="manual">
+    <button type="button" class="btn btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> Copy to clipboard</button>
+  </Tippy>
+</template>

--- a/src/Frontend/src/components/codeEditorTypes.ts
+++ b/src/Frontend/src/components/codeEditorTypes.ts
@@ -1,0 +1,1 @@
+export type CodeLanguage = "json" | "xml" | "shell" | "powershell" | "csharp";

--- a/src/Frontend/src/components/configuration/EndpointConnection.vue
+++ b/src/Frontend/src/components/configuration/EndpointConnection.vue
@@ -5,7 +5,7 @@ import ServiceControlNotAvailable from "../ServiceControlNotAvailable.vue";
 import { licenseStatus } from "@/composables/serviceLicense";
 import { connectionState, useServiceControlConnections } from "@/composables/serviceServiceControl";
 import BusyIndicator from "../BusyIndicator.vue";
-import VCodeBlock from "@wdns/vue-code-block";
+import CodeEditor from "@/components/CodeEditor.vue";
 
 const isExpired = licenseStatus.isExpired;
 
@@ -109,7 +109,7 @@ function switchJsonTab() {
               <section v-if="showCodeOnlyTab && !loading">
                 <div class="row">
                   <div class="col-12 h-100">
-                    <VCodeBlock :code="inlineSnippet" lang="csharp"></VCodeBlock>
+                    <CodeEditor :model-value="inlineSnippet" language="csharp" :show-gutter="false"></CodeEditor>
                   </div>
                 </div>
               </section>
@@ -119,11 +119,11 @@ function switchJsonTab() {
                   <div class="col-12 h-100">
                     <p>Note that when using JSON for configuration, you also need to change the endpoint configuration as shown below.</p>
                     <p><strong>Endpoint configuration:</strong></p>
-                    <VCodeBlock :code="jsonSnippet" lang="csharp"></VCodeBlock>
+                    <CodeEditor :model-value="jsonSnippet" language="csharp" :show-gutter="false"></CodeEditor>
                     <p style="margin-top: 15px">
                       <strong>JSON configuration file:</strong>
                     </p>
-                    <VCodeBlock :code="jsonConfig" lang="json"></VCodeBlock>
+                    <CodeEditor :model-value="jsonConfig" language="json" :show-gutter="false"></CodeEditor>
                   </div>
                 </div>
               </section>

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -230,7 +230,7 @@ onMounted(() => {
                         </tbody>
                       </table>
                       <div role="tabpanel" v-if="panel === 2 && !localMessage.bodyUnavailable" style="height: calc(100% - 260px)">
-                        <div style="margin-top: 20px">
+                        <div style="margin-top: 1.25rem">
                           <CodeEditor aria-label="message body" :read-only="!localMessage.isContentTypeSupported" v-model="localMessage.messageBody" :language="localMessage.language" :show-gutter="true"></CodeEditor>
                         </div>
                         <span class="empty-error" v-if="localMessage.isBodyEmpty"><i class="fa fa-exclamation-triangle"></i> Message body cannot be empty</span>

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -231,7 +231,7 @@ onMounted(() => {
                       </table>
                       <div role="tabpanel" v-if="panel === 2 && !localMessage.bodyUnavailable" style="height: calc(100% - 260px)">
                         <div style="margin-top: 20px">
-                          <CodeEditor role="textbox" aria-label="message body" :read-only="!localMessage.isContentTypeSupported" v-model="localMessage.messageBody" :language="localMessage.language" :show-gutter="true"></CodeEditor>
+                          <CodeEditor aria-label="message body" :read-only="!localMessage.isContentTypeSupported" v-model="localMessage.messageBody" :language="localMessage.language" :show-gutter="true"></CodeEditor>
                         </div>
                         <span class="empty-error" v-if="localMessage.isBodyEmpty"><i class="fa fa-exclamation-triangle"></i> Message body cannot be empty</span>
                         <span class="reset-body" v-if="localMessage.isBodyChanged"><i class="fa fa-undo" v-tippy="`Reset changes`"></i> <a @click="resetBodyChanges()" href="javascript:void(0)">Reset changes</a></span>

--- a/src/Frontend/src/components/failedmessages/MessageRedirectForBackwardsCompatibility.vue
+++ b/src/Frontend/src/components/failedmessages/MessageRedirectForBackwardsCompatibility.vue
@@ -11,3 +11,6 @@ onMounted(async () => {
   await router.push({ path: routeLinks.messages.message.link(id.toString()), query: { back: routeLinks.failedMessage.failedMessages.link } });
 });
 </script>
+<template>
+  <template></template>
+</template>

--- a/src/Frontend/src/components/messages/BodyView.vue
+++ b/src/Frontend/src/components/messages/BodyView.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
 import { ExtendedFailedMessage } from "@/resources/FailedMessage";
-
+import { computed } from "vue";
+import CodeEditor from "@/components/CodeEditor.vue";
+import parseContentType from "@/composables/contentTypeParser";
 const props = defineProps<{
   message: ExtendedFailedMessage;
 }>();
+
+const contentType = computed(() => parseContentType(props.message.contentType));
 </script>
 
 <template>
   <div v-if="props.message.messageBodyNotFound" class="alert alert-info">Could not find message body. This could be because the message URL is invalid or the corresponding message was processed and is no longer tracked by ServiceControl.</div>
   <div v-else-if="props.message.bodyUnavailable" class="alert alert-info">Message body unavailable.</div>
-  <pre v-else>{{ props.message.messageBody }}</pre>
+  <CodeEditor v-else-if="contentType.isSupported" :model-value="props.message.messageBody" :language="contentType.language" :read-only="true" :show-gutter="true"></CodeEditor>
+  <div v-else class="alert alert-warning">Message body cannot be displayed because content type "{{ props.message.contentType }}" is not supported.</div>
 </template>
 
 <style scoped></style>

--- a/src/Frontend/src/components/messages/MessageView.vue
+++ b/src/Frontend/src/components/messages/MessageView.vue
@@ -19,10 +19,11 @@ import Message from "@/resources/Message";
 import { NServiceBusHeaders } from "@/resources/Header";
 import { useConfiguration } from "@/composables/configuration";
 import { useIsMassTransitConnected } from "@/composables/useIsMassTransitConnected";
-import { parse, stringify } from "lossless-json";
 import BodyView from "@/components/messages/BodyView.vue";
 import HeadersView from "@/components/messages/HeadersView.vue";
 import StackTraceView from "@/components/messages/StacktraceView.vue";
+import { stringify, parse } from "lossless-json";
+import xmlFormat from "xml-formatter";
 
 let refreshInterval: number | undefined;
 let pollingFaster = false;
@@ -150,116 +151,19 @@ async function downloadBody(message: ExtendedFailedMessage) {
   }
 
   try {
-    switch (response.headers.get("content-type")) {
-      case "application/json": {
-        const jsonBodyRaw = await response.text();
-        const jsonBody = parse(jsonBodyRaw.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => (g ? "" : m)));
-        message.messageBody = formatJson(jsonBody);
-        return;
-      }
-      case "text/xml": {
-        const xmlBody = await response.text();
-        message.messageBody = formatXml(xmlBody);
-        return;
-      }
-      default: {
-        message.messageBody = await response.text();
-      }
+    const contentType = response.headers.get("content-type");
+    message.contentType = contentType ?? "text/plain";
+    message.messageBody = await response.text();
+
+    if (contentType === "application/json") {
+      message.messageBody = stringify(parse(message.messageBody), null, 2) ?? message.messageBody;
+    }
+    if (contentType === "text/xml") {
+      message.messageBody = xmlFormat(message.messageBody, { indentation: "  ", collapseContent: true });
     }
   } catch {
     message.bodyUnavailable = true;
   }
-}
-
-// taken from https://github.com/krtnio/angular-pretty-xml/blob/master/src/angular-pretty-xml.js
-function formatXml(xml: string) {
-  function createShiftArr(step: string) {
-    let space: string;
-    if (isNaN(parseInt(step))) {
-      // argument is string
-      space = step;
-    } else {
-      // argument is integer
-      space = " ".repeat(parseInt(step));
-    }
-
-    const shift = ["\n"]; // array of shifts
-
-    for (let ix = 0; ix < 100; ix++) {
-      shift.push(shift[ix] + space);
-    }
-
-    return shift;
-  }
-
-  const indent = "\t";
-
-  const arr = xml
-    .replace(/>\s*</gm, "><")
-    .replace(/</g, "~::~<")
-    .replace(/\s*xmlns([=:])/g, "~::~xmlns$1")
-    .split("~::~");
-
-  const len = arr.length,
-    shift = createShiftArr(indent);
-  let inComment = false,
-    depth = 0,
-    string = "",
-    m1: RegExpExecArray | null,
-    m2: RegExpExecArray | null;
-
-  for (let i = 0; i < len; i++) {
-    m1 = /^<[\w:\-.,]+/.exec(arr[i - 1]);
-    m2 = /^<\/[\w:\-.,]+/.exec(arr[i]);
-    // start comment or <![CDATA[...]]> or <!DOCTYPE //
-    if (arr[i].indexOf("<!") !== -1) {
-      string += shift[depth] + arr[i];
-      inComment = true;
-      // end comment or <![CDATA[...]]> //
-      if (arr[i].indexOf("-->") !== -1 || arr[i].indexOf("]>") !== -1 || arr[i].indexOf("!DOCTYPE") !== -1) {
-        inComment = false;
-      }
-    } else if (arr[i].indexOf("-->") !== -1 || arr[i].indexOf("]>") !== -1) {
-      // end comment  or <![CDATA[...]]> //
-      string += arr[i];
-      inComment = false;
-    } else if (
-      /^<\w/.test(arr[i - 1]) &&
-      /^<\/\w/.test(arr[i]) && // <elm></elm> //
-      m1 &&
-      m2 &&
-      m1[0] === m2[0].replace("/", "")
-    ) {
-      string += arr[i];
-      if (!inComment) depth--;
-    } else if (arr[i].search(/<\w/) !== -1 && arr[i].indexOf("</") === -1 && arr[i].indexOf("/>") === -1) {
-      // <elm> //
-      string += !inComment ? shift[depth++] + arr[i] : arr[i];
-    } else if (arr[i].search(/<\w/) !== -1 && arr[i].indexOf("</") !== -1) {
-      // <elm>...</elm> //
-      string += !inComment ? shift[depth] + arr[i] : arr[i];
-    } else if (arr[i].search(/<\//) > -1) {
-      // </elm> //
-      string += !inComment ? shift[--depth] + arr[i] : arr[i];
-    } else if (arr[i].indexOf("/>") !== -1) {
-      // <elm/> //
-      string += !inComment ? shift[depth] + arr[i] : arr[i];
-    } else if (arr[i].indexOf("<?") !== -1) {
-      // <? xml ... ?> //
-      string += shift[depth] + arr[i];
-    } else if (arr[i].indexOf("xmlns:") !== -1 || arr[i].indexOf("xmlns=") !== -1) {
-      // xmlns //
-      string += shift[depth] + arr[i];
-    } else {
-      string += arr[i];
-    }
-  }
-
-  return string.trim();
-}
-
-function formatJson(json: unknown) {
-  return stringify(json, null, 2) as string;
 }
 
 function togglePanel(panelNum: number) {
@@ -446,7 +350,7 @@ onUnmounted(() => {
                 <h5 :class="{ active: panel === 3 }" class="nav-item" @click.prevent="togglePanel(3)"><a href="#">Headers</a></h5>
                 <h5 v-if="!isMassTransitConnected" :class="{ active: panel === 4 }" class="nav-item" @click.prevent="togglePanel(4)"><a href="#">Flow Diagram</a></h5>
               </div>
-              <StackTraceView v-if="panel === 1" :message="failedMessage" />
+              <StackTraceView v-if="panel === 1 && failedMessage.exception?.stack_trace" :message="failedMessage" />
               <BodyView v-if="panel === 2" :message="failedMessage" />
               <HeadersView v-if="panel === 3" :message="failedMessage" />
               <FlowDiagram v-if="panel === 4" :message="failedMessage" />

--- a/src/Frontend/src/components/messages/StacktraceView.vue
+++ b/src/Frontend/src/components/messages/StacktraceView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ExtendedFailedMessage } from "@/resources/FailedMessage";
-import VCodeBlock from "@wdns/vue-code-block";
+import CodeEditor from "@/components/CodeEditor.vue";
 
 const props = defineProps<{
   message: ExtendedFailedMessage;
@@ -8,5 +8,5 @@ const props = defineProps<{
 </script>
 
 <template>
-  <VCodeBlock :code="props.message.exception.stack_trace" lang="csharp"></VCodeBlock>
+  <CodeEditor :model-value="props.message.exception.stack_trace" language="powershell" :read-only="true" :show-gutter="false"></CodeEditor>
 </template>

--- a/src/Frontend/src/composables/contentTypeParser.ts
+++ b/src/Frontend/src/composables/contentTypeParser.ts
@@ -1,0 +1,63 @@
+import { CodeLanguage } from "@/components/codeEditorTypes";
+
+function parseContentType(contentType: string | undefined): { isSupported: boolean; language?: CodeLanguage } {
+  if (contentType === undefined) {
+    return {
+      isSupported: false,
+    };
+  }
+
+  // remove content type parameter, e.g. charset=utf-8
+  contentType = contentType.split(";")[0].trim();
+
+  if (contentType === "application/json") {
+    return {
+      isSupported: true,
+      language: "json",
+    };
+  }
+
+  if (contentType === "text/xml") {
+    return {
+      isSupported: true,
+      language: "xml",
+    };
+  }
+
+  if (contentType.startsWith("text/")) {
+    return {
+      isSupported: true,
+    };
+  }
+
+  if (contentType === "application/xml") {
+    return {
+      isSupported: true,
+      language: "xml",
+    };
+  }
+
+  if (contentType.startsWith("application/")) {
+    // Some examples:
+    // application/atom+xml
+    // application/ld+json
+    // application/vnd.masstransit+json
+    if (contentType.endsWith("+json")) {
+      return {
+        isSupported: true,
+        language: "json",
+      };
+    } else if (contentType.endsWith("+xml")) {
+      return {
+        isSupported: true,
+        language: "xml",
+      };
+    }
+  }
+
+  return {
+    isSupported: false,
+  };
+}
+
+export default parseContentType;

--- a/src/Frontend/src/mount.ts
+++ b/src/Frontend/src/mount.ts
@@ -5,8 +5,6 @@ import Toast, { type PluginOptions, POSITION } from "vue-toastification";
 import VueTippy from "vue-tippy";
 import { createPinia } from "pinia";
 import SimpleTypeahead from "vue3-simple-typeahead";
-import { createVCodeBlock } from "@wdns/vue-code-block";
-import "highlight.js/styles/github-dark.css";
 
 const toastOptions: PluginOptions = {
   position: POSITION.BOTTOM_RIGHT,
@@ -24,14 +22,8 @@ export function mount({ router }: { router: Router }) {
     next();
   });
 
-  const VCodeBlock = createVCodeBlock({
-    theme: "github-dark",
-    cssPath: "highlight.js/styles/github-dark.css",
-    highlightjs: true,
-  });
-
   const app = createApp(App);
-  app.use(router).use(Toast, toastOptions).use(SimpleTypeahead).use(VCodeBlock).use(createPinia()).use(VueTippy);
+  app.use(router).use(Toast, toastOptions).use(SimpleTypeahead).use(createPinia()).use(VueTippy);
   app.mount(`#app`);
 
   app.config.errorHandler = (err, instance) => {

--- a/src/Frontend/src/resources/FailedMessage.ts
+++ b/src/Frontend/src/resources/FailedMessage.ts
@@ -38,6 +38,7 @@ export interface ExtendedFailedMessage extends FailedMessage {
   headers: Header[];
   conversationId: string;
   messageBody: string;
+  contentType: string;
   isEditAndRetryEnabled: boolean;
   redirect: boolean;
   submittedForRetrial: boolean;

--- a/src/Frontend/src/views/throughputreport/setup/ConfigurationCode.vue
+++ b/src/Frontend/src/views/throughputreport/setup/ConfigurationCode.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import VCodeBlock from "@wdns/vue-code-block";
 import { ThroughputConnectionSetting } from "@/resources/ThroughputConnectionSettings";
 import { computed, ref } from "vue";
 import DropDown, { Item } from "@/components/DropDown.vue";
+import CodeEditor from "@/components/CodeEditor.vue";
+import { CodeLanguage } from "@/components/codeEditorTypes";
 
 const props = withDefaults(
   defineProps<{
@@ -43,11 +44,11 @@ const languageSelected = ref("config");
 const codeSelected = computed(() => {
   switch (languageSelected.value) {
     case "bash":
-      return { code: bash.value, lang: "bash" };
+      return { code: bash.value, lang: <CodeLanguage>"shell" };
     case "windows":
-      return { code: windows.value, lang: "cmd" };
+      return { code: windows.value, lang: <CodeLanguage>"shell" };
     default:
-      return { code: config.value, lang: "xml" };
+      return { code: config.value, lang: <CodeLanguage>"xml" };
   }
 });
 
@@ -75,7 +76,7 @@ function languageChanged(item: Item) {
     <drop-down label="Configuration type" :select-item="languages.find((v) => v.value === languageSelected)" :callback="languageChanged" :items="languages" />
   </div>
   <div class="configuration">
-    <VCodeBlock :code="codeSelected.code" :lang="codeSelected.lang" />
+    <CodeEditor :model-value="codeSelected.code" :language="codeSelected.lang" :show-gutter="false" />
     <div class="instructions">
       <slot name="configInstructions" v-if="languageSelected === 'config'"></slot>
       <slot name="environmentVariableInstructions" v-else></slot>

--- a/src/Frontend/src/vue-highlight-code.d.ts
+++ b/src/Frontend/src/vue-highlight-code.d.ts
@@ -1,1 +1,0 @@
-declare module "vue-highlight-code";

--- a/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
+++ b/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
@@ -77,7 +77,7 @@ describe("FEATURE: Editing failed messages", () => {
         await messageEditor.switchToMessageBodyTab();
 
         //Then The message body should be editable
-        expect(messageEditor.bodyFieldIsDisabled()).toBeFalsy();
+        expect(messageEditor.bodyFieldIsReadOnly()).toBeFalsy();
       });
     });
 
@@ -103,7 +103,7 @@ describe("FEATURE: Editing failed messages", () => {
       await messageEditor.switchToMessageBodyTab();
 
       //Then The message body should NOT be editable
-      expect(messageEditor.bodyFieldIsDisabled()).toBeTruthy();
+      expect(messageEditor.bodyFieldIsReadOnly()).toBeTruthy();
       expect(
         messageEditor.hasWarningMatchingText(/message body cannot be edited because content type "application\/octet-stream" is not supported\. only messages with content types "application\/json" and "text\/xml" can be edited\./i)
       ).toBeTruthy();

--- a/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
+++ b/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
@@ -5,6 +5,32 @@ import { getEditAndRetryEditor } from "./questions/getEditAndRetryEditor";
 import { expect } from "vitest";
 
 describe("FEATURE: Editing failed messages", () => {
+  function getBoundingClientRect(): DOMRect {
+    const rec = {
+      x: 0,
+      y: 0,
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+    };
+    return { ...rec, toJSON: () => rec };
+  }
+
+  class FakeDOMRectList extends Array<DOMRect> implements DOMRectList {
+    item(index: number): DOMRect | null {
+      return this[index];
+    }
+  }
+
+  document.elementFromPoint = (): null => null;
+  HTMLElement.prototype.getBoundingClientRect = getBoundingClientRect;
+  HTMLElement.prototype.getClientRects = (): DOMRectList => new FakeDOMRectList();
+  Range.prototype.getBoundingClientRect = getBoundingClientRect;
+  Range.prototype.getClientRects = (): DOMRectList => new FakeDOMRectList();
+
   describe("RULE: Editing of a message should only be allowed when ServiceControl 'AllowMessageEditing' is enabled", () => {
     test.todo(
       "EXAMPLE: ServiceControl 'AllowMessageEditing' is disabled"

--- a/src/Frontend/test/specs/failedmessages/questions/getEditAndRetryEditor.ts
+++ b/src/Frontend/test/specs/failedmessages/questions/getEditAndRetryEditor.ts
@@ -9,8 +9,9 @@ export async function getEditAndRetryEditor() {
       await UserEvent.click(tab);
     },
 
-    bodyFieldIsDisabled() {
-      return within(dialog).getByRole("textbox", { name: "message body" }).hasAttribute("readonly");
+    bodyFieldIsReadOnly() {
+      const textbox = within(within(dialog).getByLabelText("message body")).getByRole("textbox");
+      return textbox.ariaReadOnly === "true";
     },
 
     hasWarningMatchingText(legendText: RegExp) {

--- a/src/Frontend/test/specs/failedmessages/questions/getEditAndRetryEditor.ts
+++ b/src/Frontend/test/specs/failedmessages/questions/getEditAndRetryEditor.ts
@@ -10,7 +10,7 @@ export async function getEditAndRetryEditor() {
     },
 
     bodyFieldIsDisabled() {
-      return within(dialog).getByRole("textbox", { name: "message body" }).hasAttribute("disabled");
+      return within(dialog).getByRole("textbox", { name: "message body" }).hasAttribute("readonly");
     },
 
     hasWarningMatchingText(legendText: RegExp) {


### PR DESCRIPTION
This PR adds CodeMirror as the code editor and syntax highlighter.

I changed the stack trace to use the editor. At the moment, the syntax highlighter for the stack trace uses the "PowerShell" language, which highlights it slightly but not super nicely. We can write a [custom language](https://codemirror.net/examples/lang-package/) for it later.
![image](https://github.com/user-attachments/assets/02ddb67e-a9ca-454a-9a5a-7d97e465cd5d)

Also added syntax highlighting to the message body in both view and editing mode.
![image](https://github.com/user-attachments/assets/eb331cfa-40b5-4086-ab40-ce8eb22522bf)

For editing mode, we can add lint so that it helps the user avoid syntax mistakes. See https://codemirror.net/examples/lint/
![Mar-17-2025 11-05-29](https://github.com/user-attachments/assets/51769d02-7962-4995-bb7a-f0d824c1f9df)

The editor has:
- code folding
- copy to clipboard
- line numbers