### PR TITLE
No point in checking for Dependabot PRs anymore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ defaults:
     shell: pwsh
 jobs:
   windows-standalone:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: windows-latest
     steps:
       - name: Check for secrets
@@ -104,7 +103,6 @@ jobs:
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
   linux-container:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     name: linux-container
     defaults:


### PR DESCRIPTION
After the switch from Dependabot to Renovate, Renovate has the secrets to create signed Windows installers and other artifacts, so there's no need to check for the Dependabot actor which would not have those secrets.