### PR TITLE
Messages view does not indicate that it is waiting for a response from ServiceControl

### DIFF
--- a/src/Frontend/src/components/FilterInput.vue
+++ b/src/Frontend/src/components/FilterInput.vue
@@ -6,7 +6,7 @@ import { faFilter } from "@fortawesome/free-solid-svg-icons";
 
 const model = defineModel<string>({ required: true });
 const emit = defineEmits<{ focus: []; blur: [] }>();
-const props = withDefaults(defineProps<{ placeholder?: string; ariaLabel?: string }>(), { placeholder: "Filter by name...", ariaLabel: "Filter by name" });
+const props = withDefaults(defineProps<{ placeholder?: string; ariaLabel?: string; disabled?: boolean }>(), { placeholder: "Filter by name...", ariaLabel: "Filter by name" });
 const localInput = computed({
   get() {
     return model.value;
@@ -30,7 +30,7 @@ function focus() {
 <template>
   <div role="search" aria-label="filter" class="filter-input">
     <FAIcon :icon="faFilter" class="icon" />
-    <input ref="textField" type="search" @focus="() => emit('focus')" @blur="() => emit('blur')" :placeholder="props.placeholder" :aria-label="props.ariaLabel" class="form-control filter-input" v-model="localInput" />
+    <input ref="textField" type="search" @focus="() => emit('focus')" @blur="() => emit('blur')" :placeholder="props.placeholder" :aria-label="props.ariaLabel" :disabled="props.disabled" class="form-control filter-input" v-model="localInput" />
   </div>
 </template>
 

--- a/src/Frontend/src/components/LoadingSpinner.vue
+++ b/src/Frontend/src/components/LoadingSpinner.vue
@@ -1,9 +1,29 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+defineProps<{ overlay?: boolean }>();
+</script>
 
 <template>
-  <div class="text-center">
+  <div :class="overlay ? 'loading-overlay' : 'text-center'">
     <div class="spinner-border" role="status">
       <span class="visually-hidden">Loading...</span>
     </div>
   </div>
 </template>
+
+<style scoped>
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.9);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.loading-overlay .spinner-border {
+  position: sticky;
+  top: 4rem;
+  margin-top: 2rem;
+}
+</style>

--- a/src/Frontend/src/components/RefreshConfig.spec.ts
+++ b/src/Frontend/src/components/RefreshConfig.spec.ts
@@ -53,7 +53,7 @@ async function renderRefreshConfig(isLoading: boolean) {
 
 // ==================== Tests ====================
 
-describe("RefreshConfig spinner", () => {
+describe("FEATURE: Refresh Button Loading State", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -62,40 +62,46 @@ describe("RefreshConfig spinner", () => {
     vi.useRealTimers();
   });
 
-  test("shows spinner immediately when loading starts", async () => {
-    const { setIsLoading, verify } = await renderRefreshConfig(false);
+  describe("RULE: Spinner shows immediately when a fetch starts", () => {
+    test("EXAMPLE: Spinner is visible when isLoading becomes true", async () => {
+      const { setIsLoading, verify } = await renderRefreshConfig(false);
 
-    await setIsLoading(true);
+      await setIsLoading(true);
 
-    verify.isSpinning();
+      verify.isSpinning();
+    });
   });
 
-  test("keeps spinner on while loading is still true past 1s", async () => {
-    const { setIsLoading, verify } = await renderRefreshConfig(false);
-    await setIsLoading(true);
+  describe("RULE: Spinner stays on for the full duration of the fetch", () => {
+    test("EXAMPLE: Spinner stays on while isLoading is still true past 1s", async () => {
+      const { setIsLoading, verify } = await renderRefreshConfig(false);
+      await setIsLoading(true);
 
-    vi.advanceTimersByTime(1500);
-    await nextTick();
+      vi.advanceTimersByTime(1500);
+      await nextTick();
 
-    verify.isSpinning();
+      verify.isSpinning();
+    });
   });
 
-  test("turns spinner off only after loading ends and minimum duration elapses", async () => {
-    const { setIsLoading, verify } = await renderRefreshConfig(false);
-    await setIsLoading(true);
+  describe("RULE: Spinner stays on for a minimum duration to prevent rapid re-clicks", () => {
+    test("EXAMPLE: Spinner turns off only after loading ends and minimum duration elapses", async () => {
+      const { setIsLoading, verify } = await renderRefreshConfig(false);
+      await setIsLoading(true);
 
-    // fetch completes after 400ms (under the 1000ms minimum)
-    vi.advanceTimersByTime(400);
-    await setIsLoading(false);
+      // fetch completes after 400ms (under the 1000ms minimum)
+      vi.advanceTimersByTime(400);
+      await setIsLoading(false);
 
-    // 600ms remaining — not yet
-    vi.advanceTimersByTime(599);
-    await nextTick();
-    verify.isSpinning();
+      // 600ms remaining — not yet
+      vi.advanceTimersByTime(599);
+      await nextTick();
+      verify.isSpinning();
 
-    // minimum elapsed — spinner clears
-    vi.advanceTimersByTime(1);
-    await nextTick();
-    verify.isNotSpinning();
+      // minimum elapsed — spinner clears
+      vi.advanceTimersByTime(1);
+      await nextTick();
+      verify.isNotSpinning();
+    });
   });
 });

--- a/src/Frontend/src/components/RefreshConfig.spec.ts
+++ b/src/Frontend/src/components/RefreshConfig.spec.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/vue";
+import { defineComponent, nextTick } from "vue";
+import RefreshConfig from "@/components/RefreshConfig.vue";
+
+/**
+ * DSL for the RefreshConfig spinner timing behavior.
+ *
+ * Tests verify that the refresh button's loading state stays in sync with the
+ * isLoading prop for the full duration of the HTTP call, with a minimum display
+ * time to prevent rapid re-clicks.
+ *
+ * If the loading UI changes (different button component, different attribute), only
+ * the helpers below need updating — the tests remain unchanged.
+ */
+
+// ==================== Stubs ====================
+
+const ActionButtonStub = defineComponent({
+  props: { loading: Boolean },
+  template: '<button :data-loading="String(loading)"><slot /></button>',
+});
+
+// ==================== DSL ====================
+
+async function renderRefreshConfig(isLoading: boolean) {
+  const { rerender } = render(RefreshConfig, {
+    props: { isLoading, modelValue: null },
+    global: {
+      stubs: {
+        ActionButton: ActionButtonStub,
+        ListFilterSelector: true,
+      },
+    },
+  });
+
+  function getButton(): HTMLButtonElement {
+    return document.querySelector("button[data-loading]") as HTMLButtonElement;
+  }
+
+  async function setIsLoading(value: boolean) {
+    await rerender({ isLoading: value, modelValue: null });
+  }
+
+  return {
+    setIsLoading,
+    verify: {
+      isSpinning: () => expect(getButton().dataset.loading).toBe("true"),
+      isNotSpinning: () => expect(getButton().dataset.loading).toBe("false"),
+    },
+  };
+}
+
+// ==================== Tests ====================
+
+describe("RefreshConfig spinner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("shows spinner immediately when loading starts", async () => {
+    const { setIsLoading, verify } = await renderRefreshConfig(false);
+
+    await setIsLoading(true);
+
+    verify.isSpinning();
+  });
+
+  test("keeps spinner on while loading is still true past 1s", async () => {
+    const { setIsLoading, verify } = await renderRefreshConfig(false);
+    await setIsLoading(true);
+
+    vi.advanceTimersByTime(1500);
+    await nextTick();
+
+    verify.isSpinning();
+  });
+
+  test("turns spinner off only after loading ends and minimum duration elapses", async () => {
+    const { setIsLoading, verify } = await renderRefreshConfig(false);
+    await setIsLoading(true);
+
+    // fetch completes after 400ms (under the 1000ms minimum)
+    vi.advanceTimersByTime(400);
+    await setIsLoading(false);
+
+    // 600ms remaining — not yet
+    vi.advanceTimersByTime(599);
+    await nextTick();
+    verify.isSpinning();
+
+    // minimum elapsed — spinner clears
+    vi.advanceTimersByTime(1);
+    await nextTick();
+    verify.isNotSpinning();
+  });
+});

--- a/src/Frontend/src/components/RefreshConfig.spec.ts
+++ b/src/Frontend/src/components/RefreshConfig.spec.ts
@@ -1,14 +1,13 @@
-import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, test, expect } from "vitest";
 import { render } from "@testing-library/vue";
-import { defineComponent, nextTick } from "vue";
+import { defineComponent } from "vue";
 import RefreshConfig from "@/components/RefreshConfig.vue";
 
 /**
- * DSL for the RefreshConfig spinner timing behavior.
+ * DSL for the RefreshConfig query-in-progress behavior.
  *
- * Tests verify that the refresh button's loading state stays in sync with the
- * isLoading prop for the full duration of the HTTP call, with a minimum display
- * time to prevent rapid re-clicks.
+ * Tests verify that the refresh controls stay in sync with the page-level query
+ * state owned by AuditList.
  *
  * If the loading UI changes (different button component, different attribute), only
  * the helpers below need updating — the tests remain unchanged.
@@ -17,19 +16,24 @@ import RefreshConfig from "@/components/RefreshConfig.vue";
 // ==================== Stubs ====================
 
 const ActionButtonStub = defineComponent({
-  props: { loading: Boolean },
-  template: '<button :data-loading="String(loading)"><slot /></button>',
+  props: { loading: Boolean, disabled: Boolean },
+  template: '<button :data-loading="String(loading)" :disabled="disabled"><slot /></button>',
+});
+
+const ListFilterSelectorStub = defineComponent({
+  props: { disabled: Boolean },
+  template: '<button :data-disabled="String(disabled)" />',
 });
 
 // ==================== DSL ====================
 
-function renderRefreshConfig(isLoading: boolean) {
+function renderRefreshConfig(queryInProgress: boolean) {
   const { rerender } = render(RefreshConfig, {
-    props: { isLoading, modelValue: null },
+    props: { queryInProgress, modelValue: null },
     global: {
       stubs: {
         ActionButton: ActionButtonStub,
-        ListFilterSelector: true,
+        ListFilterSelector: ListFilterSelectorStub,
       },
     },
   });
@@ -38,70 +42,49 @@ function renderRefreshConfig(isLoading: boolean) {
     return document.querySelector("button[data-loading]") as HTMLButtonElement;
   }
 
-  async function setIsLoading(value: boolean) {
-    await rerender({ isLoading: value, modelValue: null });
+  function getAutoRefreshSelector(): HTMLButtonElement {
+    return document.querySelector("button[data-disabled]") as HTMLButtonElement;
+  }
+
+  async function setQueryInProgress(value: boolean) {
+    await rerender({ queryInProgress: value, modelValue: null });
   }
 
   return {
-    setIsLoading,
+    setQueryInProgress,
     verify: {
-      isSpinning: () => expect(getButton().dataset.loading).toBe("true"),
-      isNotSpinning: () => expect(getButton().dataset.loading).toBe("false"),
+      refreshButtonIsLoading: () => expect(getButton().dataset.loading).toBe("true"),
+      refreshButtonIsNotLoading: () => expect(getButton().dataset.loading).toBe("false"),
+      refreshButtonIsDisabled: () => expect(getButton()).toBeDisabled(),
+      refreshButtonIsEnabled: () => expect(getButton()).toBeEnabled(),
+      autoRefreshSelectorIsDisabled: () => expect(getAutoRefreshSelector().dataset.disabled).toBe("true"),
+      autoRefreshSelectorIsEnabled: () => expect(getAutoRefreshSelector().dataset.disabled).toBe("false"),
     },
   };
 }
 
 // ==================== Tests ====================
 
-describe("FEATURE: Refresh Button Loading State", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
+describe("FEATURE: Refresh Controls Query State", () => {
+  describe("RULE: Refresh controls are disabled while a query is in progress", () => {
+    test("EXAMPLE: Refresh controls reflect queryInProgress changes", async () => {
+      const { setQueryInProgress, verify } = renderRefreshConfig(false);
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+      verify.refreshButtonIsNotLoading();
+      verify.refreshButtonIsEnabled();
+      verify.autoRefreshSelectorIsEnabled();
 
-  describe("RULE: Spinner shows immediately when a fetch starts", () => {
-    test("EXAMPLE: Spinner is visible when isLoading becomes true", async () => {
-      const { setIsLoading, verify } = renderRefreshConfig(false);
+      await setQueryInProgress(true);
 
-      await setIsLoading(true);
+      verify.refreshButtonIsLoading();
+      verify.refreshButtonIsDisabled();
+      verify.autoRefreshSelectorIsDisabled();
 
-      verify.isSpinning();
-    });
-  });
+      await setQueryInProgress(false);
 
-  describe("RULE: Spinner stays on for the full duration of the fetch", () => {
-    test("EXAMPLE: Spinner stays on while isLoading is still true past 1s", async () => {
-      const { setIsLoading, verify } = renderRefreshConfig(false);
-      await setIsLoading(true);
-
-      vi.advanceTimersByTime(1500);
-      await nextTick();
-
-      verify.isSpinning();
-    });
-  });
-
-  describe("RULE: Spinner stays on for a minimum duration to prevent rapid re-clicks", () => {
-    test("EXAMPLE: Spinner turns off only after loading ends and minimum duration elapses", async () => {
-      const { setIsLoading, verify } = renderRefreshConfig(false);
-      await setIsLoading(true);
-
-      // fetch completes after 400ms (under the 1000ms minimum)
-      vi.advanceTimersByTime(400);
-      await setIsLoading(false);
-
-      // 600ms remaining — not yet
-      vi.advanceTimersByTime(599);
-      await nextTick();
-      verify.isSpinning();
-
-      // minimum elapsed — spinner clears
-      vi.advanceTimersByTime(1);
-      await nextTick();
-      verify.isNotSpinning();
+      verify.refreshButtonIsNotLoading();
+      verify.refreshButtonIsEnabled();
+      verify.autoRefreshSelectorIsEnabled();
     });
   });
 });

--- a/src/Frontend/src/components/RefreshConfig.spec.ts
+++ b/src/Frontend/src/components/RefreshConfig.spec.ts
@@ -23,7 +23,7 @@ const ActionButtonStub = defineComponent({
 
 // ==================== DSL ====================
 
-async function renderRefreshConfig(isLoading: boolean) {
+function renderRefreshConfig(isLoading: boolean) {
   const { rerender } = render(RefreshConfig, {
     props: { isLoading, modelValue: null },
     global: {
@@ -64,7 +64,7 @@ describe("FEATURE: Refresh Button Loading State", () => {
 
   describe("RULE: Spinner shows immediately when a fetch starts", () => {
     test("EXAMPLE: Spinner is visible when isLoading becomes true", async () => {
-      const { setIsLoading, verify } = await renderRefreshConfig(false);
+      const { setIsLoading, verify } = renderRefreshConfig(false);
 
       await setIsLoading(true);
 
@@ -74,7 +74,7 @@ describe("FEATURE: Refresh Button Loading State", () => {
 
   describe("RULE: Spinner stays on for the full duration of the fetch", () => {
     test("EXAMPLE: Spinner stays on while isLoading is still true past 1s", async () => {
-      const { setIsLoading, verify } = await renderRefreshConfig(false);
+      const { setIsLoading, verify } = renderRefreshConfig(false);
       await setIsLoading(true);
 
       vi.advanceTimersByTime(1500);
@@ -86,7 +86,7 @@ describe("FEATURE: Refresh Button Loading State", () => {
 
   describe("RULE: Spinner stays on for a minimum duration to prevent rapid re-clicks", () => {
     test("EXAMPLE: Spinner turns off only after loading ends and minimum duration elapses", async () => {
-      const { setIsLoading, verify } = await renderRefreshConfig(false);
+      const { setIsLoading, verify } = renderRefreshConfig(false);
       await setIsLoading(true);
 
       // fetch completes after 400ms (under the 1000ms minimum)

--- a/src/Frontend/src/components/RefreshConfig.vue
+++ b/src/Frontend/src/components/RefreshConfig.vue
@@ -4,7 +4,7 @@ import ListFilterSelector from "@/components/audit/ListFilterSelector.vue";
 import ActionButton from "@/components/ActionButton.vue";
 import { faRefresh } from "@fortawesome/free-solid-svg-icons";
 
-const props = defineProps<{ isLoading: boolean }>();
+const props = defineProps<{ queryInProgress: boolean }>();
 const model = defineModel<number | null>({ required: true });
 const emit = defineEmits<{ (e: "manualRefresh"): Promise<void> }>();
 const autoRefreshOptionsText: [number, string][] = [
@@ -43,24 +43,6 @@ watch(selectedRefresh, (newValue) => {
     }
   }
 });
-const MIN_SPIN_MS = 1000;
-const showSpinning = ref(false);
-let spinStartTime = 0;
-
-watch(
-  () => props.isLoading,
-  (newValue) => {
-    if (newValue) {
-      showSpinning.value = true;
-      spinStartTime = Date.now();
-    } else {
-      const remaining = Math.max(0, MIN_SPIN_MS - (Date.now() - spinStartTime));
-      setTimeout(() => {
-        showSpinning.value = false;
-      }, remaining);
-    }
-  }
-);
 async function refresh() {
   await emit("manualRefresh");
 }
@@ -68,11 +50,11 @@ async function refresh() {
 
 <template>
   <div class="refresh-config">
-    <ActionButton size="sm" :icon="faRefresh" :loading="showSpinning" @click="refresh">Refresh List</ActionButton>
+    <ActionButton size="sm" :icon="faRefresh" :loading="props.queryInProgress" :disabled="props.queryInProgress" @click="refresh">Refresh List</ActionButton>
     <div class="filter">
       <div class="filter-label">Auto-Refresh:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="autoRefreshOptionsText.map((i) => i[1])" v-model="selectedRefresh" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" />
+        <ListFilterSelector :items="autoRefreshOptionsText.map((i) => i[1])" v-model="selectedRefresh" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" :disabled="props.queryInProgress" />
       </div>
     </div>
   </div>

--- a/src/Frontend/src/components/RefreshConfig.vue
+++ b/src/Frontend/src/components/RefreshConfig.vue
@@ -43,15 +43,21 @@ watch(selectedRefresh, (newValue) => {
     }
   }
 });
+const MIN_SPIN_MS = 1000;
 const showSpinning = ref(false);
+let spinStartTime = 0;
+
 watch(
   () => props.isLoading,
   (newValue) => {
     if (newValue) {
       showSpinning.value = true;
+      spinStartTime = Date.now();
+    } else {
+      const remaining = Math.max(0, MIN_SPIN_MS - (Date.now() - spinStartTime));
       setTimeout(() => {
         showSpinning.value = false;
-      }, 1000);
+      }, remaining);
     }
   }
 );

--- a/src/Frontend/src/components/audit/AuditList.spec.ts
+++ b/src/Frontend/src/components/audit/AuditList.spec.ts
@@ -8,7 +8,7 @@ import AuditList from "@/components/audit/AuditList.vue";
 import { type default as Message, MessageStatus } from "@/resources/Message";
 
 /**
- * DSL for the Audit Messages Loading Indicator feature.
+ * DSL for the Audit Messages Query State feature.
  *
  * This specification focuses on user-visible loading feedback, not
  * implementation details of how fetching is managed internally.
@@ -31,19 +31,21 @@ import useFetchWithAutoRefresh from "@/composables/autoRefresh";
 
 // ==================== DSL Interfaces ====================
 
-interface LoadingAssertions {
+interface QueryStateAssertions {
   spinnerIsVisible(): void;
   spinnerIsNotVisible(): void;
   overlayIsVisible(): void;
   overlayIsNotVisible(): void;
   messagesAreVisible(): void;
   messagesAreNotVisible(): void;
-  filtersAreDisabled(): void;
-  filtersAreEnabled(): void;
+  refreshControlsKnowQueryIsInProgress(): void;
+  refreshControlsKnowQueryIsIdle(): void;
+  filtersKnowQueryIsInProgress(): void;
+  filtersKnowQueryIsIdle(): void;
 }
 
 interface RenderResult {
-  verify: LoadingAssertions;
+  verify: QueryStateAssertions;
   isRefreshing: Ref<boolean>;
 }
 
@@ -67,6 +69,10 @@ function getMessageItems(): HTMLElement[] {
 
 function getFiltersPanel(): HTMLElement {
   return screen.getByTestId("filters-panel");
+}
+
+function getRefreshConfig(): HTMLElement {
+  return screen.getByTestId("refresh-config");
 }
 
 // ==================== Data Helpers ====================
@@ -127,8 +133,8 @@ async function renderAuditList(messages: Message[] = []): Promise<RenderResult> 
       plugins: [pinia, router],
       stubs: {
         AuditListItem: { template: '<div data-testid="message-item" />' },
-        RefreshConfig: true,
-        FiltersPanel: { template: '<div data-testid="filters-panel" :data-disabled="String(disabled)" />', props: ["disabled"] },
+        RefreshConfig: { template: '<div data-testid="refresh-config" :data-query-in-progress="String(queryInProgress)" />', props: ["queryInProgress"] },
+        FiltersPanel: { template: '<div data-testid="filters-panel" :data-query-in-progress="String(queryInProgress)" />', props: ["queryInProgress"] },
         ResultsCount: true,
         WizardDialog: true,
         PageBanner: true,
@@ -136,7 +142,7 @@ async function renderAuditList(messages: Message[] = []): Promise<RenderResult> 
     },
   });
 
-  const verify: LoadingAssertions = {
+  const verify: QueryStateAssertions = {
     spinnerIsVisible() {
       expect(getSpinner()).toBeInTheDocument();
     },
@@ -155,11 +161,17 @@ async function renderAuditList(messages: Message[] = []): Promise<RenderResult> 
     messagesAreNotVisible() {
       expect(getMessageItems()).toHaveLength(0);
     },
-    filtersAreDisabled() {
-      expect(getFiltersPanel().dataset.disabled).toBe("true");
+    refreshControlsKnowQueryIsInProgress() {
+      expect(getRefreshConfig().dataset.queryInProgress).toBe("true");
     },
-    filtersAreEnabled() {
-      expect(getFiltersPanel().dataset.disabled).toBe("false");
+    refreshControlsKnowQueryIsIdle() {
+      expect(getRefreshConfig().dataset.queryInProgress).toBe("false");
+    },
+    filtersKnowQueryIsInProgress() {
+      expect(getFiltersPanel().dataset.queryInProgress).toBe("true");
+    },
+    filtersKnowQueryIsIdle() {
+      expect(getFiltersPanel().dataset.queryInProgress).toBe("false");
     },
   };
 
@@ -173,7 +185,7 @@ async function waitForFirstLoadToComplete() {
 
 // ==================== Tests ====================
 
-describe("FEATURE: Audit Messages Loading Indicator", () => {
+describe("FEATURE: Audit Messages Query State", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -184,6 +196,8 @@ describe("FEATURE: Audit Messages Loading Indicator", () => {
 
       verify.spinnerIsVisible();
       verify.messagesAreNotVisible();
+      verify.refreshControlsKnowQueryIsInProgress();
+      verify.filtersKnowQueryIsInProgress();
     });
 
     test("EXAMPLE: Spinner is hidden after the first fetch completes", async () => {
@@ -193,6 +207,8 @@ describe("FEATURE: Audit Messages Loading Indicator", () => {
 
       await waitFor(() => verify.spinnerIsNotVisible());
       verify.overlayIsNotVisible();
+      verify.refreshControlsKnowQueryIsIdle();
+      verify.filtersKnowQueryIsIdle();
     });
   });
 
@@ -224,8 +240,8 @@ describe("FEATURE: Audit Messages Loading Indicator", () => {
     });
   });
 
-  describe("RULE: Filter controls are disabled during a fetch", () => {
-    test("EXAMPLE: Filters are disabled when a re-fetch is in-flight", async () => {
+  describe("RULE: Query controls are disabled during a fetch", () => {
+    test("EXAMPLE: Query controls are disabled when a re-fetch is in-flight", async () => {
       const { verify, isRefreshing } = await renderAuditList([]);
 
       await waitForFirstLoadToComplete();
@@ -233,10 +249,11 @@ describe("FEATURE: Audit Messages Loading Indicator", () => {
       isRefreshing.value = true;
       await nextTick();
 
-      verify.filtersAreDisabled();
+      verify.refreshControlsKnowQueryIsInProgress();
+      verify.filtersKnowQueryIsInProgress();
     });
 
-    test("EXAMPLE: Filters are re-enabled after the fetch completes", async () => {
+    test("EXAMPLE: Query controls are re-enabled after the fetch completes", async () => {
       const { verify, isRefreshing } = await renderAuditList([]);
 
       await waitForFirstLoadToComplete();
@@ -247,7 +264,8 @@ describe("FEATURE: Audit Messages Loading Indicator", () => {
       isRefreshing.value = false;
       await nextTick();
 
-      verify.filtersAreEnabled();
+      verify.refreshControlsKnowQueryIsIdle();
+      verify.filtersKnowQueryIsIdle();
     });
   });
 

--- a/src/Frontend/src/components/audit/AuditList.spec.ts
+++ b/src/Frontend/src/components/audit/AuditList.spec.ts
@@ -5,7 +5,7 @@ import { createRouter, createMemoryHistory } from "vue-router";
 import { ref, shallowReadonly, nextTick, type Ref } from "vue";
 import { flushPromises } from "@vue/test-utils";
 import AuditList from "@/components/audit/AuditList.vue";
-import Message, { MessageStatus } from "@/resources/Message";
+import { type default as Message, MessageStatus } from "@/resources/Message";
 
 /**
  * DSL for the Audit Messages Loading Indicator feature.

--- a/src/Frontend/src/components/audit/AuditList.spec.ts
+++ b/src/Frontend/src/components/audit/AuditList.spec.ts
@@ -38,6 +38,8 @@ interface LoadingAssertions {
   overlayIsNotVisible(): void;
   messagesAreVisible(): void;
   messagesAreNotVisible(): void;
+  filtersAreDisabled(): void;
+  filtersAreEnabled(): void;
 }
 
 interface RenderResult {
@@ -61,6 +63,10 @@ function getLoadingOverlay(): Element | null {
 
 function getMessageItems(): HTMLElement[] {
   return screen.queryAllByTestId("message-item");
+}
+
+function getFiltersPanel(): HTMLElement {
+  return screen.getByTestId("filters-panel");
 }
 
 // ==================== Data Helpers ====================
@@ -122,7 +128,7 @@ async function renderAuditList(messages: Message[] = []): Promise<RenderResult> 
       stubs: {
         AuditListItem: { template: '<div data-testid="message-item" />' },
         RefreshConfig: true,
-        FiltersPanel: true,
+        FiltersPanel: { template: '<div data-testid="filters-panel" :data-disabled="String(disabled)" />', props: ["disabled"] },
         ResultsCount: true,
         WizardDialog: true,
         PageBanner: true,
@@ -148,6 +154,12 @@ async function renderAuditList(messages: Message[] = []): Promise<RenderResult> 
     },
     messagesAreNotVisible() {
       expect(getMessageItems()).toHaveLength(0);
+    },
+    filtersAreDisabled() {
+      expect(getFiltersPanel().dataset.disabled).toBe("true");
+    },
+    filtersAreEnabled() {
+      expect(getFiltersPanel().dataset.disabled).toBe("false");
     },
   };
 
@@ -209,6 +221,33 @@ describe("FEATURE: Audit Messages Loading Indicator", () => {
       isRefreshing.value = false;
       await nextTick();
       verify.spinnerIsNotVisible();
+    });
+  });
+
+  describe("RULE: Filter controls are disabled during a fetch", () => {
+    test("EXAMPLE: Filters are disabled when a re-fetch is in-flight", async () => {
+      const { verify, isRefreshing } = await renderAuditList([]);
+
+      await waitForFirstLoadToComplete();
+
+      isRefreshing.value = true;
+      await nextTick();
+
+      verify.filtersAreDisabled();
+    });
+
+    test("EXAMPLE: Filters are re-enabled after the fetch completes", async () => {
+      const { verify, isRefreshing } = await renderAuditList([]);
+
+      await waitForFirstLoadToComplete();
+
+      isRefreshing.value = true;
+      await nextTick();
+
+      isRefreshing.value = false;
+      await nextTick();
+
+      verify.filtersAreEnabled();
     });
   });
 

--- a/src/Frontend/src/components/audit/AuditList.spec.ts
+++ b/src/Frontend/src/components/audit/AuditList.spec.ts
@@ -1,0 +1,245 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/vue";
+import { createTestingPinia } from "@pinia/testing";
+import { createRouter, createMemoryHistory } from "vue-router";
+import { ref, shallowReadonly, nextTick } from "vue";
+import type { Ref } from "vue";
+import { flushPromises } from "@vue/test-utils";
+import AuditList from "@/components/audit/AuditList.vue";
+import type Message from "@/resources/Message";
+import { MessageStatus } from "@/resources/Message";
+
+/**
+ * DSL for the Audit Messages Loading Indicator feature.
+ *
+ * This specification focuses on user-visible loading feedback, not
+ * implementation details of how fetching is managed internally.
+ *
+ * If the loading UI changes (overlay becomes skeleton, spinner moves, etc.),
+ * only the helper functions below need updating — the tests remain unchanged.
+ */
+
+// ==================== Mock Setup ====================
+
+vi.mock("@/composables/autoRefresh");
+vi.mock("@/components/platformcapabilities/capabilities/AuditingCapability", () => ({
+  useAuditingCapability: () => ({ status: { value: "Available" } }),
+}));
+vi.mock("@/components/platformcapabilities/wizards/AuditingWizardPages", () => ({
+  getAuditingWizardPages: () => [],
+}));
+
+import useFetchWithAutoRefresh from "@/composables/autoRefresh";
+
+// ==================== DSL Interfaces ====================
+
+interface LoadingAssertions {
+  spinnerIsVisible(): void;
+  spinnerIsNotVisible(): void;
+  overlayIsVisible(): void;
+  overlayIsNotVisible(): void;
+  messagesAreVisible(): void;
+  messagesAreNotVisible(): void;
+}
+
+interface RenderResult {
+  verify: LoadingAssertions;
+  isRefreshing: Ref<boolean>;
+}
+
+// ==================== DOM Query Helpers ====================
+
+function getSpinner(): Element | null {
+  const spinners = document.querySelectorAll(".spinner-border");
+  for (const el of spinners) {
+    if (!el.closest(".loading-overlay")) return el;
+  }
+  return null;
+}
+
+function getLoadingOverlay(): Element | null {
+  return document.querySelector(".loading-overlay");
+}
+
+function getMessageItems(): HTMLElement[] {
+  return screen.queryAllByTestId("message-item");
+}
+
+// ==================== Data Helpers ====================
+
+function createMessage(id = "msg-1"): Message {
+  return {
+    id,
+    message_id: id,
+    message_type: "TestMessage",
+    sending_endpoint: { name: "Sender", host_id: "h1", host: "localhost" },
+    receiving_endpoint: { name: "Receiver", host_id: "h2", host: "localhost" },
+    time_sent: new Date().toISOString(),
+    processed_at: new Date().toISOString(),
+    critical_time: "00:00:00",
+    processing_time: "00:00:00",
+    delivery_time: "00:00:00",
+    is_system_message: false,
+    conversation_id: "conv-1",
+    headers: [],
+    status: MessageStatus.Successful,
+    message_intent: "send" as never,
+    body_url: "",
+    body_size: 0,
+    instance_id: "instance-1",
+  };
+}
+
+// ==================== Component Renderer ====================
+
+async function renderAuditList(messages: Message[] = []): Promise<RenderResult> {
+  const isRefreshing = ref(false);
+
+  vi.mocked(useFetchWithAutoRefresh).mockReturnValue({
+    refreshNow: vi.fn().mockResolvedValue(undefined),
+    isRefreshing: shallowReadonly(isRefreshing),
+    updateInterval: vi.fn(),
+    isActive: ref(false),
+    start: vi.fn(),
+    stop: vi.fn(),
+  });
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: "/messages", component: { template: "<div />" } }],
+  });
+  await router.push("/messages");
+  await router.isReady();
+
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    initialState: {
+      AuditStore: { messages, totalCount: messages.length },
+    },
+  });
+
+  render(AuditList, {
+    global: {
+      plugins: [pinia, router],
+      stubs: {
+        AuditListItem: { template: '<div data-testid="message-item" />' },
+        RefreshConfig: true,
+        FiltersPanel: true,
+        ResultsCount: true,
+        WizardDialog: true,
+        PageBanner: true,
+      },
+    },
+  });
+
+  const verify: LoadingAssertions = {
+    spinnerIsVisible() {
+      expect(getSpinner()).toBeInTheDocument();
+    },
+    spinnerIsNotVisible() {
+      expect(getSpinner()).not.toBeInTheDocument();
+    },
+    overlayIsVisible() {
+      expect(getLoadingOverlay()).toBeInTheDocument();
+    },
+    overlayIsNotVisible() {
+      expect(getLoadingOverlay()).not.toBeInTheDocument();
+    },
+    messagesAreVisible() {
+      expect(getMessageItems().length).toBeGreaterThan(0);
+    },
+    messagesAreNotVisible() {
+      expect(getMessageItems()).toHaveLength(0);
+    },
+  };
+
+  return { verify, isRefreshing };
+}
+
+async function waitForFirstLoadToComplete() {
+  await new Promise((r) => setTimeout(r, 0));
+  await flushPromises();
+}
+
+// ==================== Tests ====================
+
+describe("FEATURE: Audit Messages Loading Indicator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("RULE: A spinner is shown during the initial page load", () => {
+    test("EXAMPLE: Spinner is visible before the first fetch completes", async () => {
+      const { verify } = await renderAuditList();
+
+      verify.spinnerIsVisible();
+      verify.messagesAreNotVisible();
+    });
+
+    test("EXAMPLE: Spinner is hidden after the first fetch completes", async () => {
+      const { verify } = await renderAuditList([createMessage()]);
+
+      await waitForFirstLoadToComplete();
+
+      await waitFor(() => verify.spinnerIsNotVisible());
+      verify.overlayIsNotVisible();
+    });
+  });
+
+  describe("RULE: A spinner is shown when re-fetching with no existing results", () => {
+    test("EXAMPLE: Spinner is shown when a new fetch starts with an empty message list", async () => {
+      const { verify, isRefreshing } = await renderAuditList([]);
+
+      await waitForFirstLoadToComplete();
+
+      isRefreshing.value = true;
+      await nextTick();
+
+      verify.spinnerIsVisible();
+      verify.messagesAreNotVisible();
+    });
+
+    test("EXAMPLE: Spinner is hidden after the re-fetch completes", async () => {
+      const { verify, isRefreshing } = await renderAuditList([]);
+
+      await waitForFirstLoadToComplete();
+
+      isRefreshing.value = true;
+      await nextTick();
+      verify.spinnerIsVisible();
+
+      isRefreshing.value = false;
+      await nextTick();
+      verify.spinnerIsNotVisible();
+    });
+  });
+
+  describe("RULE: A loading overlay is shown when re-fetching with existing results", () => {
+    test("EXAMPLE: Overlay appears over existing messages while a re-fetch is in-flight", async () => {
+      const { verify, isRefreshing } = await renderAuditList([createMessage()]);
+
+      await waitForFirstLoadToComplete();
+      await waitFor(() => verify.messagesAreVisible());
+
+      isRefreshing.value = true;
+      await nextTick();
+
+      verify.overlayIsVisible();
+      verify.messagesAreVisible();
+    });
+
+    test("EXAMPLE: Overlay disappears after the re-fetch completes", async () => {
+      const { verify, isRefreshing } = await renderAuditList([createMessage()]);
+
+      await waitForFirstLoadToComplete();
+
+      isRefreshing.value = true;
+      await nextTick();
+      verify.overlayIsVisible();
+
+      isRefreshing.value = false;
+      await nextTick();
+      verify.overlayIsNotVisible();
+    });
+  });
+});

