### PR TITLE
Upgrade ServicePulse to .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.1.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Set up Node.js
         uses: actions/setup-node@v6.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.1.0
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 10.0.x
       - name: Set up Node.js
         uses: actions/setup-node@v6.2.0
         with:
@@ -170,7 +170,7 @@ jobs:
             org.opencontainers.image.created=${{ steps.date.outputs.date }}
             org.opencontainers.image.title=ServicePulse
             org.opencontainers.image.description=ServicePulse provides real-time production monitoring for distributed applications. It monitors the health of a system's endpoints, detects processing errors, sends failed messages for reprocessing, and ensures the specific environment's needs are met, all in one consolidated dashboard.
-            org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
+            org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite
           annotations: |
             index:org.opencontainers.image.source=https://github.com/Particular/ServicePulse/tree/${{ github.sha }}
             index:org.opencontainers.image.authors="Particular Software"
@@ -182,7 +182,7 @@ jobs:
             index:org.opencontainers.image.created=${{ steps.date.outputs.date }}
             index:org.opencontainers.image.title=ServicePulse
             index:org.opencontainers.image.description=ServicePulse provides real-time production monitoring for distributed applications. It monitors the health of a system's endpoints, detects processing errors, sends failed messages for reprocessing, and ensures the specific environment's needs are met, all in one consolidated dashboard.
-            index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
+            index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite
           file: src/ServicePulse/Dockerfile
           tags: ghcr.io/particular/servicepulse:${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Frontend/test/specs/monitoring/sorting-endpoints.spec.ts
+++ b/src/Frontend/test/specs/monitoring/sorting-endpoints.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "vitest";
 import { test, describe } from "../../drivers/vitest/driver";
+import { waitFor } from "@testing-library/vue";
 import { groupEndpointsBy } from "./actions/groupEndpointsBy";
 import { endpointGroupNames } from "./questions/endpointGroupNames";
 import { endpointGroup } from "./questions/endpointGroup";
@@ -68,10 +69,12 @@ describe("FEATURE: Endpoint sorting", () => {
       await sortEndpointsBy({ column: columnName.ENDPOINTNAME });
 
       //Assert
-      expect(endpointGroupNames()).toEqual(["Universe.Solarsystem.Venus", "Universe.Solarsystem.Mercury", "Universe.Solarsystem.Earth"]);
-      expect(endpointGroup("Universe.Solarsystem.Venus").Endpoints).toEqual(["Endpoint4", "Endpoint3"]);
-      expect(endpointGroup("Universe.Solarsystem.Mercury").Endpoints).toEqual(["Endpoint2", "Endpoint1"]);
-      expect(endpointGroup("Universe.Solarsystem.Earth").Endpoints).toEqual(["Endpoint6", "Endpoint5"]);
+      await waitFor(() => {
+        expect(endpointGroupNames()).toEqual(["Universe.Solarsystem.Venus", "Universe.Solarsystem.Mercury", "Universe.Solarsystem.Earth"]);
+        expect(endpointGroup("Universe.Solarsystem.Venus").Endpoints).toEqual(["Endpoint4", "Endpoint3"]);
+        expect(endpointGroup("Universe.Solarsystem.Mercury").Endpoints).toEqual(["Endpoint2", "Endpoint1"]);
+        expect(endpointGroup("Universe.Solarsystem.Earth").Endpoints).toEqual(["Endpoint6", "Endpoint5"]);
+      });
     });
 
     test("EXAMPLE: Endpoints inside of the groups and group names should be sorted in ascending order when clicking twice on the endpoint name column title", async ({ driver }) => {
@@ -95,10 +98,12 @@ describe("FEATURE: Endpoint sorting", () => {
       await sortEndpointsBy({ column: columnName.ENDPOINTNAME }); //Click the column title again for ascending
 
       //Assert
-      expect(endpointGroupNames()).toEqual(["Universe.Solarsystem.Earth", "Universe.Solarsystem.Mercury", "Universe.Solarsystem.Venus"]);
-      expect(endpointGroup("Universe.Solarsystem.Earth").Endpoints).toEqual(["Endpoint5", "Endpoint6"]);
-      expect(endpointGroup("Universe.Solarsystem.Mercury").Endpoints).toEqual(["Endpoint1", "Endpoint2"]);
-      expect(endpointGroup("Universe.Solarsystem.Venus").Endpoints).toEqual(["Endpoint3", "Endpoint4"]);
+      await waitFor(() => {
+        expect(endpointGroupNames()).toEqual(["Universe.Solarsystem.Earth", "Universe.Solarsystem.Mercury", "Universe.Solarsystem.Venus"]);
+        expect(endpointGroup("Universe.Solarsystem.Earth").Endpoints).toEqual(["Endpoint5", "Endpoint6"]);
+        expect(endpointGroup("Universe.Solarsystem.Mercury").Endpoints).toEqual(["Endpoint1", "Endpoint2"]);
+        expect(endpointGroup("Universe.Solarsystem.Venus").Endpoints).toEqual(["Endpoint3", "Endpoint4"]);
+      });
     });
   });
 

--- a/src/Particular.PlatformSample.ServicePulse/Particular.PlatformSample.ServicePulse.csproj
+++ b/src/Particular.PlatformSample.ServicePulse/Particular.PlatformSample.ServicePulse.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <Description>Particular ServicePulse binaries for use by Particular.PlatformSample. Not intended for use outside of Particular.PlatformSample.</Description>

--- a/src/ServicePulse.Host/Hosting/HostArguments.cs
+++ b/src/ServicePulse.Host/Hosting/HostArguments.cs
@@ -355,8 +355,7 @@ namespace ServicePulse.Host.Hosting
                     goto case ExecutionMode.Run;
 
                 case ExecutionMode.Run:
-                    Uri spUri;
-                    if (!Uri.TryCreate(Url, UriKind.Absolute, out spUri) || (!validProtocols.Contains(spUri.Scheme, StringComparer.OrdinalIgnoreCase)))
+                    if (!Uri.TryCreate(Url, UriKind.Absolute, out Uri spUri) || (!validProtocols.Contains(spUri.Scheme, StringComparer.OrdinalIgnoreCase)))
                     {
                         throw new Exception("The value specified for 'url' is not a valid URL");
                     }

--- a/src/ServicePulse.Tests/ServicePulse.Tests.csproj
+++ b/src/ServicePulse.Tests/ServicePulse.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.24" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="NUnit" Version="4.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />

--- a/src/ServicePulse/Dockerfile
+++ b/src/ServicePulse/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install
 RUN npm run build
 
 # Host build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG TARGETARCH
 WORKDIR /
 ENV CI=true
@@ -15,7 +15,7 @@ COPY --from=frontend . .
 RUN dotnet publish src/ServicePulse/ServicePulse.csproj -a $TARGETARCH -o /app
 
 # Host runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite
 WORKDIR /app
 
 ENV ASPNETCORE_HTTP_PORTS=9090

--- a/src/ServicePulse/ServicePulse.csproj
+++ b/src/ServicePulse/ServicePulse.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>

--- a/src/ServicePulse/Settings.cs
+++ b/src/ServicePulse/Settings.cs
@@ -3,7 +3,6 @@
 using System.Net;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using IPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
 
 class Settings
 {

--- a/src/ServicePulse/WebApplicationBuilderExtensions.cs
+++ b/src/ServicePulse/WebApplicationBuilderExtensions.cs
@@ -62,7 +62,7 @@ static class WebApplicationBuilderExtensions
         }
 
         return string.IsNullOrEmpty(settings.HttpsCertificatePassword)
-            ? new X509Certificate2(certPath)
-            : new X509Certificate2(certPath, settings.HttpsCertificatePassword);
+            ? X509CertificateLoader.LoadCertificateFromFile(certPath)
+            : X509CertificateLoader.LoadPkcs12FromFile(certPath, settings.HttpsCertificatePassword);
     }
 }

