### PR TITLE
Recommend ESLint IDE integration for lint workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This command generates a report indicating the percentage of statements, branche
 
 - `dev` - runs `vite` that starts the development server doing hot reload over source files
 - `build` - runs build script that outputs files to `..\app` folder
-- `lint` - checks with eslint all vue, ts, and js files
+- `lint` - checks with eslint all vue, ts, and js files. See [IDE setup](/docs/frontend/frontend-ide.md) to catch errors on save, or run manually before committing.
 - `type-check` - runs TypeScript in no emit mode
 
 #### Vitest

--- a/docs/frontend/frontend-ide.md
+++ b/docs/frontend/frontend-ide.md
@@ -31,21 +31,12 @@ You can change your KeyMap under `File | Settings | Keymap`. A good option is th
 
 ### Extensions
 
-#### Option 1
+#### Option 1 (Recommended)
 
-This option will run a formatter on every save, which is very quick
-
-- Install the [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension
-  - In VSCode `File | Preferences | Settings`, set default formatter to Prettier and check 'Format on Save'
-    ![Prettier](vscode-prettier.png)
-- Ensure you run `npm run lint` before committing code, to identify any style or code issues
-
-#### Option 2
-
-This option runs the formatter _and_ linter on every save. It will be slower than option 1, but the solution is rather small so the impact shouldn't be large.
+This option runs the formatter _and_ linter on every save, catching errors immediately in your IDE. The solution is small enough that the performance impact is negligible.
 
 - Install the [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension
-- enable the following user setting (there is no UI for this, but you can find the codeActionsOnSave setting in `File | Preferences | Settings` which will open the settings file at the correct location for you):
+- Enable the following user setting (there is no UI for this, but you can find the codeActionsOnSave setting in `File | Preferences | Settings` which will open the settings file at the correct location for you):
 
 ```json
 {
@@ -54,3 +45,12 @@ This option runs the formatter _and_ linter on every save. It will be slower tha
   }
 }
 ```
+
+#### Option 2
+
+This option will run a formatter on every save, which is very quick. Use this if you prefer a lighter-weight setup.
+
+- Install the [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension
+  - In VSCode `File | Preferences | Settings`, set default formatter to Prettier and check 'Format on Save'
+    ![Prettier](vscode-prettier.png)
+- **Important:** Run `npm run lint` before committing code to catch any style or code issues that Prettier doesn't cover


### PR DESCRIPTION
Updates documentation to recommend ESLint IDE integration (Option 1) for catching lint errors during development.

**Why ESLint IDE integration is recommended:**
The ESLint extension provides comprehensive coverage of all lint rules directly in the editor - you see errors as red squiggles as you type, before you even save. This includes not just formatting issues (which Prettier handles) but also code quality rules, unused variables, type issues, and Vue-specific rules that Prettier doesn't cover.

**Changes:**
- Swapped VSCode extension options to recommend ESLint over Prettier-only
- Updated README lint script description to reference IDE setup docs

**Context:**
Related to #2832 - addresses feedback about lint visibility in local development after removing ESLint from vite-plugin-checker (which doesn't yet support ESLint v10).