### PR TITLE
Add back query parameter to preserve the current route path when navi…

### DIFF
--- a/src/Frontend/src/components/failedmessages/MessageList.vue
+++ b/src/Frontend/src/components/failedmessages/MessageList.vue
@@ -81,7 +81,10 @@ function labelClicked($event: MouseEvent, index: number) {
 }
 
 function navigateToMessage(messageId: string) {
-  router.push({ path: routeLinks.messages.failedMessage.link(messageId) });
+  router.push({
+    path: routeLinks.messages.failedMessage.link(messageId),
+    query: { back: router.currentRoute.value.fullPath },
+  });
 }
 
 defineExpose<IMessageList>({


### PR DESCRIPTION
…gating to a failed message detail view.