### PR TITLE
Prevent isRefreshing from getting permanently stuck on fetch errors

### DIFF
--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -63,8 +63,11 @@ onBeforeMount(() => {
 
   //without setTimeout, this happens before the store is properly initialised, and therefore the query route values aren't applied to the refresh
   setTimeout(async () => {
-    await Promise.all([refreshNow(), store.loadEndpoints()]);
-    firstLoad.value = false;
+    try {
+      await Promise.all([refreshNow(), store.loadEndpoints()]);
+    } finally {
+      firstLoad.value = false;
+    }
   }, 0);
 });
 

--- a/src/Frontend/src/composables/autoRefresh.ts
+++ b/src/Frontend/src/composables/autoRefresh.ts
@@ -11,8 +11,11 @@ export default function useFetchWithAutoRefresh(name: string, fetchFn: () => Pro
       return;
     }
     isRefreshing.value = true;
-    await fetchFn();
-    isRefreshing.value = false;
+    try {
+      await fetchFn();
+    } finally {
+      isRefreshing.value = false;
+    }
   };
   const { isActive, pause, resume } = useTimeoutPoll(
     fetchWrapper,


### PR DESCRIPTION
Fixes:

- https://github.com/Particular/ServicePulse/issues/2883

Without try/finally, any exception thrown by the fetch function left isRefreshing=true forever, causing all subsequent refreshNow() calls to silently no-op — including the manual Refresh button. Also ensures firstLoad is always cleared so the spinner never shows indefinitely.

## Reviewer Checklist

- [x] Components are broken down into sensible and maintainable sub-components.
- [x] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [x] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [x] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [x] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
