### PR TITLE
Rename DSL assert to verify in spec files

### DIFF
--- a/src/Frontend/src/components/PaginationStrip.spec.ts
+++ b/src/Frontend/src/components/PaginationStrip.spec.ts
@@ -9,10 +9,10 @@ interface PaginationStripDSL {
   clickJumpPagesForward(): Promise<void>;
   clickJumpPagesBack(): Promise<void>;
   updateNumberOfRecordsPerPage(newNumberOfItemsPerPage: number): Promise<void>;
-  assert: PaginationStripDSLAssertions;
+  verify: PaginationStripDSLAssertions;
 }
 
-//Defines a domain-specific language (DSL) for checking assertions against the system under test (sut)
+//Defines a domain-specific language (DSL) for checking verifications against the system under test (sut)
 interface PaginationStripDSLAssertions {
   stripOfButtonsMatchesSequence(value: string): void;
   activePageIs(value: string): void;
@@ -29,35 +29,35 @@ describe("Feature: Moving backwards through pages with a single button must be p
     test("EXAMPLE: First page is active on the initial render", () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 1 });
 
-      component.assert.previousIsDisabled();
+      component.verify.previousIsDisabled();
     });
 
     test("EXAMPLE: Clicking 'previous' button from second page", async () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 2 });
 
-      component.assert.previousIsEnabled();
+      component.verify.previousIsEnabled();
 
       await component.clickPrevious();
 
-      component.assert.previousIsDisabled();
-      component.assert.activePageIs("Page 1");
+      component.verify.previousIsDisabled();
+      component.verify.activePageIs("Page 1");
     });
   });
   describe("Rule: The 'Previous' button is enabled when the first page is not active", () => {
     test("EXAMPLE: Second page is active on initial render", () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 2 });
-      component.assert.previousIsEnabled();
+      component.verify.previousIsEnabled();
     });
 
     test("EXAMPLE: Clicking 'Next' button from first page", async () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 1 });
 
-      component.assert.previousIsDisabled();
+      component.verify.previousIsDisabled();
 
       await component.clickNext();
 
-      component.assert.activePageIs("Page 2");
-      component.assert.previousIsEnabled();
+      component.verify.activePageIs("Page 2");
+      component.verify.previousIsEnabled();
     });
   });
 });
@@ -66,35 +66,35 @@ describe("Feature: Moving forward through pages with a single button must be pos
   describe("Rule: The 'Next' button is disabled when the last page is active", () => {
     test("EXAMPLE: Last page is active on the initial render", () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 10 });
-      component.assert.nextIsDisabled();
+      component.verify.nextIsDisabled();
     });
 
     test("EXAMPLE: Clicking 'Next' button from penultimate page", async () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 9 });
 
-      component.assert.nextIsEnabled();
+      component.verify.nextIsEnabled();
 
       await component.clickNext();
 
-      component.assert.nextIsDisabled();
-      component.assert.activePageIs("Page 10");
+      component.verify.nextIsDisabled();
+      component.verify.activePageIs("Page 10");
     });
   });
   describe("Rule: The 'Next' button is enabled when the last page is not active", () => {
     test("EXAMPLE: Penultimate page is active on initial render", () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 9 });
 
-      component.assert.nextIsEnabled();
+      component.verify.nextIsEnabled();
     });
 
     test("EXAMPLE: Clicking 'Previous' button from last page", async () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 10 });
 
-      component.assert.nextIsDisabled();
+      component.verify.nextIsDisabled();
 
       await component.clickPrevious();
-      component.assert.nextIsEnabled();
-      component.assert.activePageIs("Page 9");
+      component.verify.nextIsEnabled();
+      component.verify.activePageIs("Page 9");
     });
   });
 });
@@ -104,12 +104,12 @@ describe("Feature: Navigating to a specific page that is available must be possi
     test("EXAMPLE: First page is active then clicking to page number 4", async () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 1, allowToJumpPagesBy: 2 });
 
