### PR TITLE
Update Windows runner version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
   build:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0


### PR DESCRIPTION
See https://github.com/Particular/ServicePulse/issues/2631#issuecomment-3337023987 to get the build unblocked