--- a/src/ServicePulse/WebApplicationExtensions.cs
+++ b/src/ServicePulse/WebApplicationExtensions.cs
@@ -27,7 +27,7 @@ static class WebApplicationExtensions
 
                 // Configuration
                 var knownProxies = settings.ForwardedHeadersKnownProxies.Select(p => p.ToString()).ToArray();
-                var knownNetworks = settings.ForwardedHeadersKnownNetworks.Select(n => $"{n.Prefix}/{n.PrefixLength}").ToArray();
+                var knownNetworks = settings.ForwardedHeadersKnownNetworks.Select(n => $"{n.BaseAddress}/{n.PrefixLength}").ToArray();
 
                 return new
                 {
@@ -58,7 +58,7 @@ static class WebApplicationExtensions
 
         // Clear default loopback-only restrictions
         options.KnownProxies.Clear();
-        options.KnownNetworks.Clear();
+        options.KnownIPNetworks.Clear();
 
         // Enabled by default
         if (settings.ForwardedHeadersTrustAllProxies)
@@ -76,7 +76,7 @@ static class WebApplicationExtensions
 
             foreach (var network in settings.ForwardedHeadersKnownNetworks)
             {
-                options.KnownNetworks.Add(network);
+                options.KnownIPNetworks.Add(network);
             }
         }
 


### PR DESCRIPTION
## Summary

Upgrades ServicePulse to .NET 10.

## Changes

### Target Framework Updates
- `ServicePulse` → net10.0
- `ServicePulse.Tests` → net10.0  
- `Particular.PlatformSample.ServicePulse` → net10.0

### Dockerfile
- SDK: `mcr.microsoft.com/dotnet/sdk:10.0`
- Runtime: `mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite`

### Breaking Changes Fixed
| API | .NET 8 | .NET 10 |
|-----|--------|---------|
| IPNetwork type | `Microsoft.AspNetCore.HttpOverrides.IPNetwork` | `System.Net.IPNetwork` |
| Forwarded headers | `KnownNetworks` | `KnownIPNetworks` |
| Network prefix | `IPNetwork.Prefix` | `IPNetwork.BaseAddress` |
| Certificate loading | `new X509Certificate2(path)` | `X509CertificateLoader.LoadCertificateFromFile(path)` |

### Other
- Fixed IDE0018 code style warning in ServicePulse.Host (unrelated, but required for build)

## Testing

- ✅ Solution builds successfully
- ✅ Docker build succeeds
- ✅ Container starts without errors
- ✅ HTTP requests return 200 OK
- ✅ All 76 unit tests pass

## Notes

- ServicePulse.Host remains on net48 (Windows service hosting - separate migration effort)
- This also resolves the MVID mismatch issue (alternative to #2845)