### PR TITLE
reunify metadata icon colours

### DIFF
--- a/src/Frontend/src/components/MetadataItem.vue
+++ b/src/Frontend/src/components/MetadataItem.vue
@@ -25,5 +25,6 @@ defineProps<Props>();
 
 .icon {
   margin-right: 0.25rem;
+  color: var(--reduced-emphasis);
 }
 </style>

--- a/src/Frontend/src/components/messages/MessageView.vue
+++ b/src/Frontend/src/components/messages/MessageView.vue
@@ -93,7 +93,7 @@ watch(
   },
   { immediate: true }
 );
-const endpointColor = hexToCSSFilter("#777F7F").filter;
+const endpointColor = hexToCSSFilter("#929E9E").filter;
 
 onMounted(() => {
   const { back, ...otherArgs } = route.query;


### PR DESCRIPTION
reduced-emphasis colour override had been lost during
- switch to font-awesome v6 on MessageView
- extraction of MetadataItem on DeletedGroupsView

The filter on the endpoint icon in MessageView had subsequently been updated to match the incorrect colour on the other icons. This change pulls it all back to be reduced-emphasis ("#929E9E")