### PR TITLE
Fix Docker container MVID mismatch error

### DIFF
--- a/src/ServicePulse/ServicePulse.csproj
+++ b/src/ServicePulse/ServicePulse.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.11" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Fixes the MVID mismatch error when running the ServicePulse Docker container:

```
Process terminated. MVID mismatch between loaded assembly 'Microsoft.Extensions.FileProviders.Embedded' 
(MVID = {aec62d2b-06ce-4272-a78e-ef0089d64d08}) and an assembly with the same simple name embedded in 
the native image 'full-composite.r2r.dll' (MVID = {331dc36b-694a-4022-92d1-da09744c5fbe})
```

## Root Cause

The `aspnet:8.0-noble-chiseled-composite` base image contains R2R precompiled .NET 8.0.x framework assemblies. When the app references `Microsoft.Extensions.FileProviders.Embedded` version 10.0.3, there's an MVID conflict with the 8.0.x version baked into the composite image.

## Fix

Downgrade `Microsoft.Extensions.FileProviders.Embedded` from 10.0.3 to 8.0.11 to match the base image's framework version.

## Alternative Considered

Switching from `aspnet:8.0-noble-chiseled-composite` to `aspnet:8.0-noble-chiseled` (non-composite) would also work but has a slight cold-start performance penalty. The downgrade is preferred since the 10.0.3 package contains no meaningful changes for ServicePulse's use case.

## Testing

- ✅ Docker build succeeds
- ✅ Container starts without MVID error  
- ✅ HTTP requests return 200 OK