### PR TITLE
Replace collapse button with accordion-style chevron toggle

### DIFF
--- a/src/Frontend/src/components/platformcapabilities/PlatformCapabilitiesDashboardItem.vue
+++ b/src/Frontend/src/components/platformcapabilities/PlatformCapabilitiesDashboardItem.vue
@@ -30,7 +30,15 @@ const hasHiddenCards = computed(() => !visibility.value.showAuditingCard || !vis
   <div v-if="visibility.showSection" class="platform-capabilities">
     <div class="capabilities-header">
       <div class="capabilities-title-row">
-        <div id="collapse-capabilities-btn" class="capabilities-toggle hide-section-btn" role="button" tabindex="0" @click="platformCapabilitiesStore.toggleSection()" @keydown.enter.prevent="platformCapabilitiesStore.toggleSection()" @keydown.space.prevent="platformCapabilitiesStore.toggleSection()">
+        <div
+          id="collapse-capabilities-btn"
+          class="capabilities-toggle hide-section-btn"
+          role="button"
+          tabindex="0"
+          @click="platformCapabilitiesStore.toggleSection()"
+          @keydown.enter.prevent="platformCapabilitiesStore.toggleSection()"
+          @keydown.space.prevent="platformCapabilitiesStore.toggleSection()"
+        >
           <FAIcon :icon="faChevronRight" class="section-chevron expanded" />
           <div>
             <h6>Platform Capabilities</h6>
@@ -87,7 +95,15 @@ const hasHiddenCards = computed(() => !visibility.value.showAuditingCard || !vis
     </div>
   </div>
   <div v-else class="platform-capabilities-collapsed">
-    <div id="expand-capabilities-btn" class="capabilities-toggle" role="button" tabindex="0" @click="platformCapabilitiesStore.toggleSection()" @keydown.enter.prevent="platformCapabilitiesStore.toggleSection()" @keydown.space.prevent="platformCapabilitiesStore.toggleSection()">
+    <div
+      id="expand-capabilities-btn"
+      class="capabilities-toggle"
+      role="button"
+      tabindex="0"
+      @click="platformCapabilitiesStore.toggleSection()"
+      @keydown.enter.prevent="platformCapabilitiesStore.toggleSection()"
+      @keydown.space.prevent="platformCapabilitiesStore.toggleSection()"
+    >
       <FAIcon :icon="faChevronRight" class="section-chevron" />
       <h6>Show Platform Capabilities</h6>
     </div>


### PR DESCRIPTION
Fixes:

- https://github.com/Particular/ServicePulse/issues/2888

The separate pill button is replaced with a rotating chevron icon inline with the section title, following the standard accordion pattern. The expand state uses the same visual affordance, keeping the interaction consistent and familiar.

![collapse](https://github.com/user-attachments/assets/334c8535-21c9-4583-861d-5fbabdbe553f)

## Reviewer Checklist

- [x] Components are broken down into sensible and maintainable sub-components.
- [x] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [x] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [x] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [x] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