--- a/src/Frontend/src/components/audit/AuditList.spec.ts
+++ b/src/Frontend/src/components/audit/AuditList.spec.ts
@@ -2,12 +2,10 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/vue";
 import { createTestingPinia } from "@pinia/testing";
 import { createRouter, createMemoryHistory } from "vue-router";
-import { ref, shallowReadonly, nextTick } from "vue";
-import type { Ref } from "vue";
+import { ref, shallowReadonly, nextTick, type Ref } from "vue";
 import { flushPromises } from "@vue/test-utils";
 import AuditList from "@/components/audit/AuditList.vue";
-import type Message from "@/resources/Message";
-import { MessageStatus } from "@/resources/Message";
+import Message, { MessageStatus } from "@/resources/Message";
 
 /**
  * DSL for the Audit Messages Loading Indicator feature.

--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -190,6 +190,11 @@ watch(autoRefreshValue, (newValue) => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+}
+
+.loading-overlay .spinner-border {
+  position: sticky;
+  top: 4rem;
+  margin-top: 2rem;
 }
 </style>

--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -23,6 +23,7 @@ const router = useRouter();
 const autoRefreshValue = ref<number | null>(null);
 const { refreshNow, isRefreshing, updateInterval, isActive, start, stop } = useFetchWithAutoRefresh("audit-list", store.refresh, 0);
 const firstLoad = ref(true);
+const queryInProgress = computed(() => firstLoad.value || isRefreshing.value);
 const showWizard = ref(false);
 const { status: auditStatus } = useAuditingCapability();
 const wizardPages = computed(() => getAuditingWizardPages(auditStatus.value));
@@ -136,9 +137,9 @@ watch(autoRefreshValue, (newValue) => {
 <template>
   <div>
     <div class="header">
-      <RefreshConfig v-model="autoRefreshValue" :isLoading="isRefreshing" @manual-refresh="refreshNow" />
+      <RefreshConfig v-model="autoRefreshValue" :query-in-progress="queryInProgress" @manual-refresh="refreshNow" />
       <div class="row">
-        <FiltersPanel :disabled="isRefreshing" />
+        <FiltersPanel :query-in-progress="queryInProgress" />
       </div>
       <div class="row">
         <ResultsCount :displayed="messages.length" :total="totalCount" />

--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -148,15 +148,10 @@ watch(autoRefreshValue, (newValue) => {
     </div>
     <WizardDialog v-if="showWizard" title="Getting Started with Auditing" :pages="wizardPages" @close="showWizard = false" />
     <div class="row results-table">
-      <LoadingSpinner v-if="firstLoad || (messages.length === 0 && isRefreshing)" />
-      <template v-else v-for="message in messages" :key="message.id">
+      <LoadingSpinner v-if="firstLoad || isRefreshing" :overlay="isRefreshing && messages.length > 0" />
+      <template v-for="message in messages" :key="message.id">
         <AuditListItem :message="message" />
       </template>
-      <div v-if="isRefreshing && messages.length > 0" class="loading-overlay">
-        <div class="spinner-border" role="status">
-          <span class="visually-hidden">Loading...</span>
-        </div>
-      </div>
     </div>
   </div>
 </template>
@@ -179,20 +174,5 @@ watch(autoRefreshValue, (newValue) => {
   margin-bottom: 5rem;
   background-color: #ffffff;
   position: relative;
-}
-
-.loading-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.9);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.loading-overlay .spinner-border {
-  position: sticky;
-  top: 4rem;
-  margin-top: 2rem;
 }
 </style>

--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -183,10 +183,7 @@ watch(autoRefreshValue, (newValue) => {
 
 .loading-overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background: rgba(255, 255, 255, 0.9);
   display: flex;
   flex-direction: column;

--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -138,7 +138,7 @@ watch(autoRefreshValue, (newValue) => {
     <div class="header">
       <RefreshConfig v-model="autoRefreshValue" :isLoading="isRefreshing" @manual-refresh="refreshNow" />
       <div class="row">
-        <FiltersPanel />
+        <FiltersPanel :disabled="isRefreshing" />
       </div>
       <div class="row">
         <ResultsCount :displayed="messages.length" :total="totalCount" />

--- a/src/Frontend/src/components/audit/AuditList.vue
+++ b/src/Frontend/src/components/audit/AuditList.vue
@@ -147,10 +147,15 @@ watch(autoRefreshValue, (newValue) => {
     </div>
     <WizardDialog v-if="showWizard" title="Getting Started with Auditing" :pages="wizardPages" @close="showWizard = false" />
     <div class="row results-table">
-      <LoadingSpinner v-if="firstLoad" />
-      <template v-for="message in messages" :key="message.id">
+      <LoadingSpinner v-if="firstLoad || (messages.length === 0 && isRefreshing)" />
+      <template v-else v-for="message in messages" :key="message.id">
         <AuditListItem :message="message" />
       </template>
+      <div v-if="isRefreshing && messages.length > 0" class="loading-overlay">
+        <div class="spinner-border" role="status">
+          <span class="visually-hidden">Loading...</span>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -172,5 +177,19 @@ watch(autoRefreshValue, (newValue) => {
   margin-top: 1rem;
   margin-bottom: 5rem;
   background-color: #ffffff;
+  position: relative;
+}
+
+.loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.9);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 </style>

--- a/src/Frontend/src/components/audit/DatePickerRange.vue
+++ b/src/Frontend/src/components/audit/DatePickerRange.vue
@@ -7,6 +7,7 @@ import { useDateFormatter } from "@/composables/dateFormatter";
 
 const { formatDateRange, isValidDateRange } = useDateFormatter();
 
+const props = defineProps<{ disabled?: boolean }>();
 const model = defineModel<DateRange>({ required: true });
 const internalModel = ref<DateRange>([]);
 const displayDataRange = ref<string>("No dates");
@@ -39,13 +40,14 @@ function clearCurrentDate() {
     ref="datePicker"
     class="dropdown"
     v-model="internalModel"
+    :disabled="props.disabled"
     :formats="{ input: (dates: Date[]) => formatDateRange(dates as DateRange) }"
     :range="{ partialRange: false }"
     :time-config="{ enableSeconds: true }"
     :action-row="{ showNow: false, showCancel: false, showSelect: true }"
   >
     <template #trigger>
-      <button type="button" class="btn btn-dropdown dropdown-toggle sp-btn-menu">
+      <button type="button" class="btn btn-dropdown dropdown-toggle sp-btn-menu" :disabled="props.disabled">
         {{ displayDataRange }}
       </button>
     </template>

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -6,6 +6,7 @@ import ListFilterSelector from "@/components/audit/ListFilterSelector.vue";
 import { computed } from "vue";
 import DatePickerRange from "@/components/audit/DatePickerRange.vue";
 
+const props = defineProps<{ disabled?: boolean }>();
 const store = useAuditStore();
 const { sortBy, messageFilterString, selectedEndpointName, endpoints, itemsPerPage, dateRange } = storeToRefs(store);
 const endpointNames = computed(() => {
@@ -59,32 +60,32 @@ function findKeyByValue(searchValue: string) {
     <div class="filter">
       <div class="filter-label"></div>
       <div class="filter-component text-search-container">
-        <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" />
+        <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" :disabled="props.disabled" />
         <div class="note">Check the <a href="https://docs.particular.net/servicepulse/all-messages#filtering-options">documentation</a> to see the available filtering options</div>
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Endpoint:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="endpointNames" instructions="Select an endpoint" v-model="selectedEndpointName" item-name="endpoint" label="Endpoint" default-empty-text="Any" :show-clear="true" :show-filter="true" />
+        <ListFilterSelector :items="endpointNames" instructions="Select an endpoint" v-model="selectedEndpointName" item-name="endpoint" label="Endpoint" default-empty-text="Any" :show-clear="true" :show-filter="true" :disabled="props.disabled" />
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Dates:</div>
       <div class="filter-component">
-        <DatePickerRange v-model="dateRange" />
+        <DatePickerRange v-model="dateRange" :disabled="props.disabled" />
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Show:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="numberOfItemsPerPage" instructions="Max results to display" v-model="selectedItemsPerPage" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" />
+        <ListFilterSelector :items="numberOfItemsPerPage" instructions="Max results to display" v-model="selectedItemsPerPage" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" :disabled="props.disabled" />
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Sort:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="sortByItems" v-model="selectedSortByItem" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" />
+        <ListFilterSelector :items="sortByItems" v-model="selectedSortByItem" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" :disabled="props.disabled" />
       </div>
     </div>
   </div>

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -77,7 +77,7 @@ function findKeyByValue(searchValue: string) {
           :show-clear="true"
           :show-filter="true"
           :disabled="props.queryInProgress"
-       />
+        />
       </div>
     </div>
     <div class="filter">

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -6,7 +6,7 @@ import ListFilterSelector from "@/components/audit/ListFilterSelector.vue";
 import { computed } from "vue";
 import DatePickerRange from "@/components/audit/DatePickerRange.vue";
 
-const props = defineProps<{ disabled?: boolean }>();
+const props = defineProps<{ queryInProgress?: boolean }>();
 const store = useAuditStore();
 const { sortBy, messageFilterString, selectedEndpointName, endpoints, itemsPerPage, dateRange } = storeToRefs(store);
 const endpointNames = computed(() => {
@@ -60,32 +60,32 @@ function findKeyByValue(searchValue: string) {
     <div class="filter">
       <div class="filter-label"></div>
       <div class="filter-component text-search-container">
-        <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" :disabled="props.disabled" />
+        <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" :disabled="props.queryInProgress" />
         <div class="note">Check the <a href="https://docs.particular.net/servicepulse/all-messages#filtering-options">documentation</a> to see the available filtering options</div>
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Endpoint:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="endpointNames" instructions="Select an endpoint" v-model="selectedEndpointName" item-name="endpoint" label="Endpoint" default-empty-text="Any" :show-clear="true" :show-filter="true" :disabled="props.disabled" />
+        <ListFilterSelector :items="endpointNames" instructions="Select an endpoint" v-model="selectedEndpointName" item-name="endpoint" label="Endpoint" default-empty-text="Any" :show-clear="true" :show-filter="true" :disabled="props.queryInProgress" />
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Dates:</div>
       <div class="filter-component">
-        <DatePickerRange v-model="dateRange" :disabled="props.disabled" />
+        <DatePickerRange v-model="dateRange" :disabled="props.queryInProgress" />
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Show:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="numberOfItemsPerPage" instructions="Max results to display" v-model="selectedItemsPerPage" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" :disabled="props.disabled" />
+        <ListFilterSelector :items="numberOfItemsPerPage" instructions="Max results to display" v-model="selectedItemsPerPage" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" :disabled="props.queryInProgress" />
       </div>
     </div>
     <div class="filter">
       <div class="filter-label">Sort:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="sortByItems" v-model="selectedSortByItem" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" :disabled="props.disabled" />
+        <ListFilterSelector :items="sortByItems" v-model="selectedSortByItem" item-name="result" :can-clear="false" :show-clear="false" :show-filter="false" :disabled="props.queryInProgress" />
       </div>
     </div>
   </div>

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -67,7 +67,16 @@ function findKeyByValue(searchValue: string) {
     <div class="filter">
       <div class="filter-label">Endpoint:</div>
       <div class="filter-component">
-        <ListFilterSelector :items="endpointNames" instructions="Select an endpoint" v-model="selectedEndpointName" item-name="endpoint" label="Endpoint" default-empty-text="Any" :show-clear="true" :show-filter="true" :disabled="props.queryInProgress" />
+        <ListFilterSelector 
+            :items="endpointNames"
+            instructions="Select an endpoint" 
+            v-model="selectedEndpointName" 
+            item-name="endpoint" 
+            label="Endpoint" 
+            default-empty-text="Any" 
+            :show-clear="true" 
+            :show-filter="true" 
+            :disabled="props.queryInProgress" />
       </div>
     </div>
     <div class="filter">

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -69,15 +69,15 @@ function findKeyByValue(searchValue: string) {
       <div class="filter-component">
         <ListFilterSelector
           :items="endpointNames"
-            instructions="Select an endpoint"
-            v-model="selectedEndpointName"
-            item-name="endpoint"
-            label="Endpoint"
-            default-empty-text="Any"
-            :show-clear="true"
-            :show-filter="true"
-            :disabled="props.queryInProgress"
-             />
+          instructions="Select an endpoint"
+          v-model="selectedEndpointName"
+          item-name="endpoint"
+          label="Endpoint"
+          default-empty-text="Any"
+          :show-clear="true"
+          :show-filter="true"
+          :disabled="props.queryInProgress"
+       />
       </div>
     </div>
     <div class="filter">

--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -67,16 +67,17 @@ function findKeyByValue(searchValue: string) {
     <div class="filter">
       <div class="filter-label">Endpoint:</div>
       <div class="filter-component">
-        <ListFilterSelector 
-            :items="endpointNames"
-            instructions="Select an endpoint" 
-            v-model="selectedEndpointName" 
-            item-name="endpoint" 
-            label="Endpoint" 
-            default-empty-text="Any" 
-            :show-clear="true" 
-            :show-filter="true" 
-            :disabled="props.queryInProgress" />
+        <ListFilterSelector
+          :items="endpointNames"
+            instructions="Select an endpoint"
+            v-model="selectedEndpointName"
+            item-name="endpoint"
+            label="Endpoint"
+            default-empty-text="Any"
+            :show-clear="true"
+            :show-filter="true"
+            :disabled="props.queryInProgress"
+             />
       </div>
     </div>
     <div class="filter">

--- a/src/Frontend/src/components/audit/ListFilterSelector.vue
+++ b/src/Frontend/src/components/audit/ListFilterSelector.vue
@@ -14,6 +14,7 @@ const props = withDefaults(
     canClear?: boolean;
     showClear: boolean;
     showFilter: boolean;
+    disabled?: boolean;
   }>(),
   { canClear: true }
 );
@@ -42,7 +43,7 @@ onMounted(() => {
 
 <template>
   <div ref="bootstrapDropDown" class="dropdown">
-    <button type="button" aria-label="open dropdown menu" class="btn btn-dropdown dropdown-toggle sp-btn-menu" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button type="button" aria-label="open dropdown menu" class="btn btn-dropdown dropdown-toggle sp-btn-menu" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" :disabled="props.disabled">
       <span class="wrap-text">{{ selected || defaultEmptyText }}</span>
     </button>
     <div class="dropdown-menu wrapper">


### PR DESCRIPTION
### Symptoms

### Who's affected
All users of ServicePulse, but more so those where HTTP requests to ServiceControl from the Messages view take longer to resolve.

### Root cause
The UI only had a loading indicator showing on the first load, not on subsequent requests from auto-refresh, searching, or filtering.

### Confirmed workarounds
None

### Additional Information

When HTTP calls to ServiceControl take longer than expected, the audit messages view does not make it clear that the user is waiting for something to finish. This introduces some UI improvements to help with that:
- The message list now shows the loading spinner with an overlay when waiting on an HTTP call
- The refresh button is linked to HTTP calls instead of becoming ready after a hardcoded 1 second
- The search and filter controls become disabled along with the refresh button while data is being fetched

## Reviewer Checklist

- [x] Components are broken down into sensible and maintainable sub-components.
- [x] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [x] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [x] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [x] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
