### PR TITLE
Use 204 to express no_content

### DIFF
--- a/src/Frontend/src/components/messages/BodyView.vue
+++ b/src/Frontend/src/components/messages/BodyView.vue
@@ -25,6 +25,7 @@ const body = computed(() => bodyState.value.data.value);
     <div v-if="bodyState.not_found" class="alert alert-info">Could not find the message body. This could be because the message URL is invalid or the corresponding message was processed and is no longer tracked by ServiceControl.</div>
     <div v-else-if="bodyState.failed_to_load" class="alert alert-info">Message body unavailable.</div>
     <LoadingSpinner v-else-if="bodyState.loading" />
+    <div v-else-if="body === ''" class="alert alert-info">Body was too large and not stored. Edit ServiceControl/MaxBodySizeToStore to be larger in the ServiceControl configuration.</div>
     <CodeEditor v-else-if="body !== undefined && contentType.isSupported" :model-value="body" :language="contentType.language" :read-only="true" :show-gutter="true"></CodeEditor>
     <div v-else-if="body && !contentType.isSupported" class="alert alert-warning">Message body cannot be displayed because content type "{{ bodyState.data.content_type }}" is not supported.</div>
   </div>

--- a/src/Frontend/src/components/messages/BodyView.vue
+++ b/src/Frontend/src/components/messages/BodyView.vue
@@ -25,7 +25,7 @@ const body = computed(() => bodyState.value.data.value);
     <div v-if="bodyState.not_found" class="alert alert-info">Could not find the message body. This could be because the message URL is invalid or the corresponding message was processed and is no longer tracked by ServiceControl.</div>
     <div v-else-if="bodyState.failed_to_load" class="alert alert-info">Message body unavailable.</div>
     <LoadingSpinner v-else-if="bodyState.loading" />
-    <div v-else-if="body === ''" class="alert alert-info">Body was too large and not stored. Edit ServiceControl/MaxBodySizeToStore to be larger in the ServiceControl configuration.</div>
+    <div v-else-if="bodyState.data.no_content" class="alert alert-info">Body was too large and not stored. Edit ServiceControl/MaxBodySizeToStore to be larger in the ServiceControl configuration.</div>
     <CodeEditor v-else-if="body !== undefined && contentType.isSupported" :model-value="body" :language="contentType.language" :read-only="true" :show-gutter="true"></CodeEditor>
     <div v-else-if="body && !contentType.isSupported" class="alert alert-warning">Message body cannot be displayed because content type "{{ bodyState.data.content_type }}" is not supported.</div>
   </div>

--- a/src/Frontend/src/stores/MessageStore.ts
+++ b/src/Frontend/src/stores/MessageStore.ts
@@ -61,7 +61,7 @@ interface Model {
 
 export const useMessageStore = defineStore("MessageStore", () => {
   const headers = ref<DataContainer<Header[]>>({ data: [] });
-  const body = ref<DataContainer<{ value?: string; content_type?: string }>>({ data: {} });
+  const body = ref<DataContainer<{ value?: string; content_type?: string; no_content?: boolean }>>({ data: {} });
   const state = reactive<DataContainer<Model>>({ data: { failure_metadata: {}, failure_status: {}, dialog_status: {}, invoked_saga: {} } });
   let bodyLoadedId = "";
   let conversationLoadedId = "";
@@ -204,6 +204,12 @@ export const useMessageStore = defineStore("MessageStore", () => {
         return;
       }
 
+      if (response.status === 204) {
+        body.value.data.no_content = true;
+
+        return;
+      }
+
       const contentType = response.headers.get("content-type");
       body.value.data.content_type = contentType ?? "text/plain";
       body.value.data.value = await response.text();
@@ -288,7 +294,7 @@ export const useMessageStore = defineStore("MessageStore", () => {
 
     await downloadBody();
 
-    if (!(body.value.not_found || body.value.failed_to_load)) {
+    if (!(body.value.not_found || body.value.failed_to_load || body.value.data.no_content)) {
       exportString += "\n\nMESSAGE BODY\n";
       exportString += body.value.data.value;
     }


### PR DESCRIPTION
Suggested changes for #2585 

[ServiceControl returns NoContent (204) for bodies that are not stored](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControl/CompositeViews/Messages/GetMessagesController.cs#L93)

This has already been used by [ServiceInsight](https://github.com/Particular/ServiceInsight/blob/master/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs#L267)