### PR TITLE
My permissions page always shows even if authorization is disabled

### DIFF
--- a/src/Frontend/src/components/configuration/UserPermissions.vue
+++ b/src/Frontend/src/components/configuration/UserPermissions.vue
@@ -89,12 +89,15 @@ export const groups: ApplicationCapabilityGroup[] = [
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { storeToRefs } from "pinia";
 import { faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
 import FAIcon from "@/components/FAIcon.vue";
 import ConditionalRender from "@/components/ConditionalRender.vue";
 import { useAllowedRoutes } from "@/composables/useAllowedRoutes";
+import { useAuthStore } from "@/stores/AuthStore";
 
 const { canCall, supported, roles } = useAllowedRoutes();
+const { authorizationEnabled } = storeToRefs(useAuthStore());
 
 const rows = computed(() =>
   groups.map((g) => ({
@@ -130,7 +133,21 @@ const rows = computed(() =>
           </div>
         </template>
 
-        <table class="permissions-table">
+        <div v-if="authorizationEnabled === false" class="container not-supported">
+          <div class="row">
+            <div class="col-sm-12">
+              <div class="text-center message">
+                <p>Role-based access control is not enabled.</p>
+                <p>Control who can see and do what in ServicePulse. Role-based authorization lets you restrict failed message retries, endpoint management, and other sensitive actions to the right people.</p>
+                <div>
+                  <a class="btn btn-default btn-primary" href="https://docs.particular.net/servicecontrol/security/configuration/authorization" target="_blank">Learn how to enable authorization</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <table v-else class="permissions-table">
           <thead>
             <tr>
               <th scope="col" class="area-col">Area</th>

--- a/src/Frontend/src/stores/AuthStore.ts
+++ b/src/Frontend/src/stores/AuthStore.ts
@@ -8,6 +8,8 @@ import serviceControlClient from "@/components/serviceControlClient";
 
 interface AuthConfigResponse {
   enabled: boolean;
+  // Absent on ServiceControl versions older than the one that introduced this field.
+  role_based_authorization_enabled?: boolean;
   client_id: string;
   authority: string;
   api_scopes: string;
@@ -21,6 +23,8 @@ export const useAuthStore = defineStore("auth", () => {
   const authError = ref<string | null>(null);
   const authConfig = ref<AuthConfig | null>(null);
   const authEnabled = ref(false);
+  // undefined means ServiceControl didn't report this field (older version) — treat as enabled.
+  const authorizationEnabled = ref<boolean | undefined>(undefined);
   const loading = ref(true);
 
   async function refresh() {
@@ -29,6 +33,7 @@ export const useAuthStore = defineStore("auth", () => {
       const config = await getAuthConfig();
       if (config) {
         authEnabled.value = config.enabled;
+        authorizationEnabled.value = config.role_based_authorization_enabled;
         authConfig.value = config.enabled ? transformToAuthConfig(config) : null;
       }
     } finally {
@@ -108,6 +113,7 @@ export const useAuthStore = defineStore("auth", () => {
     authError,
     authConfig,
     authEnabled,
+    authorizationEnabled,
     loading,
     refresh,
     setToken,

--- a/src/Frontend/test/preconditions/authentication.ts
+++ b/src/Frontend/test/preconditions/authentication.ts
@@ -7,6 +7,7 @@ import * as precondition from ".";
  */
 export interface AuthConfigResponse {
   enabled: boolean;
+  role_based_authorization_enabled: boolean;
   client_id: string;
   authority: string;
   api_scopes: string;
@@ -19,6 +20,7 @@ export interface AuthConfigResponse {
  */
 export const authDisabledConfig: AuthConfigResponse = {
   enabled: false,
+  role_based_authorization_enabled: false,
   client_id: "",
   authority: "",
   api_scopes: "[]",
@@ -31,6 +33,7 @@ export const authDisabledConfig: AuthConfigResponse = {
  */
 export const authEnabledConfig: AuthConfigResponse = {
   enabled: true,
+  role_based_authorization_enabled: true,
   client_id: "servicepulse-test",
   authority: "https://login.microsoftonline.com/test-tenant-id/v2.0",
   api_scopes: '["api://servicecontrol/access_as_user"]',


### PR DESCRIPTION
Doesn't show the roles and permissions if ServiceControl reports that authorization is disabled.

Current behaviour only changes once the following is merged:

- https://github.com/Particular/ServiceControl/pull/5588