### PR TITLE
Reduce version check polling frequency from 5s to 1h

### DIFF
--- a/src/Frontend/src/composables/useEnvironmentAndVersionsAutoRefresh.ts
+++ b/src/Frontend/src/composables/useEnvironmentAndVersionsAutoRefresh.ts
@@ -1,4 +1,4 @@
 import { useEnvironmentAndVersionsStore } from "@/stores/EnvironmentAndVersionsStore";
 import { useStoreAutoRefresh } from "./useAutoRefresh";
 
-export default useStoreAutoRefresh("environmentAndVersions", useEnvironmentAndVersionsStore, 5000).autoRefresh;
+export default useStoreAutoRefresh("environmentAndVersions", useEnvironmentAndVersionsStore, 3600000).autoRefresh;


### PR DESCRIPTION
The environment and versions store was polling SC root endpoint, monitoring version, and platformupdate.particular.net every 5 seconds. These values are effectively static during a session, so hourly refresh is sufficient. This dramatically reduces noise in the browser devtools network tab.

## Reviewer Checklist

- [ ] Components are broken down into sensible and maintainable sub-components.
- [ ] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [ ] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [ ] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [ ] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