-      component.assert.stripOfButtonsMatchesSequence("Previous,1,2,3,4,...,10,Next");
+      component.verify.stripOfButtonsMatchesSequence("Previous,1,2,3,4,...,10,Next");
 
       await component.clickPage("Page 4");
-      component.assert.activePageIs("Page 4");
+      component.verify.activePageIs("Page 4");
 
-      component.assert.stripOfButtonsMatchesSequence("Previous,1,...,2,3,4,5,6,...,10,Next");
+      component.verify.stripOfButtonsMatchesSequence("Previous,1,...,2,3,4,5,6,...,10,Next");
     });
   });
 });
@@ -119,65 +119,65 @@ describe("Feature: Jumping a number of pages forward or backward must be possibl
     test("EXAMPLE: Strip for 100 records with 10 items per page, allowing to jump pages by 2", () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 1, allowToJumpPagesBy: 2 });
 
-      component.assert.stripOfButtonsMatchesSequence("Previous,1,2,3,4,...,10,Next");
+      component.verify.stripOfButtonsMatchesSequence("Previous,1,2,3,4,...,10,Next");
     });
 
     test("EXAMPLE: Enough pages to jump forward and backward", () => {
       const component = renderPaginationStripWith({ records: 500, itemsPerPage: 10, selectedPage: 10, allowToJumpPagesBy: 5 });
 
-      component.assert.jumpPagesBackIsPresent();
-      component.assert.jumpPagesForwardIsPresent();
+      component.verify.jumpPagesBackIsPresent();
+      component.verify.jumpPagesForwardIsPresent();
     });
 
     test("EXAMPLE: Enough pages to jump foward only", () => {
       const component = renderPaginationStripWith({ records: 500, itemsPerPage: 10, selectedPage: 6, allowToJumpPagesBy: 5 });
 
-      component.assert.jumpPagesBackIsPresent(false);
-      component.assert.jumpPagesForwardIsPresent();
+      component.verify.jumpPagesBackIsPresent(false);
+      component.verify.jumpPagesForwardIsPresent();
     });
 
     test("EXAMPLE: Enough pages to jump back only", () => {
       const component = renderPaginationStripWith({ records: 500, itemsPerPage: 10, selectedPage: 50, allowToJumpPagesBy: 5 });
 
-      component.assert.jumpPagesBackIsPresent();
-      component.assert.jumpPagesForwardIsPresent(false);
-      component.assert.activePageIs("Page 50");
+      component.verify.jumpPagesBackIsPresent();
+      component.verify.jumpPagesForwardIsPresent(false);
+      component.verify.activePageIs("Page 50");
     });
 
     test("EXAMPLE: Not enough pages to jump forward or backward", () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 1, allowToJumpPagesBy: 5 });
 
-      component.assert.jumpPagesBackIsPresent(false);
-      component.assert.jumpPagesForwardIsPresent(false);
+      component.verify.jumpPagesBackIsPresent(false);
+      component.verify.jumpPagesForwardIsPresent(false);
     });
 
     test("EXAMPLE: Jump 5 pages forward", async () => {
       const component = renderPaginationStripWith({ records: 500, itemsPerPage: 10, selectedPage: 6, allowToJumpPagesBy: 5 });
 
-      component.assert.jumpPagesBackIsPresent(false);
-      component.assert.jumpPagesForwardIsPresent();
+      component.verify.jumpPagesBackIsPresent(false);
+      component.verify.jumpPagesForwardIsPresent();
 
       await component.clickJumpPagesForward();
 
-      component.assert.jumpPagesBackIsPresent();
-      component.assert.jumpPagesForwardIsPresent();
+      component.verify.jumpPagesBackIsPresent();
+      component.verify.jumpPagesForwardIsPresent();
 
-      component.assert.activePageIs("Page 11");
+      component.verify.activePageIs("Page 11");
     });
 
     test("EXAMPLE: Jump 10 pages back", async () => {
       const component = renderPaginationStripWith({ records: 500, itemsPerPage: 10, selectedPage: 50, allowToJumpPagesBy: 5 });
 
-      component.assert.jumpPagesBackIsPresent();
-      component.assert.jumpPagesForwardIsPresent(false);
+      component.verify.jumpPagesBackIsPresent();
+      component.verify.jumpPagesForwardIsPresent(false);
 
       await component.clickJumpPagesBack();
       await component.clickJumpPagesBack();
 
-      component.assert.jumpPagesBackIsPresent();
-      component.assert.jumpPagesForwardIsPresent();
+      component.verify.jumpPagesBackIsPresent();
+      component.verify.jumpPagesForwardIsPresent();
 
-      component.assert.activePageIs("Page 40");
+      component.verify.activePageIs("Page 40");
     });
   });
 });
