### PR TITLE
Rename text file to something more generic

### DIFF
--- a/src/Frontend/src/components/messages/ExportMessageButton.vue
+++ b/src/Frontend/src/components/messages/ExportMessageButton.vue
@@ -13,7 +13,7 @@ async function exportMessage() {
   await showToastAfterOperation(
     async () => {
       const exportedString = await store.exportMessage();
-      useDownloadFileFromString(exportedString, "text/txt", "failedMessage.txt");
+      useDownloadFileFromString(exportedString, "text/txt", "message.txt");
     },
     TYPE.INFO,
     "Info",


### PR DESCRIPTION
The export message function is generic and is also applied in the message view. Therefore, failedMessage.txt is not exactly an appropriate name for the text file