### PR TITLE
replace wildcard tooltip with static text, replace the instructions text

### DIFF
--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -160,6 +160,11 @@ watch(autoRefreshValue, (newValue) => dataRetriever.updateTimeout(newValue));
         <FiltersPanel />
       </div>
       <div class="row">
+        <div class="col format-showing-tip">
+          <div>Use <i class="fa fa-asterisk asterisk" /> as a wildcard. Eg: <i class="fa fa-asterisk asterisk"></i>World! or Hello<i class="fa fa-asterisk asterisk"></i> finds Hello World!</div>
+        </div>
+      </div>
+      <div class="row">
         <ResultsCount :displayed="messages.length" :total="totalCount" />
       </div>
     </div>
@@ -296,5 +301,10 @@ watch(autoRefreshValue, (newValue) => dataRetriever.updateTimeout(newValue));
 
 .retry-issued {
   background-image: url("@/assets/status_retry_issued.svg");
+}
+.format-showing-tip {
+  display: flex;
+  align-items: flex-end;
+  font-style: italic;
 }
 </style>

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -60,7 +60,6 @@ function findKeyByValue(searchValue: string) {
       <div class="filter-label"></div>
       <div class="filter-component text-search-container">
         <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" />
-        <p><i>Use * as a wildcard. Eg: *World! or Hello* finds Hello World!</i></p>
       </div>
     </div>
     <div class="filter">
@@ -99,7 +98,6 @@ function findKeyByValue(searchValue: string) {
   display: flex;
   gap: 1.1rem;
   flex-wrap: wrap;
-  align-items: flex-start;
 }
 
 .filter {
@@ -117,7 +115,6 @@ function findKeyByValue(searchValue: string) {
 }
 
 .text-search-container {
-  max-width: 25rem;
-  flex: 1;
+  width: 25rem;
 }
 </style>

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -3,16 +3,15 @@ import FilterInput from "@/components/FilterInput.vue";
 import { storeToRefs } from "pinia";
 import { FieldNames, useAuditStore } from "@/stores/AuditStore.ts";
 import ListFilterSelector from "@/components/audit/ListFilterSelector.vue";
-import { computed, useTemplateRef } from "vue";
+import { computed } from "vue";
 import DatePickerRange from "@/components/audit/DatePickerRange.vue";
-import { Tippy, TippyComponent } from "vue-tippy";
 
 const store = useAuditStore();
 const { sortBy, messageFilterString, selectedEndpointName, endpoints, itemsPerPage, dateRange } = storeToRefs(store);
 const endpointNames = computed(() => {
   return [...new Set(endpoints.value.map((endpoint) => endpoint.name))].sort();
 });
-const wildcardTooltipRef = useTemplateRef<TippyComponent | null>("wildcardTooltipRef");
+
 const sortByItemsMap = new Map([
   ["Latest sent", `${FieldNames.TimeSent},desc`],
   ["Oldest sent", `${FieldNames.TimeSent},asc`],
@@ -53,14 +52,6 @@ function findKeyByValue(searchValue: string) {
   }
   return "";
 }
-
-function toggleWildcardToolTip(show: boolean) {
-  if (show) {
-    wildcardTooltipRef.value?.show();
-  } else {
-    wildcardTooltipRef.value?.hide();
-  }
-}
 </script>
 
 <template>
@@ -68,15 +59,8 @@ function toggleWildcardToolTip(show: boolean) {
     <div class="filter">
       <div class="filter-label"></div>
       <div class="filter-component text-search-container">
-        <Tippy ref="wildcardTooltipRef" trigger="click" :hideOnClick="false">
-          <template #content>
-            <h4>Use <i class="fa fa-asterisk asterisk" /> to do wildcard searches</h4>
-            <p>
-              Example: <i><i class="fa fa-asterisk asterisk" />World!</i> or <i>Hello<i class="fa fa-asterisk asterisk" /></i>, to look for <i>Hello World!</i>
-            </p>
-          </template>
-          <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" @focus="() => toggleWildcardToolTip(true)" @blur="() => toggleWildcardToolTip(false)" @input="() => toggleWildcardToolTip(false)" />
-        </Tippy>
+        <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" />
+        <p><i>Use * as a wildcard. Eg: *World! or Hello* finds Hello World!</i></p>
       </div>
     </div>
     <div class="filter">
@@ -94,7 +78,7 @@ function toggleWildcardToolTip(show: boolean) {
     <div class="filter">
       <div class="filter-label">Show:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="numberOfItemsPerPage" instructions="Select how many result to display" v-model="selectedItemsPerPage" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" />
+        <ListFilterSelector :items="numberOfItemsPerPage" instructions="Max results to display" v-model="selectedItemsPerPage" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" />
       </div>
     </div>
     <div class="filter">
@@ -107,10 +91,6 @@ function toggleWildcardToolTip(show: boolean) {
 </template>
 
 <style scoped>
-.asterisk {
-  color: #04b9ff;
-  font-size: 1.2rem;
-}
 .filters {
   background-color: #f3f3f3;
   border: #8c8c8c 1px solid;
@@ -119,6 +99,7 @@ function toggleWildcardToolTip(show: boolean) {
   display: flex;
   gap: 1.1rem;
   flex-wrap: wrap;
+  align-items: flex-start;
 }
 
 .filter {
@@ -136,6 +117,7 @@ function toggleWildcardToolTip(show: boolean) {
 }
 
 .text-search-container {
-  width: 25rem;
+  max-width: 25rem;
+  flex: 1;
 }
 </style>


### PR DESCRIPTION
replace wildcard tooltip with static text and  replace the instructions text to get a cleaner and tighter look.

Old way of using a tooltip
![image](https://github.com/user-attachments/assets/c045b5c3-a79c-4a40-b95f-ac96c381cc4b)

New way of using a static text
![image](https://github.com/user-attachments/assets/19ead869-b301-42b9-8074-b1870fff1d02)

