### PR TITLE
Add Renovate group for MSW package

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -106,5 +106,18 @@
         '/^@vue-flow//',
       ],
     },
+    {
+      matchDatasources: [
+        'npm',
+      ],
+      matchPackageNames: [
+        'msw',
+      ],
+      groupName: 'msw',
+      groupSlug: 'msw-group',
+      prBodyNotes: [
+        '> [!WARNING]\n> **Do not auto-merge or merge via this PR directly.** `msw` runs a post-install script that regenerates `mockServiceWorker.js` with the new version number. After merging, you must manually run `npx msw init <PUBLIC_DIR>` to update this generated file, then commit the result.',
+      ],
+    },
   ],
 }


### PR DESCRIPTION
Configures Renovate to group updates for the `msw` package and adds a warning to PRs. `msw` requires a manual post-merge step (`npx msw init`) to regenerate `mockServiceWorker.js` after a version update. The notes ensure this crucial step isn't missed, preventing an outdated service worker.


