### PR TITLE
Allow users to see more diagram

### DIFF
--- a/src/Frontend/src/components/messages2/FlowDiagram/FlowDiagram.vue
+++ b/src/Frontend/src/components/messages2/FlowDiagram/FlowDiagram.vue
@@ -222,7 +222,7 @@ const selectedErrorColor = hexToCSSFilter("#e8e6e8").filter;
     <div v-if="store.conversationData.failed_to_load" class="alert alert-info">FlowDiagram data is unavailable.</div>
     <LoadingSpinner v-else-if="store.conversationData.loading" />
     <div v-else id="tree-container">
-      <VueFlow :nodes="nodes" :edges="edges" :min-zoom="0.1" :max-zoom="1.2" :only-render-visible-elements="true" @nodes-initialized="layoutGraph">
+      <VueFlow :nodes="nodes" :edges="edges" :min-zoom="0.1" :max-zoom="1.2" :only-render-visible-elements="true" :zoom-on-scroll="false" @nodes-initialized="layoutGraph">
         <Controls :show-interactive="false" position="top-left" class="controls" />
         <template #node-message="{ id, data }: { id: string; data: NodeData }">
           <TextEllipses class="address" :text="`${data.sendingEndpoint.name}@${data.sendingEndpoint.host}`" />
@@ -284,8 +284,8 @@ const selectedErrorColor = hexToCSSFilter("#e8e6e8").filter;
 }
 
 #tree-container {
-  width: 92vw;
-  height: 70vh;
+  width: 100vw;
+  height: 100vh;
 }
 
 .sagas {


### PR DESCRIPTION
This PR removed the default setting of zooming in and out based on scrolling instead users use Ctrl+scroll or the + - controls. This allows much more fine control.

And also allows the user to use as much of their screen size as possible  to see the whole diagram by not confining it to a small window.

Here is a before UX:
![image](https://github.com/user-attachments/assets/ffb96d24-d3de-4326-9af6-e14724f0915e)

After UX:
![image](https://github.com/user-attachments/assets/732b4ce8-dbc3-495f-8905-7d05f1ffb520)


