### PR TITLE
Add activity filter for endpoint message types

### DIFF
--- a/src/Frontend/src/components/monitoring/EndpointMessageTypes.vue
+++ b/src/Frontend/src/components/monitoring/EndpointMessageTypes.vue
@@ -13,9 +13,11 @@ import ColumnHeader from "@/components/ColumnHeader.vue";
 import { CriticalTime, MessageType, ProcessingTime, ScheduledRetries, Throughput } from "@/resources/MonitoringResources";
 import FAIcon from "@/components/FAIcon.vue";
 import { faWarning } from "@fortawesome/free-solid-svg-icons";
+import { useMonitoringHistoryPeriodStore } from "@/stores/MonitoringHistoryPeriodStore";
 
 const monitoringStore = useMonitoringEndpointDetailsStore();
 const { endpointDetails: endpoint, messageTypes, messageTypesAvailable } = storeToRefs(monitoringStore);
+const { historyPeriod } = storeToRefs(useMonitoringHistoryPeriodStore());
 
 const route = useRoute();
 const router = useRouter();
@@ -40,7 +42,16 @@ const props = defineProps({
 const filteredMessageTypes = computed(() => {
   if (!messageTypes.value) return [];
   if (activityFilter.value === 0) return messageTypes.value.data;
-  return messageTypes.value.data.filter((mt) => mt.metrics.throughput.average > 0 || mt.metrics.throughput.points.some((p) => p > 0));
+
+  return messageTypes.value.data.filter((mt) => {
+    const points = mt.metrics.throughput.points;
+    if (points.length === 0) return false;
+
+    const pVal = historyPeriod.value.pVal;
+    const pointsToCheck = Math.min(points.length, Math.ceil((activityFilter.value / pVal) * points.length));
+    const recentPoints = points.slice(-pointsToCheck);
+    return recentPoints.some((p) => p > 0);
+  });
 });
 
 const paginatedMessageTypes = computed(() => {
@@ -58,7 +69,7 @@ const paginatedMessageTypes = computed(() => {
         <a @click="monitoringStore.updateMessageTypes()" class="alink">Click here to reload the view</a>
       </div>
 
-      <MessageTypeActivityFilter v-model="activityFilter" />
+      <MessageTypeActivityFilter v-model="activityFilter" :historyPeriod="historyPeriod.pVal" />
 
       <!-- Breakdown by message type-->
       <!--headers-->

--- a/src/Frontend/src/components/monitoring/EndpointMessageTypes.vue
+++ b/src/Frontend/src/components/monitoring/EndpointMessageTypes.vue
@@ -7,6 +7,7 @@ import { storeToRefs } from "pinia";
 import NoData from "@/components/NoData.vue";
 import SmallGraph from "./SmallGraph.vue";
 import PaginationStrip from "@/components/PaginationStrip.vue";
+import MessageTypeActivityFilter from "./MessageTypeActivityFilter.vue";
 import { useMonitoringEndpointDetailsStore } from "@/stores/MonitoringEndpointDetailsStore";
 import ColumnHeader from "@/components/ColumnHeader.vue";
 import { CriticalTime, MessageType, ProcessingTime, ScheduledRetries, Throughput } from "@/resources/MonitoringResources";
@@ -19,9 +20,14 @@ const { endpointDetails: endpoint, messageTypes, messageTypesAvailable } = store
 const route = useRoute();
 const router = useRouter();
 const messageTypesPage = ref(Number(route?.query?.pageNo ?? "1"));
+const activityFilter = ref(0);
 
 watch(messageTypesPage, () => {
   router.replace({ query: { ...route.query, pageNo: messageTypesPage.value } });
+});
+
+watch(activityFilter, () => {
+  messageTypesPage.value = 1;
 });
 
 const props = defineProps({
@@ -31,10 +37,16 @@ const props = defineProps({
   },
 });
 
+const filteredMessageTypes = computed(() => {
+  if (!messageTypes.value) return [];
+  if (activityFilter.value === 0) return messageTypes.value.data;
+  return messageTypes.value.data.filter((mt) => mt.metrics.throughput.average > 0 || mt.metrics.throughput.points.some((p) => p > 0));
+});
+
 const paginatedMessageTypes = computed(() => {
   const pageStart = (messageTypesPage.value - 1) * props.perPage;
   const pageEnd = messageTypesPage.value * props.perPage;
-  return messageTypes.value ? messageTypes.value.data.slice(pageStart, pageEnd) : [];
+  return filteredMessageTypes.value.slice(pageStart, pageEnd);
 });
 </script>
 
@@ -45,6 +57,8 @@ const paginatedMessageTypes = computed(() => {
         <FAIcon :icon="faWarning" /> <strong>Warning:</strong> The number of available message types has changed.
         <a @click="monitoringStore.updateMessageTypes()" class="alink">Click here to reload the view</a>
       </div>
+
+      <MessageTypeActivityFilter v-model="activityFilter" />
 
       <!-- Breakdown by message type-->
       <!--headers-->
@@ -65,6 +79,7 @@ const paginatedMessageTypes = computed(() => {
       </div>
 
       <no-data v-if="!endpoint?.messageTypes?.length" message="No messages processed in this period of time."></no-data>
+      <no-data v-else-if="filteredMessageTypes.length === 0" message="No active message types found for the selected filter."></no-data>
 
       <div role="rowgroup" aria-label="message-type-rows" class="row">
         <div class="col-xs-12 no-side-padding">
@@ -157,7 +172,7 @@ const paginatedMessageTypes = computed(() => {
           </div>
         </div>
       </div>
-      <PaginationStrip v-model="messageTypesPage" :itemsPerPage="perPage" :totalCount="messageTypes?.data?.length ?? 0" />
+      <PaginationStrip v-model="messageTypesPage" :itemsPerPage="perPage" :totalCount="filteredMessageTypes.length" />
     </div>
   </div>
 </template>

--- a/src/Frontend/src/components/monitoring/MessageTypeActivityFilter.vue
+++ b/src/Frontend/src/components/monitoring/MessageTypeActivityFilter.vue
@@ -1,17 +1,28 @@
 <script setup lang="ts">
+import { computed, watch } from "vue";
+
 export interface ActivityFilterOption {
   value: number;
   text: string;
 }
 
-const filterOptions: ActivityFilterOption[] = [
+const allFilterOptions: ActivityFilterOption[] = [
   { value: 0, text: "All" },
   { value: 1, text: "1 min" },
   { value: 5, text: "5 min" },
   { value: 15, text: "15 min" },
 ];
 
+const props = defineProps<{ historyPeriod: number }>();
 const selected = defineModel<number>({ default: 0 });
+
+const filterOptions = computed(() => allFilterOptions.filter((o) => o.value === 0 || o.value <= props.historyPeriod));
+
+watch(filterOptions, () => {
+  if (!filterOptions.value.some((o) => o.value === selected.value)) {
+    selected.value = 0;
+  }
+});
 </script>
 
 <template>

--- a/src/Frontend/src/components/monitoring/MessageTypeActivityFilter.vue
+++ b/src/Frontend/src/components/monitoring/MessageTypeActivityFilter.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+export interface ActivityFilterOption {
+  value: number;
+  text: string;
+}
+
+const filterOptions: ActivityFilterOption[] = [
+  { value: 0, text: "All" },
+  { value: 1, text: "1 min" },
+  { value: 5, text: "5 min" },
+  { value: 15, text: "15 min" },
+];
+
+const selected = defineModel<number>({ default: 0 });
+</script>
+
+<template>
+  <div class="activity-filter">
+    <span class="activity-filter-label">Show active in the last:</span>
+    <ul aria-label="activity-filter-list" class="nav nav-pills activity-filter-pills">
+      <li v-for="option in filterOptions" :key="option.value" :class="{ active: option.value === selected }" :aria-selected="option.value === selected">
+        <a href="#" @click.prevent="selected = option.value">{{ option.text }}</a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.activity-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 16px 0 8px;
+}
+
+.activity-filter-label {
+  font-size: 13px;
+  color: #8c8c8c;
+  white-space: nowrap;
+}
+
+.nav-pills.activity-filter-pills > li > a {
+  border-radius: 0;
+  border-bottom: 3px solid transparent;
+  padding: 6px 8px;
+  font-size: 13px;
+  color: #00a3c4;
+}
+
+.nav-pills.activity-filter-pills > li > a:hover {
+  color: #00a3c4;
+  font-weight: normal;
+  background-color: initial;
+  border-bottom-color: #00a3c4;
+  text-decoration: none;
+}
+
+.nav-pills.activity-filter-pills > li.active > a,
+.nav-pills.activity-filter-pills > li.active > a:hover,
+.nav-pills.activity-filter-pills > li.active > a:focus {
+  color: #000;
+  font-weight: bold;
+  background-color: initial;
+  border-bottom-color: #000;
+}
+
+.nav li {
+  display: flex;
+}
+
+.nav-pills > li + li {
+  margin-left: 2px;
+}
+</style>


### PR DESCRIPTION
_Closes #2890_

Adds a client-side filter to the Message Types tab on the Endpoint Details monitoring view, allowing users to show only message types with recent throughput activity.

  - Filter options: All (default) | 1 min | 5 min | 15 min
  - Filters by checking only the trailing portion of the throughput data points matching the selected time window
  - Filter options adapt to the selected history period (e.g. "15 min" is hidden when viewing 1 or 5 minute history)
  - Pagination resets to page 1 and reflects the filtered count when a filter is active

![servicepulse](https://github.com/user-attachments/assets/e1f62f73-19f1-488e-8b03-5a14a6d32904)

## Reviewer Checklist

- [ ] Components are broken down into sensible and maintainable sub-components.
- [ ] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [ ] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [ ] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [ ] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
