### PR TITLE
Add back query parameter to preserve the current route when navigating a failed message list

### DIFF
--- a/src/Frontend/src/components/failedmessages/MessageList.vue
+++ b/src/Frontend/src/components/failedmessages/MessageList.vue
@@ -81,7 +81,10 @@ function labelClicked($event: MouseEvent, index: number) {
 }
 
 function navigateToMessage(messageId: string) {
-  router.push({ path: routeLinks.messages.failedMessage.link(messageId) });
+  router.push({
+    path: routeLinks.messages.failedMessage.link(messageId),
+    query: { back: router.currentRoute.value.fullPath },
+  });
 }
 
 defineExpose<IMessageList>({


### PR DESCRIPTION
Fix for #2566. Ensures we pass a back query parameter when viewing a failed message from a list of failed messages. This ensures the back button returns us back to the right place contextually given there are several ways to access a failed message from a failed message list.

**Before**
_Navigating to a failed message from all failed messages_
<img width="3730" height="2187" alt="image" src="https://github.com/user-attachments/assets/6dc2d29b-b241-431c-bf2f-318b95e96e74" />

_Navigating to a failed message from a failed message group_
<img width="3730" height="2187" alt="image" src="https://github.com/user-attachments/assets/c6c237ac-aff0-4589-a642-ae4648944ef8" />


**After**
_Navigating to a failed message from all failed messages_
<img width="3816" height="2149" alt="image" src="https://github.com/user-attachments/assets/5d11b192-702b-41b5-b405-0cdf333eda26" />
_Navigating to a failed message from a failed message group_
<img width="3808" height="2157" alt="image" src="https://github.com/user-attachments/assets/f6c25e0d-d105-4b57-bd07-6dae86d6a674" />