### PR TITLE
Display saga messages body using CodeEditor

### DIFF
--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import CodeEditor from "@/components/CodeEditor.vue";
+import DiffMaximizeIcon from "@/assets/diff-maximize.svg";
+import DiffCloseIcon from "@/assets/diff-close.svg";
+import { Extension } from "@codemirror/state";
+import { CodeLanguage } from "@/components/codeEditorTypes";
+
+// Define the model value to be passed to CodeEditor
+const modelValue = defineModel<string>({ required: true });
+
+// Define props by extending the CodeEditor props and adding maximize-specific ones
+withDefaults(
+  defineProps<{
+    language?: CodeLanguage;
+    readOnly?: boolean;
+    showGutter?: boolean;
+    showCopyToClipboard?: boolean;
+    ariaLabel?: string;
+    extensions?: Extension[];
+    modalTitle?: string;
+  }>(),
+  {
+    readOnly: false,
+    showGutter: false,
+    showCopyToClipboard: false,
+    extensions: () => [],
+    modalTitle: "Code View",
+  }
+);
+
+// Component state for maximize functionality
+const showMaximizeModal = ref(false);
+
+// Handle maximize functionality
+const toggleMaximizeModal = () => {
+  showMaximizeModal.value = !showMaximizeModal.value;
+};
+
+// Handle ESC key to close modal
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key === "Escape" && showMaximizeModal.value) {
+    showMaximizeModal.value = false;
+  }
+};
+
+// Setup keyboard events for maximize modal
+onMounted(() => {
+  window.addEventListener("keydown", handleKeyDown);
+});
+
+// Clean up event listeners when component is destroyed
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", handleKeyDown);
+});
+</script>
+
+<template>
+  <div class="code-editor-wrapper">
+    <!-- Regular CodeEditor with maximize button in toolbarRight -->
+    <CodeEditor v-model="modelValue" :language="language" :read-only="readOnly" :show-gutter="showGutter" :show-copy-to-clipboard="showCopyToClipboard" :aria-label="ariaLabel" :extensions="extensions">
+      <template #toolbarLeft>
+        <slot name="toolbarLeft"></slot>
+      </template>
+      <template #toolbarRight>
+        <slot name="toolbarRight"></slot>
+        <img class="maximize-icon-inline" :src="DiffMaximizeIcon" alt="Maximize" @click="toggleMaximizeModal" title="Maximize view" />
+      </template>
+    </CodeEditor>
+
+    <!-- Maximize modal for CodeEditor -->
+    <div v-if="showMaximizeModal" class="maximize-modal">
+      <div class="maximize-modal-content">
+        <div class="maximize-modal-toolbar">
+          <span class="maximize-modal-title">{{ modalTitle }}</span>
+          <img class="maximize-modal-close" :src="DiffCloseIcon" alt="Close" @click="toggleMaximizeModal" title="Close" />
+        </div>
+        <div class="maximize-modal-body">
+          <CodeEditor v-model="modelValue" :language="language" :read-only="readOnly" :show-copy-to-clipboard="true" :show-gutter="true" :aria-label="ariaLabel" :extensions="[]" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.code-editor-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* Maximize icon styles */
+.maximize-icon-inline {
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+  margin-left: 8px;
+}
+
+.maximize-icon-inline:hover {
+  opacity: 1;
+}
+
+/* Modal styles copied from DiffViewer */
+.maximize-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.maximize-modal-content {
+  background-color: white;
+  width: calc(100% - 40px);
+  height: calc(100% - 40px);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.maximize-modal-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 15px;
+  background-color: #f8f8f8;
+  border-bottom: 1px solid #ddd;
+}
+
+.maximize-modal-title {
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.maximize-modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+}
+
+.maximize-modal-body {
+  flex: 1;
+  overflow: auto;
+  padding: 15px;
+}
+
+/* Ensure the CodeEditor wrapper fills the modal body */
+.maximize-modal-body :deep(.wrapper) {
+  height: calc(100% - 20px);
+}
+
+.maximize-modal-body :deep(.cm-editor),
+.maximize-modal-body :deep(.cm-scroller) {
+  height: 100%;
+}
+</style>

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -6,10 +6,8 @@ import DiffCloseIcon from "@/assets/diff-close.svg";
 import { Extension } from "@codemirror/state";
 import { CodeLanguage } from "@/components/codeEditorTypes";
 
-// Define the model value to be passed to CodeEditor
 const modelValue = defineModel<string>({ required: true });
 