@@ -187,13 +187,13 @@ describe("Feature: changes in the number of records per page are allowed", () =>
     test("EXAMPLE: Number of records per page gets updated from 10 to 50", async () => {
       const component = renderPaginationStripWith({ records: 100, itemsPerPage: 10, selectedPage: 3, allowToJumpPagesBy: 2 });
 
-      component.assert.stripOfButtonsMatchesSequence("Previous,1,2,3,4,5,...,10,Next");
-      component.assert.activePageIs("Page 3");
+      component.verify.stripOfButtonsMatchesSequence("Previous,1,2,3,4,5,...,10,Next");
+      component.verify.activePageIs("Page 3");
 
       await component.updateNumberOfRecordsPerPage(50);
-      component.assert.stripOfButtonsMatchesSequence("Previous,1,2,Next");
+      component.verify.stripOfButtonsMatchesSequence("Previous,1,2,Next");
 
-      component.assert.activePageIs("Page 1");
+      component.verify.activePageIs("Page 1");
     });
   });
 });
@@ -235,7 +235,7 @@ function renderPaginationStripWith({ records, itemsPerPage, selectedPage, allowT
         pageBuffer: allowToJumpPagesBy,
       });
     },
-    assert: {
+    verify: {
       previousIsDisabled: function () {
         expect(screen.queryByLabelText("Previous Page")).toBeDisabled();
       },

--- a/src/Frontend/src/components/configuration/HealthCheckNotifications.spec.ts
+++ b/src/Frontend/src/components/configuration/HealthCheckNotifications.spec.ts
@@ -16,7 +16,7 @@ interface ComponentDSL {
     requestTestNotification(): Promise<void>;
     provideValidEmailConfiguration(): Promise<void>;
   };
-  assert: {
+  verify: {
     emailNotificationsAreEnabled(): void;
     emailNotificationsAreDisabled(): void;
     emailConfigurationIsAccessible(): void;
@@ -67,9 +67,9 @@ describe("FEATURE: Health check notifications", () => {
         },
       });
 
-      componentDriver.assert.emailNotificationsAreDisabled();
+      componentDriver.verify.emailNotificationsAreDisabled();
       await componentDriver.actions.toggleEmailNotifications();
-      componentDriver.assert.emailNotificationsWereToggled();
+      componentDriver.verify.emailNotificationsWereToggled();
     });
 
     test("EXAMPLE: Email notifications are currently enabled", async () => {
@@ -86,9 +86,9 @@ describe("FEATURE: Health check notifications", () => {
         },
       });
 
-      componentDriver.assert.emailNotificationsAreEnabled();
+      componentDriver.verify.emailNotificationsAreEnabled();
       await componentDriver.actions.toggleEmailNotifications();
-      componentDriver.assert.emailNotificationsWereToggled();
+      componentDriver.verify.emailNotificationsWereToggled();
     });
   });
 
