### PR TITLE
Replace window.setTimeout with just setTimeout

### DIFF
--- a/src/Frontend/src/components/CopyToClipboard.vue
+++ b/src/Frontend/src/components/CopyToClipboard.vue
@@ -13,16 +13,16 @@ const props = withDefaults(
 );
 
 const tippyRef = useTemplateRef<TippyComponent | null>("tippyRef");
-const timeoutId = ref(0);
+const timeoutId = ref<ReturnType<typeof setTimeout>>();
 
 async function copyToClipboard() {
   await navigator.clipboard.writeText(props.value);
 
   tippyRef.value?.show();
-  timeoutId.value = window.setTimeout(() => tippyRef.value?.hide(), 3000);
+  timeoutId.value = setTimeout(() => tippyRef.value?.hide(), 3000);
 }
 
-watch(timeoutId, (_, previousTimeoutId) => window.clearTimeout(previousTimeoutId));
+watch(timeoutId, (_, previousTimeoutId) => clearTimeout(previousTimeoutId));
 </script>
 
 <template>

--- a/src/Frontend/src/components/RefreshConfig.vue
+++ b/src/Frontend/src/components/RefreshConfig.vue
@@ -49,7 +49,7 @@ watch(
   (newValue) => {
     if (newValue) {
       showSpinning.value = true;
-      window.setTimeout(() => {
+      setTimeout(() => {
         showSpinning.value = false;
       }, 1000);
     }

--- a/src/Frontend/src/composables/autoRefresh.ts
+++ b/src/Frontend/src/composables/autoRefresh.ts
@@ -4,12 +4,12 @@
  * @param defaultTimeout The time between refreshes in ms or null if no auto-refresh is desired
  */
 export default function useAutoRefresh(refreshAction: () => Promise<void>, defaultTimeout: number | null, startImmediately = true) {
-  let refreshInterval: number | null = null;
+  let refreshInterval: ReturnType<typeof setTimeout> | null = null;
   const timeout = { value: defaultTimeout };
 
   function stopTimer() {
     if (refreshInterval !== null) {
-      window.clearTimeout(refreshInterval);
+      clearTimeout(refreshInterval);
       refreshInterval = null;
     }
   }
@@ -18,7 +18,7 @@ export default function useAutoRefresh(refreshAction: () => Promise<void>, defau
     if (timeout.value === null) return;
 
     stopTimer();
-    refreshInterval = window.setTimeout(() => {
+    refreshInterval = setTimeout(() => {
       executeAndResetTimer();
     }, timeout.value as number);
   }

--- a/src/Frontend/src/views/throughputreport/endpoints/useHiddenFeature.ts
+++ b/src/Frontend/src/views/throughputreport/endpoints/useHiddenFeature.ts
@@ -8,7 +8,7 @@ const keyHandler = (event: KeyboardEvent) => {
 
 watchEffect((onCleanup) => {
   if (keys.value.length > 0) {
-    const timeout = window.setTimeout(() => keys.value.splice(0), 5000);
+    const timeout = setTimeout(() => keys.value.splice(0), 5000);
     onCleanup(() => clearTimeout(timeout));
   }
 });


### PR DESCRIPTION
This is to fix the flaky test failures that cause: Error: ReferenceError: window is not defined
 ❯ stopTimer src/composables/autoRefresh.ts:12:7
 ❯ startTimer src/composables/autoRefresh.ts:20:5
 ❯ executeAndResetTimer src/composables/autoRefresh.ts:31:7
 ❯ Timeout._onTimeout src/composables/autoRefresh.ts:22:7
 ❯ listOnTimeout node:internal/timers:588:17
 ❯ processTimers node:internal/timers:523:7