### PR TITLE
Copy feature in message headers in message view

### DIFF
--- a/src/Frontend/src/components/CopyToClipboard.vue
+++ b/src/Frontend/src/components/CopyToClipboard.vue
@@ -2,9 +2,16 @@
 import { Tippy, TippyComponent } from "vue-tippy";
 import { useTemplateRef } from "vue";
 
-const props = defineProps<{
-  value: string;
-}>();
+const props = defineProps({
+  value: {
+    type: String,
+    required: true,
+  },
+  isIconOnly: {
+    type: Boolean,
+    default: false, // Default value
+  },
+});
 
 const tippyRef = useTemplateRef<TippyComponent | null>("tippyRef");
 let timeoutId: number;
@@ -19,6 +26,6 @@ async function copyToClipboard() {
 
 <template>
   <Tippy content="Copied" ref="tippyRef" trigger="manual">
-    <button type="button" class="btn btn-secondary btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> Copy to clipboard</button>
+    <button type="button" class="btn btn-secondary btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> <span v-if="!props.isIconOnly">Copy to clipboard</span></button>
   </Tippy>
 </template>

--- a/src/Frontend/src/components/CopyToClipboard.vue
+++ b/src/Frontend/src/components/CopyToClipboard.vue
@@ -25,7 +25,7 @@ async function copyToClipboard() {
 </script>
 
 <template>
-  <Tippy content="Copied" ref="tippyRef" trigger="manual">
+  <Tippy content="Copied" ref="tippyRef" trigger="manual" :title="props.isIconOnly ? 'Copy to Clipboard' : ''">
     <button type="button" class="btn btn-secondary btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> <span v-if="!props.isIconOnly">Copy to clipboard</span></button>
   </Tippy>
 </template>

--- a/src/Frontend/src/components/CopyToClipboard.vue
+++ b/src/Frontend/src/components/CopyToClipboard.vue
@@ -2,16 +2,13 @@
 import { Tippy, TippyComponent } from "vue-tippy";
 import { useTemplateRef } from "vue";
 
-const props = defineProps({
-  value: {
-    type: String,
-    required: true,
-  },
-  isIconOnly: {
-    type: Boolean,
-    default: false, // Default value
-  },
-});
+const props = withDefaults(
+  defineProps<{
+    value: string;
+    isIconOnly?: boolean;
+  }>(),
+  { isIconOnly: false }
+);
 
 const tippyRef = useTemplateRef<TippyComponent | null>("tippyRef");
 let timeoutId: number;

--- a/src/Frontend/src/components/CopyToClipboard.vue
+++ b/src/Frontend/src/components/CopyToClipboard.vue
@@ -22,7 +22,8 @@ async function copyToClipboard() {
 </script>
 
 <template>
-  <Tippy content="Copied" ref="tippyRef" trigger="manual" :title="props.isIconOnly ? 'Copy to Clipboard' : ''">
-    <button type="button" class="btn btn-secondary btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> <span v-if="!props.isIconOnly">Copy to clipboard</span></button>
+  <Tippy content="Copied" ref="tippyRef" trigger="manual">
+    <button v-if="!props.isIconOnly" type="button" class="btn btn-secondary btn-sm" @click="copyToClipboard"><i class="fa fa-copy"></i> Copy to clipboard</button>
+    <button v-else type="button" class="btn btn-secondary btn-sm" @click="copyToClipboard" v-tippy="'Copy to clipboard'"><i class="fa fa-copy"></i></button>
   </Tippy>
 </template>

--- a/src/Frontend/src/components/messages/HeadersView.vue
+++ b/src/Frontend/src/components/messages/HeadersView.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
 import { ExtendedFailedMessage } from "@/resources/FailedMessage";
 import CopyToClipboard from "@/components/CopyToClipboard.vue";
+import { ref } from "vue";
 const props = defineProps<{
   message: ExtendedFailedMessage;
 }>();
+
+const hoverStates = ref<Record<number, boolean>>({});
+
+const toggleHover = (index: number, state: boolean) => {
+  hoverStates.value[index] = state;
+};
 </script>
 
 <template>
@@ -12,9 +19,9 @@ const props = defineProps<{
       <tr class="interactiveList" v-for="(header, index) in props.message.headers" :key="index">
         <td nowrap="nowrap">{{ header.key }}</td>
         <td class="toolbar">
-          <div style="display: flex; align-items: center">
+          <div style="display: flex; align-items: center" @mouseover="toggleHover(index, true)" @mouseleave="toggleHover(index, false)">
             <pre>{{ header.value }}</pre>
-            <CopyToClipboard :value="header.value || ''" />
+            <CopyToClipboard v-if="hoverStates[index]" :value="header.value || ''" />
           </div>
         </td>
       </tr>

--- a/src/Frontend/src/components/messages/HeadersView.vue
+++ b/src/Frontend/src/components/messages/HeadersView.vue
@@ -18,8 +18,8 @@ const toggleHover = (index: number, state: boolean) => {
     <tbody>
       <tr class="interactiveList" v-for="(header, index) in props.message.headers" :key="index">
         <td nowrap="nowrap">{{ header.key }}</td>
-        <td class="toolbar">
-          <div style="display: flex; align-items: center" @mouseover="toggleHover(index, true)" @mouseleave="toggleHover(index, false)">
+        <td>
+          <div class="headercopy" @mouseover="toggleHover(index, true)" @mouseleave="toggleHover(index, false)">
             <pre>{{ header.value }}</pre>
             <CopyToClipboard v-if="hoverStates[index]" :value="header.value || ''" :isIconOnly="true" />
           </div>
@@ -30,4 +30,10 @@ const toggleHover = (index: number, state: boolean) => {
   <div v-if="props.message.headersNotFound" class="alert alert-info">Could not find message headers. This could be because the message URL is invalid or the corresponding message was processed and is no longer tracked by ServiceControl.</div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.headercopy {
+  display: flex;
+  align-items: top;
+  gap: 10px;
+}
+</style>

--- a/src/Frontend/src/components/messages/HeadersView.vue
+++ b/src/Frontend/src/components/messages/HeadersView.vue
@@ -21,7 +21,7 @@ const toggleHover = (index: number, state: boolean) => {
         <td class="toolbar">
           <div style="display: flex; align-items: center" @mouseover="toggleHover(index, true)" @mouseleave="toggleHover(index, false)">
             <pre>{{ header.value }}</pre>
-            <CopyToClipboard v-if="hoverStates[index]" :value="header.value || ''" />
+            <CopyToClipboard v-if="hoverStates[index]" :value="header.value || ''" :isIconOnly="true" />
           </div>
         </td>
       </tr>

--- a/src/Frontend/src/components/messages/HeadersView.vue
+++ b/src/Frontend/src/components/messages/HeadersView.vue
@@ -34,6 +34,6 @@ const toggleHover = (index: number, state: boolean) => {
 .headercopy {
   display: flex;
   align-items: top;
-  gap: 10px;
+  gap: 0.4rem;
 }
 </style>

--- a/src/Frontend/src/components/messages/HeadersView.vue
+++ b/src/Frontend/src/components/messages/HeadersView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ExtendedFailedMessage } from "@/resources/FailedMessage";
-
+import CopyToClipboard from "@/components/CopyToClipboard.vue";
 const props = defineProps<{
   message: ExtendedFailedMessage;
 }>();
@@ -11,8 +11,20 @@ const props = defineProps<{
     <tbody>
       <tr class="interactiveList" v-for="(header, index) in props.message.headers" :key="index">
         <td nowrap="nowrap">{{ header.key }}</td>
-        <td>
+        <td class="toolbar">
+          <!--
           <pre>{{ header.value }}</pre>
+          <span>
+            <CopyToClipboard :value="header.value || ''" />
+            
+          </span>
+          -->
+          <!-- Use flexbox to align items horizontally -->
+          <div style="display: flex; align-items: center">
+            <!-- The pre element should not wrap, so use white-space: nowrap or keep it as a block element -->
+            <pre style="margin: 0; white-space: nowrap">{{ header.value }}</pre>
+            <CopyToClipboard :value="header.value || ''" />
+          </div>
         </td>
       </tr>
     </tbody>

--- a/src/Frontend/src/components/messages/HeadersView.vue
+++ b/src/Frontend/src/components/messages/HeadersView.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
         <td nowrap="nowrap">{{ header.key }}</td>
         <td class="toolbar">
           <div style="display: flex; align-items: center">
-            <pre style="margin: 0; white-space: nowrap">{{ header.value }}</pre>
+            <pre>{{ header.value }}</pre>
             <CopyToClipboard :value="header.value || ''" />
           </div>
         </td>

--- a/src/Frontend/src/components/messages/HeadersView.vue
+++ b/src/Frontend/src/components/messages/HeadersView.vue
@@ -12,16 +12,7 @@ const props = defineProps<{
       <tr class="interactiveList" v-for="(header, index) in props.message.headers" :key="index">
         <td nowrap="nowrap">{{ header.key }}</td>
         <td class="toolbar">
-          <!--
-          <pre>{{ header.value }}</pre>
-          <span>
-            <CopyToClipboard :value="header.value || ''" />
-            
-          </span>
-          -->
-          <!-- Use flexbox to align items horizontally -->
           <div style="display: flex; align-items: center">
-            <!-- The pre element should not wrap, so use white-space: nowrap or keep it as a block element -->
             <pre style="margin: 0; white-space: nowrap">{{ header.value }}</pre>
             <CopyToClipboard :value="header.value || ''" />
           </div>


### PR DESCRIPTION
This PR adds a copy icon next to each message header, enabling the copy of the header value to the clipboard.