@@ -101,9 +101,9 @@ describe("FEATURE: Health check notifications", () => {
        */
       const componentDriver = renderComponent();
 
-      componentDriver.assert.emailConfigurationIsNotAccessible();
+      componentDriver.verify.emailConfigurationIsNotAccessible();
       await componentDriver.actions.openEmailConfiguration();
-      componentDriver.assert.emailConfigurationIsAccessible();
+      componentDriver.verify.emailConfigurationIsAccessible();
     });
 
     test("EXAMPLE: Edits have been made in the configuration dialog", async () => {
@@ -117,11 +117,11 @@ describe("FEATURE: Health check notifications", () => {
       const componentDriver = renderComponent();
 
       await componentDriver.actions.openEmailConfiguration();
-      componentDriver.assert.emailConfigurationIsAccessible();
+      componentDriver.verify.emailConfigurationIsAccessible();
       await componentDriver.actions.provideValidEmailConfiguration();
       await componentDriver.actions.discardEmailConfigurationChanges();
-      componentDriver.assert.emailConfigurationIsNotAccessible();
-      componentDriver.assert.emailConfigurationWasNotSaved();
+      componentDriver.verify.emailConfigurationIsNotAccessible();
+      componentDriver.verify.emailConfigurationWasNotSaved();
     });
   });
 
@@ -142,7 +142,7 @@ describe("FEATURE: Health check notifications", () => {
       });
 
       await componentDriver.actions.openEmailConfiguration();
-      componentDriver.assert.userCannotSaveConfiguration();
+      componentDriver.verify.userCannotSaveConfiguration();
     });
 
     test("EXAMPLE: All required fields are present and valid", async () => {
@@ -160,9 +160,9 @@ describe("FEATURE: Health check notifications", () => {
       });
 
       await componentDriver.actions.openEmailConfiguration();
-      componentDriver.assert.userCannotSaveConfiguration();
+      componentDriver.verify.userCannotSaveConfiguration();
       await componentDriver.actions.provideValidEmailConfiguration();
-      componentDriver.assert.userCanSaveConfiguration();
+      componentDriver.verify.userCanSaveConfiguration();
     });
   });
 
@@ -185,10 +185,10 @@ describe("FEATURE: Health check notifications", () => {
 
       await componentDriver.actions.openEmailConfiguration();
       await componentDriver.actions.provideValidEmailConfiguration();
-      componentDriver.assert.userCanSaveConfiguration();
+      componentDriver.verify.userCanSaveConfiguration();
       await componentDriver.actions.confirmEmailConfigurationChanges();
-      componentDriver.assert.emailConfigurationWasSaved();
-      componentDriver.assert.emailConfigurationIsNotAccessible();
+      componentDriver.verify.emailConfigurationWasSaved();
+      componentDriver.verify.emailConfigurationIsNotAccessible();
     });
   });
 
@@ -222,7 +222,7 @@ describe("FEATURE: Health check notifications", () => {
       });
 
       await componentDriver.actions.openEmailConfiguration();
-      componentDriver.assert.emailConfigurationMatches(savedConfig);
+      componentDriver.verify.emailConfigurationMatches(savedConfig);
     });
 
     test("EXAMPLE: Email notifications were enabled before refresh", () => {
@@ -239,7 +239,7 @@ describe("FEATURE: Health check notifications", () => {
         },
       });
 
-      componentDriver.assert.emailNotificationsAreEnabled();
+      componentDriver.verify.emailNotificationsAreEnabled();
     });
 
     test("EXAMPLE: Email notifications were disabled before refresh", () => {
@@ -256,7 +256,7 @@ describe("FEATURE: Health check notifications", () => {
         },
       });
 
-      componentDriver.assert.emailNotificationsAreDisabled();
+      componentDriver.verify.emailNotificationsAreDisabled();
     });
   });
 
@@ -274,8 +274,8 @@ describe("FEATURE: Health check notifications", () => {
       vi.mocked(store.testEmailNotifications).mockResolvedValue(false);
 
       await componentDriver.actions.requestTestNotification();
-      componentDriver.assert.testNotificationWasRequested();
-      await componentDriver.assert.testNotificationFailed();
+      componentDriver.verify.testNotificationWasRequested();
+      await componentDriver.verify.testNotificationFailed();
     });
 
     test("EXAMPLE: The email configuration is valid", async () => {
@@ -291,8 +291,8 @@ describe("FEATURE: Health check notifications", () => {
       vi.mocked(store.testEmailNotifications).mockResolvedValue(true);
 
       await componentDriver.actions.requestTestNotification();
-      componentDriver.assert.testNotificationWasRequested();
-      await componentDriver.assert.testNotificationWasSuccessful();
+      componentDriver.verify.testNotificationWasRequested();
+      await componentDriver.verify.testNotificationWasSuccessful();
     });
   });
 });
