### PR TITLE
Saga diagram: Navigate to timeout message

### DIFF
--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingTimeoutMessage.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingTimeoutMessage.vue
@@ -3,12 +3,20 @@ import { SagaTimeoutMessageViewModel } from "./SagaDiagramParser";
 import MessageDataBox from "./MessageDataBox.vue";
 import TimeoutIcon from "@/assets/TimeoutIcon.svg";
 import SagaTimeoutIcon from "@/assets/SagaTimeoutIcon.svg";
+import { useSagaDiagramStore } from "@/stores/SagaDiagramStore";
 
-defineProps<{
+const props = defineProps<{
   message: SagaTimeoutMessageViewModel;
   isLastMessage: boolean;
   showMessageData?: boolean;
 }>();
+
+const store = useSagaDiagramStore();
+
+const navigateToTimeout = () => {
+  // Set the selected message ID in the store
+  store.setSelectedMessageId(props.message.MessageId);
+};
 </script>
 
 <template>
@@ -16,7 +24,8 @@ defineProps<{
     <div class="cell cell--center">
       <div class="cell-inner cell-inner-line">
         <img class="saga-icon saga-icon--center-cell saga-icon--overlap" :src="SagaTimeoutIcon" alt="" />
-        <a class="timeout-status" href="" aria-label="timeout requested">Timeout Requested = {{ message.TimeoutFriendly }}</a>
+        <a v-if="message.HasBeenProcessed" class="timeout-status" href="#" @click.prevent="navigateToTimeout" aria-label="timeout requested">Timeout Requested = {{ message.TimeoutFriendly }}</a>
+        <span v-else class="timeout-status" aria-label="timeout requested">Timeout Requested = {{ message.TimeoutFriendly }}</span>
       </div>
     </div>
     <div class="cell cell--side"></div>

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -200,6 +200,9 @@ watch(
 
 .cell-inner-side--active {
   border: solid 2px #000000;
+  -webkit-animation: blink-border 1.8s ease-in-out;
+  -moz-animation: blink-border 1.8s ease-in-out;
+  -o-animation: blink-border 1.8s ease-in-out;
   animation: blink-border 1.8s ease-in-out;
 }
 
@@ -343,6 +346,51 @@ watch(
   font-size: 1rem;
   font-weight: 900;
   color: #00a3c4;
+}
+
+@-webkit-keyframes blink-border {
+  0%,
+  100% {
+    border-color: #000000;
+  }
+  20%,
+  60% {
+    border-color: #cccccc;
+  }
+  40%,
+  80% {
+    border-color: #000000;
+  }
+}
+
+@-moz-keyframes blink-border {
+  0%,
+  100% {
+    border-color: #000000;
+  }
+  20%,
+  60% {
+    border-color: #cccccc;
+  }
+  40%,
+  80% {
+    border-color: #000000;
+  }
+}
+
+@-o-keyframes blink-border {
+  0%,
+  100% {
+    border-color: #000000;
+  }
+  20%,
+  60% {
+    border-color: #cccccc;
+  }
+  40%,
+  80% {
+    border-color: #000000;
+  }
 }
 
 @keyframes blink-border {

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -200,6 +200,7 @@ watch(
 
 .cell-inner-side--active {
   border: solid 2px #000000;
+  animation: blink-border 1.8s ease-in-out;
 }
 
 .cell-inner-right {
@@ -342,5 +343,20 @@ watch(
   font-size: 1rem;
   font-weight: 900;
   color: #00a3c4;
+}
+
+@keyframes blink-border {
+  0%,
+  100% {
+    border-color: #000000;
+  }
+  20%,
+  60% {
+    border-color: #cccccc;
+  }
+  40%,
+  80% {
+    border-color: #000000;
+  }
 }
 </style>

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -199,7 +199,7 @@ watch(
 }
 
 .cell-inner-side--active {
-  border: solid 2px #00a3c4;
+  border: solid 5px #00a3c4;
   -webkit-animation: blink-border 1.8s ease-in-out;
   -moz-animation: blink-border 1.8s ease-in-out;
   -o-animation: blink-border 1.8s ease-in-out;

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -199,7 +199,7 @@ watch(
 }
 
 .cell-inner-side--active {
-  border: solid 2px #000000;
+  border: solid 2px #00a3c4;
   -webkit-animation: blink-border 1.8s ease-in-out;
   -moz-animation: blink-border 1.8s ease-in-out;
   -o-animation: blink-border 1.8s ease-in-out;
@@ -396,7 +396,7 @@ watch(
 @keyframes blink-border {
   0%,
   100% {
-    border-color: #000000;
+    border-color: #00a3c4;
   }
   20%,
   60% {
@@ -404,7 +404,7 @@ watch(
   }
   40%,
   80% {
-    border-color: #000000;
+    border-color: #00a3c4;
   }
 }
 </style>

--- a/src/Frontend/src/stores/SagaDiagramStore.ts
+++ b/src/Frontend/src/stores/SagaDiagramStore.ts
@@ -22,6 +22,7 @@ export const useSagaDiagramStore = defineStore("SagaDiagramStore", () => {
   const showMessageData = ref(false);
   const fetchedMessages = ref(new Set<string>());
   const messagesData = ref<SagaMessageData[]>([]);
+  const selectedMessageId = ref<string | null>(null);
   const MessageBodyEndpoint = "messages/{0}/body";
 
   // Watch the sagaId and fetch saga history when it changes
@@ -188,6 +189,7 @@ export const useSagaDiagramStore = defineStore("SagaDiagramStore", () => {
     error.value = null;
     fetchedMessages.value.clear();
     messagesData.value = [];
+    selectedMessageId.value = null;
   }
 
   function formatUrl(template: string, id: string): string {
@@ -248,6 +250,10 @@ export const useSagaDiagramStore = defineStore("SagaDiagramStore", () => {
     }
   }
 
+  function setSelectedMessageId(messageId: string | null) {
+    selectedMessageId.value = messageId;
+  }
+
   return {
     sagaHistory,
     sagaId,
@@ -256,9 +262,11 @@ export const useSagaDiagramStore = defineStore("SagaDiagramStore", () => {
     error,
     showMessageData,
     messagesData,
+    selectedMessageId,
     setSagaId,
     clearSagaHistory,
     toggleMessageData,
+    setSelectedMessageId,
   };
 });
 


### PR DESCRIPTION
### Feature: Timeout Navigation in Saga Diagram

#### Rule: Clicking on a processed timeout message navigates to its corresponding incoming timeout message
##### EXAMPLE: User clicks on a timeout message that has been processed
Given a saga with an outgoing timeout message that has been processed
When the user clicks on the timeout link
Then the page scrolls to the corresponding incoming timeout message
And the incoming timeout message is highlighted with a blinking animation

#### Rule: Timeouts that have not been processed yet are displayed as non-clickable text
##### EXAMPLE: User views a timeout message that has not been processed yet
Given a saga with an outgoing timeout message that has not been processed
When the user views the saga diagram
Then the timeout message is displayed as non-clickable text

#### Rule: Only one timeout message can be highlighted at a time
##### EXAMPLE: User clicks on multiple timeout messages sequentially
Given a saga with multiple outgoing timeout messages that have been processed
When the user clicks on one timeout message and then another
Then only the most recently clicked timeout message is highlighted
And the previously highlighted timeout message is no longer highlighted