### PR TITLE
Add minimum release age for npm updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,12 @@
       matchDatasources: [
         'npm',
       ],
+      minimumReleaseAge: '4 days',
+    },
+    {
+      matchDatasources: [
+        'npm',
+      ],
       matchUpdateTypes: [
         'patch',
       ],


### PR DESCRIPTION
Enabling [minimumReleaseAge](https://docs.renovatebot.com/key-concepts/minimum-release-age/) in Renovate prevents the bot from suggesting dependency updates right after they are published. It acts as a safety "cooldown" period, giving the community and security tools time to catch malicious code or critical bugs before they reach your codebase.
