### PR TITLE
Tippy warnings suggestions

### DIFF
--- a/src/Frontend/src/components/PermissionGate.spec.ts
+++ b/src/Frontend/src/components/PermissionGate.spec.ts
@@ -6,7 +6,6 @@ function mountGate(allowed: boolean) {
   return render(PermissionGate, {
     props: { allowed, reason: "You don't have permission" },
     slots: { default: '<button class="btn">Do it</button>' },
-    global: { directives: { tippy: () => {} } },
   });
 }
 

--- a/src/Frontend/src/components/configuration/EndpointConnection.spec.ts
+++ b/src/Frontend/src/components/configuration/EndpointConnection.spec.ts
@@ -119,9 +119,6 @@ async function renderComponent({ initialState = {} }: { initialState?: Record<st
           stubActions: true,
         }),
       ],
-      directives: {
-        tippy: () => {},
-      },
       stubs: {
         RouterLink: true,
       },

--- a/src/Frontend/src/components/configuration/HealthCheckNotifications.spec.ts
+++ b/src/Frontend/src/components/configuration/HealthCheckNotifications.spec.ts
@@ -313,10 +313,6 @@ function renderComponent({ initialState = {} }: { initialState?: Record<string, 
           stubActions: true,
         }),
       ],
-      directives: {
-        // v-tippy is used by ActionButton; stub it in unit tests
-        tippy: () => {},
-      },
       stubs: {
         // RouterLink is used deep inside ServiceControlAvailable; stub it to
         // avoid "Failed to resolve component" warnings in unit tests

--- a/src/Frontend/src/components/failedmessages/messageGroupButtonPermissions.spec.ts
+++ b/src/Frontend/src/components/failedmessages/messageGroupButtonPermissions.spec.ts
@@ -60,7 +60,6 @@ async function renderGroupList(allowedRouteKeys: string[]) {
           },
         }),
       ],
-      directives: { tippy: () => {} },
     },
   });
 

--- a/src/Frontend/src/components/messages/SagaDiagram.spec.ts
+++ b/src/Frontend/src/components/messages/SagaDiagram.spec.ts
@@ -197,10 +197,6 @@ function rendercomponent({ initialState = {} }: { initialState?: { MessageStore?
         CodeEditor: true,
         CopyToClipboard: true,
       },
-      directives: {
-        // Add stub for tippy directive
-        tippy: () => {},
-      },
     },
   });
 

--- a/src/Frontend/src/components/messages/messageButtonPermissions.spec.ts
+++ b/src/Frontend/src/components/messages/messageButtonPermissions.spec.ts
@@ -49,7 +49,6 @@ function renderButton(component: Component, allowedRouteKeys: string[], archived
           },
         }),
       ],
-      directives: { tippy: () => {} },
     },
   });
 }

--- a/src/Frontend/src/views/ThroughputReportView.spec.ts
+++ b/src/Frontend/src/views/ThroughputReportView.spec.ts
@@ -40,10 +40,6 @@ describe("EndpointsView tests", () => {
           RouterLink: RouterLinkStub,
         },
         plugins: [makeRouter(), Toast],
-        directives: {
-          // Add stub for tippy directive
-          tippy: () => {},
-        },
       },
     });
     await flushPromises();

--- a/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/EndpointsView.spec.ts
@@ -34,10 +34,6 @@ describe("EndpointsView tests", () => {
           RouterLink: RouterLinkStub,
         },
         plugins: [makeRouter()],
-        directives: {
-          // Add stub for tippy directive
-          tippy: () => {},
-        },
       },
     });
     await flushPromises();

--- a/src/Frontend/src/views/throughputreport/SetupView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/SetupView.spec.ts
@@ -55,10 +55,6 @@ describe("SetupView tests", () => {
           RouterLink: RouterLinkStub,
         },
         plugins: [makeRouter()],
-        directives: {
-          // Add stub for tippy directive
-          tippy: () => {},
-        },
       },
     });
     await flushPromises();

--- a/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/endpoints/DetectedListView.spec.ts
@@ -38,8 +38,6 @@ describe("DetectedListView tests", () => {
       global: {
         directives: {
           tooltip: {},
-          // Add stub for tippy directive
-          tippy: () => {},
         },
       },
       container: document.body,

--- a/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/setup/DiagnosticsView.spec.ts
@@ -51,10 +51,6 @@ describe("DiagnosticsView tests", () => {
     const { debug } = render(DiagnosticsView, {
       global: {
         plugins: [],
-        directives: {
-          // Add stub for tippy directive
-          tippy: () => {},
-        },
       },
     });
 

--- a/src/Frontend/src/views/throughputreport/setup/MasksView.spec.ts
+++ b/src/Frontend/src/views/throughputreport/setup/MasksView.spec.ts
@@ -28,7 +28,7 @@ describe("MaskView tests", () => {
     driver.mockEndpoint(`${window.defaultConfig.service_control_url}licensing/settings/masks`, { body });
     setActivePinia(createTestingPinia({ stubActions: false }));
 
-    const { debug } = render(MasksView, { global: { plugins: [Toast], directives: { tippy: () => {} } } });
+    const { debug } = render(MasksView, { global: { plugins: [Toast] } });
     await flushPromises();
 
     return { debug, driver };

--- a/src/Frontend/test/drivers/vitest/setup.ts
+++ b/src/Frontend/test/drivers/vitest/setup.ts
@@ -6,8 +6,7 @@ import monitoringClient from "@/components/monitoring/monitoringClient";
 import serviceControlClient from "@/components/serviceControlClient";
 import VueTippy from "vue-tippy";
 
-// Removes warnings about tippy:
-// [Vue warn]: Failed to resolve directive: tippy 
+// Removes test warning noise failing to resolve tippy
 if (!config.global.plugins.includes(VueTippy)) {
   config.global.plugins.push(VueTippy);
 }

--- a/src/Frontend/test/drivers/vitest/setup.ts
+++ b/src/Frontend/test/drivers/vitest/setup.ts
@@ -1,8 +1,16 @@
 import { afterAll, beforeAll, beforeEach, vi } from "vitest";
+import { config } from "@vue/test-utils";
 import { mockServer } from "../../mock-server";
 import "@testing-library/jest-dom/vitest";
 import monitoringClient from "@/components/monitoring/monitoringClient";
 import serviceControlClient from "@/components/serviceControlClient";
+import VueTippy from "vue-tippy";
+
+// Removes warnings about tippy:
+// [Vue warn]: Failed to resolve directive: tippy 
+if (!config.global.plugins.includes(VueTippy)) {
+  config.global.plugins.push(VueTippy);
+}
 
 const defaultConfig = {
   default_route: "/dashboard",


### PR DESCRIPTION
Suggestion for:
- https://github.com/Particular/ServicePulse/pull/3061

This adds a global tippy stub so future tests don't need to stub it and removes test-specific stubs that throw a dupilcate warning.

## Reviewer Checklist

- [ ] Components are broken down into sensible and maintainable sub-components.
- [ ] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [ ] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [ ] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [ ] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
