### PR TITLE
Update test to use new url

### DIFF
--- a/src/Frontend/src/components/messages/MessageView.vue
+++ b/src/Frontend/src/components/messages/MessageView.vue
@@ -428,7 +428,7 @@ onUnmounted(() => {
                 <button type="button" class="btn btn-default" v-if="!failedMessage.archived" :disabled="failedMessage.retried || failedMessage.resolved" @click="showDeleteConfirm = true"><i class="fa fa-trash"></i> Delete message</button>
                 <button type="button" class="btn btn-default" v-if="failedMessage.archived" @click="showRestoreConfirm = true"><i class="fa fa-undo"></i> Restore</button>
                 <button type="button" class="btn btn-default" :disabled="failedMessage.retried || failedMessage.archived || failedMessage.resolved" @click="showRetryConfirm = true"><i class="fa fa-refresh"></i> Retry message</button>
-                <button type="button" class="btn btn-default" v-if="failedMessage.isEditAndRetryEnabled" :disabled="failedMessage.retried || failedMessage.archived || failedMessage.resolved" @click="showEditAndRetryModal()">
+                <button type="button" class="btn btn-default" aria-label="Edit & retry" v-if="failedMessage.isEditAndRetryEnabled" :disabled="failedMessage.retried || failedMessage.archived || failedMessage.resolved" @click="showEditAndRetryModal()">
                   <i class="fa fa-pencil"></i> Edit & retry
                 </button>
                 <button v-if="!isMassTransitConnected" type="button" class="btn btn-default" @click="debugInServiceInsight()" title="Browse this message in ServiceInsight, if installed">

--- a/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
+++ b/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
@@ -45,7 +45,7 @@ describe("FEATURE: Editing failed messages", () => {
         );
 
         //When the user opens the message editor
-        await driver.goTo("failed-messages/message/81dca64e-76fc-e1c3-11a2-3069f51c58c8");
+        await driver.goTo("messages/81dca64e-76fc-e1c3-11a2-3069f51c58c8");
         await openEditAndRetryEditor();
         const messageEditor = await getEditAndRetryEditor();
         await messageEditor.switchToMessageBodyTab();
@@ -71,7 +71,7 @@ describe("FEATURE: Editing failed messages", () => {
       );
 
       //When the user opens the message editor
-      await driver.goTo("failed-messages/message/81dca64e-76fc-e1c3-11a2-3069f51c58c8");
+      await driver.goTo("messages/81dca64e-76fc-e1c3-11a2-3069f51c58c8");
       await openEditAndRetryEditor();
       const messageEditor = await getEditAndRetryEditor();
       await messageEditor.switchToMessageBodyTab();


### PR DESCRIPTION
This should fix the flaky test:
![image](https://github.com/user-attachments/assets/3cbac97c-36c0-44ce-89fb-da853e19c2c8)

