### PR TITLE
Fix reset original body

### DIFF
--- a/src/Frontend/src/components/CodeEditor.vue
+++ b/src/Frontend/src/components/CodeEditor.vue
@@ -51,8 +51,12 @@ const extensions = computed(() => {
 
 <template>
   <div class="wrapper" :aria-label="ariaLabel" :class="css">
-    <div v-if="props.showCopyToClipboard" class="toolbar">
-      <CopyToClipboard :value="code" />
+    <div v-if="props.showCopyToClipboard || $slots.toolbarLeft || $slots.toolbarRight" class="toolbar">
+      <div><slot name="toolbarLeft"></slot></div>
+      <div>
+        <slot name="toolbarRight"></slot>
+        <CopyToClipboard class="clipboard" v-if="props.showCopyToClipboard" :value="code" />
+      </div>
     </div>
     <CodeMirror v-model="code" :extensions="extensions" :basic="props.showGutter" :minimal="!props.showGutter" :readonly="props.readOnly" :gutter="!props.readOnly" :wrap="true"></CodeMirror>
   </div>
@@ -76,6 +80,10 @@ const extensions = computed(() => {
   margin-bottom: 0.5rem;
   display: flex;
   flex-direction: row;
-  justify-content: end;
+  justify-content: space-between;
+  align-items: center;
+}
+.clipboard {
+  margin-left: 0.5rem;
 }
 </style>

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog2.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog2.vue
@@ -60,7 +60,7 @@ const debounceBodyUpdate = debounce((value: string) => {
   const newValue = value.replaceAll(regExToPruneLineEndings, "");
   localMessage.value.isBodyChanged = newValue !== uneditedMessageBody.value.replaceAll(regExToPruneLineEndings, "");
   localMessage.value.isBodyEmpty = newValue === "";
-}, 1000);
+}, 100);
 
 watch(
   () => localMessage.value.messageBody,

--- a/src/Frontend/src/components/messages2/EditAndRetryButton.vue
+++ b/src/Frontend/src/components/messages2/EditAndRetryButton.vue
@@ -9,12 +9,12 @@ import { storeToRefs } from "pinia";
 import { FailedMessageStatus } from "@/resources/FailedMessage";
 
 const store = useMessageStore();
-const { state } = storeToRefs(store);
+const { state, edit_and_retry_config } = storeToRefs(store);
 const isConfirmDialogVisible = ref(false);
 
 const failureStatus = computed(() => state.value.data.failure_status);
 const isDisabled = computed(() => failureStatus.value.retried || failureStatus.value.archived || failureStatus.value.resolved);
-const isVisible = computed(() => store.edit_and_retry_config.enabled && state.value.data.status !== MessageStatus.Successful && state.value.data.status !== MessageStatus.ResolvedSuccessfully);
+const isVisible = computed(() => edit_and_retry_config.value.enabled && state.value.data.status !== MessageStatus.Successful && state.value.data.status !== MessageStatus.ResolvedSuccessfully);
 const handleConfirm = async () => {
   isConfirmDialogVisible.value = false;
 

--- a/src/Frontend/src/components/messages2/FlowDiagram/FlowDiagram.vue
+++ b/src/Frontend/src/components/messages2/FlowDiagram/FlowDiagram.vue
@@ -23,12 +23,12 @@ enum MessageType {
 }
 
 const store = useMessageStore();
-const { state } = storeToRefs(store);
+const { state, conversationData } = storeToRefs(store);
 
 async function getConversation(conversationId: string) {
   await store.loadConversation(conversationId);
 
-  return store.conversationData.data;
+  return conversationData.value.data;
 }
 
 class SagaInvocation {

--- a/src/Frontend/src/components/messages2/RetryMessageButton.vue
+++ b/src/Frontend/src/components/messages2/RetryMessageButton.vue
@@ -14,7 +14,7 @@ const isConfirmDialogVisible = ref(false);
 
 const failureStatus = computed(() => state.value.data.failure_status);
 const isDisabled = computed(() => failureStatus.value.retried || failureStatus.value.archived || failureStatus.value.resolved);
-const isVisible = computed(() => store.edit_and_retry_config.enabled && state.value.data.status !== MessageStatus.Successful && state.value.data.status !== MessageStatus.ResolvedSuccessfully);
+const isVisible = computed(() => state.value.data.status !== MessageStatus.Successful && state.value.data.status !== MessageStatus.ResolvedSuccessfully);
 
 const handleConfirm = async () => {
   isConfirmDialogVisible.value = false;

--- a/src/Frontend/src/stores/SequenceDiagramStore.ts
+++ b/src/Frontend/src/stores/SequenceDiagramStore.ts
@@ -27,7 +27,7 @@ export const Endpoint_Width = 260;
 
 export const useSequenceDiagramStore = defineStore("SequenceDiagramStore", () => {
   const messageStore = useMessageStore();
-  const { state } = storeToRefs(messageStore);
+  const { state, conversationData } = storeToRefs(messageStore);
   const router = useRouter();
 
   const startX = ref(Endpoint_Width / 2);
@@ -43,11 +43,11 @@ export const useSequenceDiagramStore = defineStore("SequenceDiagramStore", () =>
   const selectedId = computed(() => `${state.value.data.message_type ?? ""}(${state.value.data.id})`);
 
   watch(
-    () => messageStore.conversationData.data,
+    () => conversationData,
     (conversationData) => {
-      if (conversationData.length) {
+      if (conversationData.value.data.length) {
         startX.value = Endpoint_Width / 2;
-        const model = new ModelCreator(conversationData);
+        const model = new ModelCreator(conversationData.value.data);
         endpoints.value = model.endpoints;
         handlers.value = model.handlers;
         routes.value = model.routes;


### PR DESCRIPTION
The edit and retry dialog was suppose to show a "reset body" back to the original button.
But unfortunately the logic had a few bugs which cuased the button to not always be shown.

This PR fixes that issue as well as brings the button to the top of the dialog to be more inline with current design in other areas.