@@ -353,7 +353,7 @@ function renderComponent({ initialState = {} }: { initialState?: Record<string, 
         await user.type(screen.getByLabelText(/to address/i), "to@example.com");
       },
     },
-    assert: {
+    verify: {
       emailNotificationsAreEnabled() {
         expect(screen.getByRole("switch", { name: /emailNotifications/i })).toHaveAttribute("aria-checked", "true");
       },

--- a/src/Frontend/src/components/messages/SagaDiagram.spec.ts
+++ b/src/Frontend/src/components/messages/SagaDiagram.spec.ts
@@ -9,10 +9,10 @@ import { MessageStatus } from "@/resources/Message";
 //Defines a domain-specific language (DSL) for interacting with the system under test (sut)
 interface componentDSL {
   action1(value: string): void;
-  assert: componentDSLAssertions;
+  verify: componentDSLAssertions;
 }
 
-//Defines a domain-specific language (DSL) for checking assertions against the system under test (sut)
+//Defines a domain-specific language (DSL) for checking verifications against the system under test (sut)
 interface componentDSLAssertions {
   thereAreTheFollowingSagaChangesInThisOrder(expectedDatesInOrder: Date[]): void;
   displayedSagaGuidIs(sagaId: string): void;
@@ -43,7 +43,7 @@ describe("Feature: Message not involved in Saga", () => {
         },
       });
 
-      componentDriver.assert.NoSagaDataAvailableMessageIsShownWithMessage(/This message is not part of any saga/i);
+      componentDriver.verify.NoSagaDataAvailableMessageIsShownWithMessage(/This message is not part of any saga/i);
     });
   });
 });
@@ -68,7 +68,7 @@ describe("Feature: Detecting no Audited Saga Data Available", () => {
         },
       });
 
-      componentDriver.assert.SagaPlugInNeededIsShownWithTheMessages({
+      componentDriver.verify.SagaPlugInNeededIsShownWithTheMessages({
         messages: [/Saga audit plugin needed to visualize saga/i, /To visualize your saga, please install the appropriate nuget package in your endpoint/i, /install-package NServiceBus\.SagaAudit/i],
         withPluginDownloadUrl: "https://www.nuget.org/packages/NServiceBus.SagaAudit",
       });
@@ -96,8 +96,8 @@ describe("Feature: Navigation and Contextual Information", () => {
         },
       });
 
-      componentDriver.assert.displayedSagaNameIs("AuditingSaga");
-      componentDriver.assert.displayedSagaGuidIs("123");
+      componentDriver.verify.displayedSagaNameIs("AuditingSaga");
+      componentDriver.verify.displayedSagaGuidIs("123");
     });
   });
 });
@@ -175,7 +175,7 @@ describe("Feature: 3 Visual Representation of Saga Timeline", () => {
       });
 
       //assert
-      componentDriver.assert.thereAreTheFollowingSagaChangesInThisOrder([startTimeD, startTimeC, startTimeB, startTimeA]);
+      componentDriver.verify.thereAreTheFollowingSagaChangesInThisOrder([startTimeD, startTimeC, startTimeB, startTimeA]);
     });
   });
 });
@@ -208,7 +208,7 @@ function rendercomponent({ initialState = {} }: { initialState?: { MessageStore?
     action1: () => {
       // Add actions here;
     },
-    assert: {
+    verify: {
       NoSagaDataAvailableMessageIsShownWithMessage(message: RegExp) {
         //ensure that the only one status message is shown
         expect(screen.queryAllByRole("status")).toHaveLength(1);


### PR DESCRIPTION
Rename the 'assert' property to 'verify' in the DSL interfaces and all usages across PaginationStrip, SagaDiagram, and HealthCheckNotifications spec files.

## Reviewer Checklist

- [ ] Components are broken down into sensible and maintainable sub-components.
- [ ] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [ ] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [ ] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [ ] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