-// Define props by extending the CodeEditor props and adding maximize-specific ones
 withDefaults(
   defineProps<{
     language?: CodeLanguage;

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -85,7 +85,7 @@ onBeforeUnmount(() => {
       <div class="maximize-modal-content">
         <div class="maximize-modal-toolbar">
           <span class="maximize-modal-title">{{ modalTitle }}</span>
-          <button @click="toggleMaximizeModal" class="maximize-modal-close" title="Close">
+          <button @click="toggleMaximizeModal" class="maximize-modal-close" v-tippy="`Close`">
             <img :src="DiffCloseIcon" alt="Close" width="16" height="16" />
           </button>
         </div>

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -105,13 +105,13 @@ onBeforeUnmount(() => {
 
 .maximize-button {
   position: absolute;
-  right: 6px;
-  top: 6px;
+  right: 0.375rem;
+  top: 0.375rem;
   z-index: 10;
   background-color: rgba(255, 255, 255, 0.7);
   border: 1px solid #ddd;
   border-radius: 3px;
-  padding: 4px;
+  padding: 0.25rem;
   cursor: pointer;
   opacity: 0.6;
   transition: opacity 0.2s ease;
@@ -149,7 +149,7 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 15px;
+  padding: 0.625rem 0.9375rem;
   background-color: #f8f8f8;
   border-bottom: 1px solid #ddd;
 }
@@ -163,7 +163,7 @@ onBeforeUnmount(() => {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 5px;
+  padding: 0.3125rem;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -58,7 +58,7 @@ onBeforeUnmount(() => {
 <template>
   <div class="code-editor-wrapper">
     <!-- Regular CodeEditor with maximize button in toolbarRight -->
-    <CodeEditor v-model="modelValue" :language="language" :read-only="readOnly" :show-gutter="showGutter" :show-copy-to-clipboard="showCopyToClipboard" :aria-label="ariaLabel" :extensions="extensions">
+    <CodeEditor class="maximazable-code-editor--inline-instance" v-model="modelValue" :language="language" :read-only="readOnly" :show-gutter="showGutter" :show-copy-to-clipboard="showCopyToClipboard" :aria-label="ariaLabel" :extensions="extensions">
       <template #toolbarLeft>
         <slot name="toolbarLeft"></slot>
       </template>
@@ -76,7 +76,7 @@ onBeforeUnmount(() => {
           <img class="maximize-modal-close" :src="DiffCloseIcon" alt="Close" @click="toggleMaximizeModal" title="Close" />
         </div>
         <div class="maximize-modal-body">
-          <CodeEditor v-model="modelValue" :language="language" :read-only="readOnly" :show-copy-to-clipboard="true" :show-gutter="true" :aria-label="ariaLabel" :extensions="[]" />
+          <CodeEditor class="maximazable-code-editor--pop-up-instance" v-model="modelValue" :language="language" :read-only="readOnly" :show-copy-to-clipboard="true" :show-gutter="true" :aria-label="ariaLabel" :extensions="[]" />
         </div>
       </div>
     </div>

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -13,7 +13,6 @@ withDefaults(
     language?: CodeLanguage;
     readOnly?: boolean;
     showGutter?: boolean;
-    showCopyToClipboard?: boolean;
     ariaLabel?: string;
     extensions?: Extension[];
     modalTitle?: string;
@@ -21,7 +20,6 @@ withDefaults(
   {
     readOnly: false,
     showGutter: false,
-    showCopyToClipboard: false,
     extensions: () => [],
     modalTitle: "Code View",
   }
@@ -72,16 +70,7 @@ onBeforeUnmount(() => {
         <img :src="DiffMaximizeIcon" alt="Maximize" width="14" height="14" />
       </button>
 
-      <CodeEditor
-        class="maximazable-code-editor--inline-instance"
-        v-model="modelValue"
-        :language="language"
-        :read-only="readOnly"
-        :show-gutter="showGutter"
-        :show-copy-to-clipboard="showCopyToClipboard"
-        :aria-label="ariaLabel"
-        :extensions="extensions"
-      >
+      <CodeEditor class="maximazable-code-editor--inline-instance" v-model="modelValue" :language="language" :read-only="readOnly" :show-gutter="showGutter" :show-copy-to-clipboard="false" :aria-label="ariaLabel" :extensions="extensions">
         <template #toolbarLeft>
           <slot name="toolbarLeft"></slot>
         </template>
@@ -151,7 +140,6 @@ onBeforeUnmount(() => {
   border: none;
 }
 
-/* Modal styles copied from DiffViewer */
 .maximize-modal {
   position: fixed;
   top: 0;

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -65,17 +65,17 @@ onBeforeUnmount(() => {
   <div class="code-editor-wrapper" @mouseenter="onEditorMouseEnter" @mouseleave="onEditorMouseLeave">
     <!-- Regular CodeEditor -->
     <div class="editor-container">
-      <!-- Maximize Button (shown on hover) -->
-      <button v-if="showMaximizeButton" @click="toggleMaximizeModal" class="maximize-button" title="Maximize view">
-        <img :src="DiffMaximizeIcon" alt="Maximize" width="14" height="14" />
-      </button>
-
       <CodeEditor class="maximazable-code-editor--inline-instance" v-model="modelValue" :language="language" :read-only="readOnly" :show-gutter="showGutter" :show-copy-to-clipboard="false" :aria-label="ariaLabel" :extensions="extensions">
         <template #toolbarLeft>
           <slot name="toolbarLeft"></slot>
         </template>
         <template #toolbarRight>
-          <slot name="toolbarRight"></slot>
+          <slot name="toolbarRight">
+            <!-- Maximize Button (shown on hover) -->
+            <button v-if="showMaximizeButton" @click="toggleMaximizeModal" class="maximize-button" title="Maximize view">
+              <img :src="DiffMaximizeIcon" alt="Maximize" width="14" height="14" />
+            </button>
+          </slot>
         </template>
       </CodeEditor>
     </div>
@@ -119,25 +119,6 @@ onBeforeUnmount(() => {
 
 .maximize-button:hover {
   opacity: 1;
-}
-
-:deep(.wrapper.maximazable-code-editor--inline-instance) {
-  border: none;
-  border-radius: 0;
-  margin-top: 0;
-}
-
-:deep(.wrapper.maximazable-code-editor--inline-instance .toolbar) {
-  border: none;
-  border-radius: 0;
-  background-color: transparent;
-  padding: 0;
-  margin-bottom: 0;
-}
-
-:deep(.wrapper.maximazable-code-editor--inline-instance .cm-editor) {
-  /* Override any borders from the default theme */
-  border: none;
 }
 
 .maximize-modal {

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -72,7 +72,7 @@ onBeforeUnmount(() => {
         <template #toolbarRight>
           <slot name="toolbarRight">
             <!-- Maximize Button (shown on hover) -->
-            <button v-if="showMaximizeButton" @click="toggleMaximizeModal" class="maximize-button" title="Maximize view">
+            <button v-if="showMaximizeButton" @click="toggleMaximizeModal" class="maximize-button" v-tippy="`Maximize view`">
               <img :src="DiffMaximizeIcon" alt="Maximize" width="14" height="14" />
             </button>
           </slot>

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -156,7 +156,7 @@ onBeforeUnmount(() => {
 
 .maximize-modal-title {
   font-weight: bold;
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .maximize-modal-close {

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -155,8 +155,8 @@ onBeforeUnmount(() => {
 
 .maximize-modal-content {
   background-color: white;
-  width: calc(100% - 40px);
-  height: calc(100% - 40px);
+  width: 95vw;
+  height: 90vh;
   border-radius: 4px;
   overflow: hidden;
   display: flex;

--- a/src/Frontend/src/components/MaximizableCodeEditor.vue
+++ b/src/Frontend/src/components/MaximizableCodeEditor.vue
@@ -29,10 +29,20 @@ withDefaults(
 
 // Component state for maximize functionality
 const showMaximizeModal = ref(false);
+const showMaximizeButton = ref(false);
 
 // Handle maximize functionality
 const toggleMaximizeModal = () => {
   showMaximizeModal.value = !showMaximizeModal.value;
+};
+
+// Handle mouse enter/leave for showing maximize button
+const onEditorMouseEnter = () => {
+  showMaximizeButton.value = true;
+};
+
+const onEditorMouseLeave = () => {
+  showMaximizeButton.value = false;
 };
 
 // Handle ESC key to close modal
@@ -54,24 +64,41 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="code-editor-wrapper">
-    <!-- Regular CodeEditor with maximize button in toolbarRight -->
-    <CodeEditor class="maximazable-code-editor--inline-instance" v-model="modelValue" :language="language" :read-only="readOnly" :show-gutter="showGutter" :show-copy-to-clipboard="showCopyToClipboard" :aria-label="ariaLabel" :extensions="extensions">
-      <template #toolbarLeft>
-        <slot name="toolbarLeft"></slot>
-      </template>
-      <template #toolbarRight>
-        <slot name="toolbarRight"></slot>
-        <img class="maximize-icon-inline" :src="DiffMaximizeIcon" alt="Maximize" @click="toggleMaximizeModal" title="Maximize view" />
-      </template>
-    </CodeEditor>
+  <div class="code-editor-wrapper" @mouseenter="onEditorMouseEnter" @mouseleave="onEditorMouseLeave">
+    <!-- Regular CodeEditor -->
+    <div class="editor-container">
+      <!-- Maximize Button (shown on hover) -->
+      <button v-if="showMaximizeButton" @click="toggleMaximizeModal" class="maximize-button" title="Maximize view">
+        <img :src="DiffMaximizeIcon" alt="Maximize" width="14" height="14" />
+      </button>
+
+      <CodeEditor
+        class="maximazable-code-editor--inline-instance"
+        v-model="modelValue"
+        :language="language"
+        :read-only="readOnly"
+        :show-gutter="showGutter"
+        :show-copy-to-clipboard="showCopyToClipboard"
+        :aria-label="ariaLabel"
+        :extensions="extensions"
+      >
+        <template #toolbarLeft>
+          <slot name="toolbarLeft"></slot>
+        </template>
+        <template #toolbarRight>
+          <slot name="toolbarRight"></slot>
+        </template>
+      </CodeEditor>
+    </div>
 
     <!-- Maximize modal for CodeEditor -->
     <div v-if="showMaximizeModal" class="maximize-modal">
       <div class="maximize-modal-content">
         <div class="maximize-modal-toolbar">
           <span class="maximize-modal-title">{{ modalTitle }}</span>
-          <img class="maximize-modal-close" :src="DiffCloseIcon" alt="Close" @click="toggleMaximizeModal" title="Close" />
+          <button @click="toggleMaximizeModal" class="maximize-modal-close" title="Close">
+            <img :src="DiffCloseIcon" alt="Close" width="16" height="16" />
+          </button>
         </div>
         <div class="maximize-modal-body">
           <CodeEditor class="maximazable-code-editor--pop-up-instance" v-model="modelValue" :language="language" :read-only="readOnly" :show-copy-to-clipboard="true" :show-gutter="true" :aria-label="ariaLabel" :extensions="[]" />
@@ -87,18 +114,41 @@ onBeforeUnmount(() => {
   width: 100%;
 }
 
-/* Maximize icon styles */
-.maximize-icon-inline {
-  width: 14px;
-  height: 14px;
+.maximize-button {
+  position: absolute;
+  right: 6px;
+  top: 6px;
+  z-index: 10;
+  background-color: rgba(255, 255, 255, 0.7);
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 4px;
   cursor: pointer;
-  opacity: 0.7;
+  opacity: 0.6;
   transition: opacity 0.2s ease;
-  margin-left: 8px;
 }
 
-.maximize-icon-inline:hover {
+.maximize-button:hover {
   opacity: 1;
+}
+
+:deep(.wrapper.maximazable-code-editor--inline-instance) {
+  border: none;
+  border-radius: 0;
+  margin-top: 0;
+}
+
+:deep(.wrapper.maximazable-code-editor--inline-instance .toolbar) {
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  padding: 0;
+  margin-bottom: 0;
+}
+
+:deep(.wrapper.maximazable-code-editor--inline-instance .cm-editor) {
+  /* Override any borders from the default theme */
+  border: none;
 }
 
 /* Modal styles copied from DiffViewer */
@@ -144,19 +194,22 @@ onBeforeUnmount(() => {
   background: none;
   border: none;
   cursor: pointer;
-  width: 16px;
-  height: 16px;
+  padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .maximize-modal-body {
   flex: 1;
   overflow: auto;
-  padding: 15px;
+  padding: 0;
 }
 
 /* Ensure the CodeEditor wrapper fills the modal body */
 .maximize-modal-body :deep(.wrapper) {
-  height: calc(100% - 20px);
+  height: 100%;
+  border-radius: 0;
 }
 
 .maximize-modal-body :deep(.cm-editor),

--- a/src/Frontend/src/components/messages2/DiffViewer.vue
+++ b/src/Frontend/src/components/messages2/DiffViewer.vue
@@ -166,8 +166,8 @@ onBeforeUnmount(() => {
 
 .maximize-modal-content {
   background-color: white;
-  width: calc(100% - 40px);
-  height: calc(100% - 40px);
+  width: 95vw;
+  height: 90vh;
   border-radius: 4px;
   overflow: hidden;
   display: flex;

--- a/src/Frontend/src/components/messages2/DiffViewer.vue
+++ b/src/Frontend/src/components/messages2/DiffViewer.vue
@@ -186,7 +186,7 @@ onBeforeUnmount(() => {
 
 .maximize-modal-title {
   font-weight: bold;
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .maximize-modal-close {

--- a/src/Frontend/src/components/messages2/SagaDiagram.spec.ts
+++ b/src/Frontend/src/components/messages2/SagaDiagram.spec.ts
@@ -257,12 +257,16 @@ function rendercomponent({ initialState = {} }: { initialState?: { MessageStore?
         CodeEditor: true,
         CopyToClipboard: true,
       },
+      directives: {
+        // Add stub for tippy directive
+        tippy: () => {},
+      },
     },
   });
 
   const dslAPI: componentDSL = {
     action1: () => {
-      // Add actions here;dl;;lksd;lksd;lkdmdslm,.mc,.
+      // Add actions here;
     },
     assert: {
       NoSagaDataAvailableMessageIsShownWithMessage(message: RegExp) {

--- a/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
@@ -42,10 +42,7 @@ const body = computed(() => props.messageData.body.data.value || "");
   <div v-else-if="messageData.body.failed_to_load" class="message-data-box message-data-box-error">
     <span class="message-data-box-text--error">An error occurred while retrieving the message data</span>
   </div>
-  <div v-else-if="messageData.body.not_found" class="message-data-box message-data-box-error">
-    <span class="message-data-box-text--error">Message body not found</span>
-  </div>
-  <div v-else-if="!messageDataLoading && !messageData.body.data.value" class="message-data-box">
+  <div v-else-if="!messageDataLoading && (!messageData.body.data.value || messageData.body.not_found)" class="message-data-box">
     <span class="message-data-box-text--empty">Empty</span>
   </div>
   <div v-else-if="contentType.isSupported" class="message-data-box message-data-box-content">

--- a/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
@@ -4,19 +4,7 @@ import { storeToRefs } from "pinia";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import MaximizableCodeEditor from "@/components/MaximizableCodeEditor.vue";
 import { computed } from "vue";
-import { EditorView } from "@codemirror/view";
 import parseContentType from "@/composables/contentTypeParser";
-
-const messageDataBoxTheme = EditorView.baseTheme({
-  ".maximazable-code-editor--inline-instance .cm-editor": {
-    fontFamily: "monospace",
-    fontSize: "0.75rem",
-    backgroundColor: "#ffffff",
-  },
-  ".maximazable-code-editor--inline-instance .cm-scroller": {
-    backgroundColor: "#ffffff",
-  },
-});
 
 const props = defineProps<{
   messageData: SagaMessageData;
@@ -46,7 +34,7 @@ const body = computed(() => props.messageData.body.data.value || "");
     <span class="message-data-box-text--empty">Empty</span>
   </div>
   <div v-else-if="contentType.isSupported" class="message-data-box message-data-box-content">
-    <MaximizableCodeEditor :model-value="body" :language="contentType.language" :readOnly="true" :showGutter="false" :modalTitle="modalTitle" :extensions="[messageDataBoxTheme]" />
+    <MaximizableCodeEditor :model-value="body" :language="contentType.language" :readOnly="true" :showGutter="false" :modalTitle="modalTitle" />
   </div>
   <div v-else class="message-data-box message-data-box-error">
     <span class="message-data-box-text--unsupported">Message body cannot be displayed because content type "{{ messageData.body.data.content_type }}" is not supported.</span>
@@ -109,5 +97,24 @@ const body = computed(() => props.messageData.body.data.value || "");
 .message-data-box-error {
   padding: 1rem;
   justify-content: center;
+}
+.message-data-box-content :deep(.wrapper.maximazable-code-editor--inline-instance) {
+  border: none;
+  border-radius: 0;
+  margin-top: 0;
+  font-size: 0.75rem;
+}
+
+.message-data-box-content :deep(.wrapper.maximazable-code-editor--inline-instance .toolbar) {
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  padding: 0;
+  margin-bottom: 0;
+}
+
+.message-data-box-content :deep(.wrapper.maximazable-code-editor--inline-instance .cm-editor) {
+  /* Override any borders from the default theme */
+  border: none;
 }
 </style>

--- a/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
@@ -6,6 +6,18 @@ import MaximizableCodeEditor from "@/components/MaximizableCodeEditor.vue";
 import { computed } from "vue";
 import { CodeLanguage } from "@/components/codeEditorTypes";
 import { parse, stringify } from "lossless-json";
+import { EditorView } from "@codemirror/view";
+
+const messageDataBoxTheme = EditorView.baseTheme({
+  ".maximazable-code-editor--inline-instance .cm-editor": {
+    fontFamily: "monospace",
+    fontSize: "0.75rem",
+    backgroundColor: "#ffffff",
+  },
+  ".maximazable-code-editor--inline-instance .cm-scroller": {
+    backgroundColor: "#ffffff",
+  },
+});
 
 const props = defineProps<{
   messageData: SagaMessageData;
@@ -45,7 +57,7 @@ const editorLanguage = computed<CodeLanguage>(() => {
     <span class="message-data-box-text--empty">Empty</span>
   </div>
   <div v-else class="message-data-box message-data-box-content">
-    <MaximizableCodeEditor :model-value="formattedData || ''" :language="editorLanguage" :read-only="true" :show-gutter="false" modalTitle="Message Data" />
+    <MaximizableCodeEditor :model-value="formattedData || ''" :language="editorLanguage" :read-only="true" :show-gutter="false" modalTitle="Message Data" :extensions="[messageDataBoxTheme]" />
   </div>
 </template>
 

--- a/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/MessageDataBox.vue
@@ -21,7 +21,12 @@ const messageDataBoxTheme = EditorView.baseTheme({
 
 const props = defineProps<{
   messageData: SagaMessageData;
+  maximizedTitle?: string;
 }>();
+
+const modalTitle = computed(() => {
+  return props.maximizedTitle ? `Message Data - ${props.maximizedTitle}` : "Message Data";
+});
 
 const sagaDiagramStore = useSagaDiagramStore();
 const { messageDataLoading } = storeToRefs(sagaDiagramStore);
@@ -39,7 +44,6 @@ const formattedData = computed(() => {
   return props.messageData.data;
 });
 
-// Ensure language is properly typed as CodeLanguage
 const editorLanguage = computed<CodeLanguage>(() => {
   const type = props.messageData.type?.toLowerCase();
   return (type === "xml" ? "xml" : "json") as CodeLanguage;
@@ -51,13 +55,13 @@ const editorLanguage = computed<CodeLanguage>(() => {
     <LoadingSpinner />
   </div>
   <div v-else-if="messageData.error" class="message-data-box message-data-box-error">
-    <span class="message-data-box-text--error">An error occurred while parsing the message data</span>
+    <span class="message-data-box-text--error">An error occurred while retrieving the message data</span>
   </div>
   <div v-else-if="!messageDataLoading && messageData.data === ''" class="message-data-box">
     <span class="message-data-box-text--empty">Empty</span>
   </div>
   <div v-else class="message-data-box message-data-box-content">
-    <MaximizableCodeEditor :model-value="formattedData || ''" :language="editorLanguage" :read-only="true" :show-gutter="false" modalTitle="Message Data" :extensions="[messageDataBoxTheme]" />
+    <MaximizableCodeEditor :model-value="formattedData || ''" :language="editorLanguage" :read-only="true" :show-gutter="false" :modalTitle="modalTitle" :extensions="[messageDataBoxTheme]" />
   </div>
 </template>
 

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
@@ -1,13 +1,13 @@
 import { SagaHistory } from "@/resources/SagaHistory";
 import { typeToName } from "@/composables/typeHumanizer";
-import { SagaMessageData, SagaMessageDataItem } from "@/stores/SagaDiagramStore";
+import { SagaMessageData } from "@/stores/SagaDiagramStore";
 import { getTimeoutFriendly } from "@/composables/deliveryDelayParser";
 
 export interface SagaMessageViewModel {
   MessageId: string;
   MessageFriendlyTypeName: string;
   FormattedTimeSent: string;
-  Data: SagaMessageDataItem[];
+  Data: SagaMessageData;
   IsEventMessage: boolean;
   IsCommandMessage: boolean;
 }
@@ -78,7 +78,7 @@ export function parseSagaUpdates(sagaHistory: SagaHistory | null, messagesData: 
       const initiatingMessageTimestamp = new Date(update.initiating_message?.time_sent || Date.now());
 
       // Find message data for initiating message
-      const initiatingMessageData = update.initiating_message ? messagesData.find((m) => m.message_id === update.initiating_message.message_id)?.data || [] : [];
+      const initiatingMessageData = update.initiating_message ? findMessageData(messagesData, update.initiating_message.message_id) : createEmptyMessageData();
 
       // Create common base message objects with shared properties
       const outgoingMessages = update.outgoing_messages.map((msg) => {
@@ -89,7 +89,7 @@ export function parseSagaUpdates(sagaHistory: SagaHistory | null, messagesData: 
         const isEventMessage = msg.intent === "Publish";
 
         // Find corresponding message data
-        const messageData = messagesData.find((m) => m.message_id === msg.message_id)?.data || [];
+        const messageData = findMessageData(messagesData, msg.message_id);
         return {
           MessageType: msg.message_type || "",
           MessageId: msg.message_id,
@@ -159,4 +159,20 @@ export function parseSagaUpdates(sagaHistory: SagaHistory | null, messagesData: 
   }
 
   return updates;
+}
+
+// Helper function to find message data or create empty data if not found
+function findMessageData(messagesData: SagaMessageData[], messageId: string): SagaMessageData {
+  const messageData = messagesData.find((m) => m.message_id === messageId);
+  return messageData || createEmptyMessageData();
+}
+
+// Helper function to create an empty message data object
+function createEmptyMessageData(): SagaMessageData {
+  return {
+    message_id: "",
+    data: "",
+    type: "json",
+    error: false,
+  };
 }

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
@@ -171,8 +171,11 @@ function findMessageData(messagesData: SagaMessageData[], messageId: string): Sa
 function createEmptyMessageData(): SagaMessageData {
   return {
     message_id: "",
-    data: "",
-    type: "json",
-    error: false,
+    body: {
+      data: {},
+      loading: false,
+      failed_to_load: false,
+      not_found: false,
+    },
   };
 }

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
@@ -16,7 +16,7 @@ export interface InitiatingMessageViewModel {
   IsSagaTimeoutMessage: boolean;
   FormattedMessageTimestamp: string;
   IsEventMessage: boolean;
-  MessageData: SagaMessageDataItem[];
+  MessageData: SagaMessageData;
   HasRelatedTimeoutRequest?: boolean;
   MessageId: string;
 }

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaDiagramParser.ts
@@ -5,14 +5,14 @@ import { getTimeoutFriendly } from "@/composables/deliveryDelayParser";
 
 export interface SagaMessageViewModel {
   MessageId: string;
-  MessageFriendlyTypeName: string;
+  FriendlyTypeName: string;
   FormattedTimeSent: string;
   Data: SagaMessageData;
   IsEventMessage: boolean;
   IsCommandMessage: boolean;
 }
 export interface InitiatingMessageViewModel {
-  MessageType: string;
+  FriendlyTypeName: string;
   IsSagaTimeoutMessage: boolean;
   FormattedMessageTimestamp: string;
   IsEventMessage: boolean;
@@ -97,7 +97,7 @@ export function parseSagaUpdates(sagaHistory: SagaHistory | null, messagesData: 
           HasTimeout: hasTimeout,
           TimeoutSeconds: timeoutSeconds,
           TimeoutFriendly: getTimeoutFriendly(delivery_delay),
-          MessageFriendlyTypeName: typeToName(msg.message_type || ""),
+          FriendlyTypeName: typeToName(msg.message_type || ""),
           Data: messageData,
           IsEventMessage: isEventMessage,
           IsCommandMessage: !isEventMessage,
@@ -132,8 +132,8 @@ export function parseSagaUpdates(sagaHistory: SagaHistory | null, messagesData: 
         Status: update.status,
         StatusDisplay: update.status === "new" ? "Saga Initiated" : "Saga Updated",
         InitiatingMessage: <InitiatingMessageViewModel>{
+          FriendlyTypeName: typeToName(update.initiating_message?.message_type || "Unknown Message") || "",
           MessageId: update.initiating_message?.message_id || "",
-          MessageType: typeToName(update.initiating_message?.message_type || "Unknown Message") || "",
           FormattedMessageTimestamp: `${initiatingMessageTimestamp.toLocaleDateString()} ${initiatingMessageTimestamp.toLocaleTimeString()}`,
           MessageData: initiatingMessageData,
           IsEventMessage: update.initiating_message?.intent === "Publish",

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingMessage.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingMessage.vue
@@ -27,11 +27,11 @@ const props = defineProps<{
     }"
   >
     <img class="saga-icon saga-icon--side-cell" :src="message.IsEventMessage ? EventIcon : CommandIcon" :alt="message.IsEventMessage ? 'Event' : 'Command'" />
-    <h2 class="message-title">{{ message.MessageFriendlyTypeName }}</h2>
+    <h2 class="message-title">{{ message.FriendlyTypeName }}</h2>
     <div class="timestamp">{{ message.FormattedTimeSent }}</div>
   </div>
   <div v-if="showMessageData" class="message-data message-data--active">
-    <MessageDataBox :messageData="message.Data" />
+    <MessageDataBox :messageData="message.Data" :maximizedTitle="message.FriendlyTypeName" />
   </div>
 </template>
 

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingTimeoutMessage.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingTimeoutMessage.vue
@@ -46,7 +46,7 @@ watch(
     <div class="cell cell--center">
       <div class="cell-inner cell-inner-line">
         <img class="saga-icon saga-icon--center-cell saga-icon--overlap" :src="SagaTimeoutIcon" alt="" />
-        <a v-if="message.HasBeenProcessed" class="timeout-status" href="#" @click.prevent="navigateToTimeout" aria-label="timeout requested">Timeout Requested = {{ message.TimeoutFriendly }}</a>
+        <a v-if="message.HasBeenProcessed" v-tippy="`Scroll to invoked timeout`" class="timeout-status" href="#" @click.prevent="navigateToTimeout" aria-label="timeout requested">Timeout Requested = {{ message.TimeoutFriendly }}</a>
         <span v-else class="timeout-status" aria-label="timeout requested">Timeout Requested = {{ message.TimeoutFriendly }}</span>
       </div>
     </div>

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingTimeoutMessage.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaOutgoingTimeoutMessage.vue
@@ -66,11 +66,11 @@ watch(
         }"
       >
         <img class="saga-icon saga-icon--side-cell" :src="TimeoutIcon" alt="" />
-        <h2 class="message-title" aria-label="timeout message type">{{ message.MessageFriendlyTypeName }}</h2>
+        <h2 class="message-title" aria-label="timeout message type">{{ message.FriendlyTypeName }}</h2>
         <div class="timestamp" aria-label="timeout message timestamp">{{ message.FormattedTimeSent }}</div>
       </div>
       <div v-if="showMessageData" class="message-data message-data--active">
-        <MessageDataBox :messageData="message.Data" />
+        <MessageDataBox :messageData="message.Data" :maximizedTitle="message.FriendlyTypeName" />
       </div>
     </div>
   </div>

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -18,19 +18,14 @@ import TimeoutIcon from "@/assets/timeout.svg";
 import EventIcon from "@/assets/event.svg";
 import SagaTimeoutIcon from "@/assets/SagaTimeoutIcon.svg";
 
-// Define the monospace theme for CodeEditor
+// Define monospace theme with specific selectors for this component
 const monospaceTheme = EditorView.baseTheme({
-  "&": {
+  ".maximazable-code-editor--inline-instance .cm-editor": {
     fontFamily: "monospace",
     fontSize: "0.75rem",
     backgroundColor: "#f2f2f2",
   },
-  ".cm-editor": {
-    fontFamily: "monospace",
-    fontSize: "0.75rem",
-    backgroundColor: "#f2f2f2",
-  },
-  ".cm-scroller": {
+  ".maximazable-code-editor--inline-instance .cm-scroller": {
     backgroundColor: "#f2f2f2",
   },
 });
@@ -428,7 +423,7 @@ const hasStateChanges = computed(() => {
 }
 
 /* Override CodeEditor wrapper styles */
-.json-container :deep(.wrapper) {
+.json-container :deep(.wrapper.maximazable-code-editor--inline-instance) {
   border-radius: 0;
   border: none;
   background-color: #f2f2f2;

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -194,7 +194,7 @@ const hasStateChanges = computed(() => {
 
             <!-- Initial state display -->
             <div v-else-if="update.IsFirstNode" class="json-container json-container--first-node">
-              <MaximizableCodeEditor :model-value="sagaUpdateStateChanges.formattedState || ''" language="json" :showGutter="false" modalTitle="Saga Initialized" :extensions="[monospaceTheme]" />
+              <MaximizableCodeEditor :model-value="sagaUpdateStateChanges.formattedState || ''" language="json" :showGutter="false" modalTitle="Initial Saga State" :extensions="[monospaceTheme]" />
             </div>
 
             <!-- No changes message -->

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -151,7 +151,7 @@ const hasStateChanges = computed(() => {
           :data-message-id="update.InitiatingMessage.IsSagaTimeoutMessage ? update.MessageId : ''"
         >
           <img class="saga-icon saga-icon--side-cell" :src="update.InitiatingMessage.IsSagaTimeoutMessage ? TimeoutIcon : update.InitiatingMessage.IsEventMessage ? EventIcon : CommandIcon" alt="" />
-          <h2 class="message-title" aria-label="initiating message type">{{ update.InitiatingMessage.MessageType }}</h2>
+          <h2 class="message-title" aria-label="initiating message type">{{ update.InitiatingMessage.FriendlyTypeName }}</h2>
           <div class="timestamp" aria-label="initiating message timestamp">{{ update.InitiatingMessage.FormattedMessageTimestamp }}</div>
         </div>
       </div>
@@ -176,7 +176,7 @@ const hasStateChanges = computed(() => {
       <div class="cell cell--side cell--left-border cell--aling-top">
         <div v-if="showMessageData" class="message-data message-data--active">
           <!-- Generic message data box -->
-          <MessageDataBox v-if="update.InitiatingMessage.MessageType" :messageData="update.InitiatingMessage.MessageData" />
+          <MessageDataBox v-if="update.InitiatingMessage" :messageData="update.InitiatingMessage.MessageData" :maximizedTitle="update.InitiatingMessage.FriendlyTypeName" />
         </div>
       </div>
 
@@ -194,7 +194,7 @@ const hasStateChanges = computed(() => {
 
             <!-- Initial state display -->
             <div v-else-if="update.IsFirstNode" class="json-container json-container--first-node">
-              <MaximizableCodeEditor :model-value="sagaUpdateStateChanges.formattedState || ''" language="json" :showCopyToClipboard="false" :showGutter="false" modalTitle="Saga Initialized" :extensions="[monospaceTheme]" />
+              <MaximizableCodeEditor :model-value="sagaUpdateStateChanges.formattedState || ''" language="json" :showGutter="false" modalTitle="Saga Initialized" :extensions="[monospaceTheme]" />
             </div>
 
             <!-- No changes message -->

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -369,7 +369,6 @@ const hasStateChanges = computed(() => {
   padding: 0.2rem;
   background-color: #ffffff;
   border: solid 1px #cccccc;
-  font-size: 0.75rem;
 }
 
 .message-data--active {
@@ -428,7 +427,19 @@ const hasStateChanges = computed(() => {
   border: none;
   background-color: #f2f2f2;
   margin-top: 0;
+  font-size: 0.75rem;
 }
+.json-container :deep(.wrapper.maximazable-code-editor--inline-instance .toolbar) {
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  padding: 0;
+  margin-bottom: 0;
+}
+
+/* :deep(.maximazable-code-editor--inline-instance .cm-scroller) {
+  background-color: #f2f2f2;
+} */
 
 .no-changes-message {
   padding: 1rem;

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -4,7 +4,7 @@ import MessageDataBox from "./MessageDataBox.vue";
 import SagaOutgoingTimeoutMessage from "./SagaOutgoingTimeoutMessage.vue";
 import SagaOutgoingMessage from "./SagaOutgoingMessage.vue";
 import DiffViewer from "@/components/messages2/DiffViewer.vue";
-import CodeEditor from "@/components/CodeEditor.vue";
+import MaximizableCodeEditor from "@/components/MaximizableCodeEditor.vue";
 import { useSagaDiagramStore } from "@/stores/SagaDiagramStore";
 import { ref, watch, computed } from "vue";
 import { EditorView } from "@codemirror/view";
@@ -34,13 +34,6 @@ const monospaceTheme = EditorView.baseTheme({
     backgroundColor: "#f2f2f2",
   },
 });
-
-// Define types for JSON values and properties
-type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
-interface JsonObject {
-  [key: string]: JsonValue;
-}
-type JsonArray = Array<JsonValue>;
 
 const props = defineProps<{
   update: SagaUpdateViewModel;
@@ -206,7 +199,7 @@ const hasStateChanges = computed(() => {
 
             <!-- Initial state display -->
             <div v-else-if="update.IsFirstNode" class="json-container json-container--first-node">
-              <CodeEditor :model-value="sagaUpdateStateChanges.formattedState || ''" language="json" :showCopyToClipboard="false" :showGutter="false" :extensions="[monospaceTheme]" />
+              <MaximizableCodeEditor :model-value="sagaUpdateStateChanges.formattedState || ''" language="json" :showCopyToClipboard="false" :showGutter="false" modalTitle="Saga Initialized" :extensions="[monospaceTheme]" />
             </div>
 
             <!-- No changes message -->

--- a/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
+++ b/src/Frontend/src/components/messages2/SagaDiagram/SagaUpdateNode.vue
@@ -159,7 +159,16 @@ const hasStateChanges = computed(() => {
         <div class="cell-inner cell-inner-center cell-inner--align-bottom">
           <template v-if="update.InitiatingMessage.IsSagaTimeoutMessage">
             <img class="saga-icon saga-icon--center-cell" :src="SagaTimeoutIcon" alt="" />
-            <a v-if="update.InitiatingMessage.HasRelatedTimeoutRequest" href="#" @click.prevent="navigateToTimeoutRequest" class="saga-status-title saga-status-title--inline timeout-status" aria-label="timeout invoked"> Timeout Invoked </a>
+            <a
+              v-if="update.InitiatingMessage.HasRelatedTimeoutRequest"
+              v-tippy="`Scroll to timeout request`"
+              href="#"
+              @click.prevent="navigateToTimeoutRequest"
+              class="saga-status-title saga-status-title--inline timeout-status"
+              aria-label="timeout invoked"
+            >
+              Timeout Invoked
+            </a>
             <h2 v-else class="saga-status-title saga-status-title--inline timeout-status" aria-label="timeout invoked">Timeout Invoked</h2>
             <br />
           </template>

--- a/src/Frontend/src/stores/DataContainer.ts
+++ b/src/Frontend/src/stores/DataContainer.ts
@@ -1,0 +1,10 @@
+/**
+ * A container for data with loading states.
+ * Used to track loading, error, and not found states for data fetched from APIs.
+ */
+export interface DataContainer<T> {
+  loading?: boolean;
+  failed_to_load?: boolean;
+  not_found?: boolean;
+  data: T;
+}

--- a/src/Frontend/src/stores/MessageStore.ts
+++ b/src/Frontend/src/stores/MessageStore.ts
@@ -11,13 +11,7 @@ import moment from "moment/moment";
 import { parse, stringify } from "lossless-json";
 import xmlFormat from "xml-formatter";
 import { useArchiveMessage, useRetryMessages, useUnarchiveMessage } from "@/composables/serviceFailedMessage";
-
-interface DataContainer<T> {
-  loading?: boolean;
-  failed_to_load?: boolean;
-  not_found?: boolean;
-  data: T;
-}
+import { DataContainer } from "./DataContainer";
 
 interface Model {
   id?: string;

--- a/src/Frontend/src/stores/SagaDiagramStore.ts
+++ b/src/Frontend/src/stores/SagaDiagramStore.ts
@@ -6,6 +6,7 @@ import Message from "@/resources/Message";
 import { parse, stringify } from "lossless-json";
 import xmlFormat from "xml-formatter";
 import { DataContainer } from "./DataContainer";
+import { useMessageStore } from "./MessageStore";
 
 export interface SagaMessageData {
   message_id: string;
@@ -24,11 +25,8 @@ export const useSagaDiagramStore = defineStore("SagaDiagramStore", () => {
   const scrollToTimeoutRequest = ref(false);
   const scrollToTimeout = ref(false);
   const MessageBodyEndpoint = "messages/{0}/body";
-
-  // Get message store to watch for changes
   const messageStore = useMessageStore();
 
-  // Watch for message_id changes in the MessageStore and update selectedMessageId
   watch(
     () => messageStore.state.data.message_id,
     (newMessageId) => {


### PR DESCRIPTION
TODO:
- [x] improve styles for the maximize button in maximizable control
- [x] Test with XML

Potential improvements:

- [ ] Extraction of the logic to load and parse a message body into a composable to be reused by Messagestore and SagaDiagramStore
- [ ] Potential reusable component for displaying the message body, to be used in BodyView.vue and MessageDataBox.vue - Both can also be maximizable 