### PR TITLE
Fix all messages / audit view not loading data when selected

### DIFF
--- a/src/Frontend/src/composables/useAuditStoreAutoRefresh.ts
+++ b/src/Frontend/src/composables/useAuditStoreAutoRefresh.ts
@@ -1,10 +1,6 @@
 import { useAuditStore } from "@/stores/AuditStore";
 import { useStoreAutoRefresh } from "./useAutoRefresh";
 
-// Override the refresh method to use checkForSuccessfulMessages, which is more lightweight
-const useAuditStoreWithRefresh = () => {
-  const store = useAuditStore();
-  return Object.assign(store, { refresh: store.checkForSuccessfulMessages });
-};
-
-export default useStoreAutoRefresh("auditStoreSuccessfulMessages", useAuditStoreWithRefresh, 5000).autoRefresh;
+// Use checkForSuccessfulMessages for auto-refresh (lightweight) via customRefresh
+// instead of mutating the store's refresh method, which would break AuditList's full fetch
+export default useStoreAutoRefresh("auditStoreSuccessfulMessages", useAuditStore, 5000, (store) => store.checkForSuccessfulMessages()).autoRefresh;

--- a/src/Frontend/src/composables/useAutoRefresh.ts
+++ b/src/Frontend/src/composables/useAutoRefresh.ts
@@ -21,14 +21,15 @@ function useAutoRefresh(name: string, refresh: () => Promise<void>, intervalMs: 
  * @param name - Name for logging purposes
  * @param useStore - Function that returns the Pinia store (called within component lifecycle)
  * @param intervalMs - Refresh interval in milliseconds
+ * @param customRefresh - Optional custom refresh function. When provided, this is called instead of store.refresh() during auto-refresh, avoiding the need to mutate the store.
  * @returns A composable function that sets up auto-refresh and returns the store. Also provides a method to update the refresh interval and a ref indicating when a refresh is happening
  */
-export function useStoreAutoRefresh<TStore extends { refresh: () => Promise<void> }>(name: string, useStore: () => TStore, intervalMs: number) {
+export function useStoreAutoRefresh<TStore extends { refresh: () => Promise<void> }>(name: string, useStore: () => TStore, intervalMs: number, customRefresh?: (store: TStore) => Promise<void>) {
   const refresh = () => {
     if (!store) {
       return Promise.resolve();
     }
-    return store.refresh();
+    return customRefresh ? customRefresh(store) : store.refresh();
   };
   let store: TStore | null = null;
   const { refresh: autoRefresh, isRefreshing, updateInterval } = useAutoRefresh(name, refresh, intervalMs);


### PR DESCRIPTION
ALWAYS when I open all messages view nothing happens. Switching do a different tab and back still no data until I do a full page reload.


> [!NOTE]
> This is a suggestion by Claude so this really needs to be reviewed by someone that understands this. I don't really have an understanding how the refresh is designed.

## Background info

The auto-refresh composable was mutating the store's refresh method via Object.assign, replacing it with checkForSuccessfulMessages. This broke AuditList's full fetch since it also called store.refresh().

Add a customRefresh parameter to useStoreAutoRefresh so the lightweight checkForSuccessfulMessages can be used for polling without mutating the store.


## Reviewer Checklist

- [ ] Components are broken down into sensible and maintainable sub-components.
- [ ] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [ ] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [ ] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [ ] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
