### PR TITLE
Frontend test warnings cleanup

### DIFF
--- a/src/Frontend/package-lock.json
+++ b/src/Frontend/package-lock.json
@@ -3343,16 +3343,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4162,9 +4162,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6183,9 +6183,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -6595,9 +6595,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6614,7 +6614,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/Frontend/src/App.vue
+++ b/src/Frontend/src/App.vue
@@ -9,10 +9,12 @@ import BackendChecksNotifications from "@/components/BackendChecksNotifications.
 import { storeToRefs } from "pinia";
 import { useAuthStore } from "@/stores/AuthStore";
 import { useAllowedRoutes } from "@/composables/useAllowedRoutes";
+import { useConfigurationStore } from "@/stores/ConfigurationStore";
 
 const authStore = useAuthStore();
+const configurationStore = useConfigurationStore();
 const route = useRoute();
-const { isAuthenticated, authEnabled } = storeToRefs(authStore);
+const { isAuthenticated, authEnabled, loading } = storeToRefs(authStore);
 
 // Load the allowed-route manifest (my/routes) once authenticated, so the nav and other
 // UI can gate on it. Fail-safe: a missing/old endpoint just leaves the manifest unloaded
@@ -33,6 +35,16 @@ const isAnonymousRoute = computed(() => route.meta?.allowAnonymous === true);
 const shouldShowApp = computed(() => !authEnabled.value || isAuthenticated.value || isAnonymousRoute.value);
 // Show full app layout (header, footer, notifications) only when authenticated or auth is disabled
 const shouldShowFullLayout = computed(() => !authEnabled.value || isAuthenticated.value);
+
+watch(
+  [loading, authEnabled, isAuthenticated],
+  ([isLoading, enabled, authenticated]) => {
+    if (!isLoading && (!enabled || authenticated)) {
+      configurationStore.ensureLoaded();
+    }
+  },
+  { immediate: true }
+);
 </script>
 
 <template>

--- a/src/Frontend/src/App.vue
+++ b/src/Frontend/src/App.vue
@@ -38,9 +38,9 @@ const shouldShowFullLayout = computed(() => !authEnabled.value || isAuthenticate
 
 watch(
   [loading, authEnabled, isAuthenticated],
-  ([isLoading, enabled, authenticated]) => {
+  async ([isLoading, enabled, authenticated]) => {
     if (!isLoading && (!enabled || authenticated)) {
-      configurationStore.ensureLoaded();
+      await configurationStore.ensureLoaded();
     }
   },
   { immediate: true }

--- a/src/Frontend/src/components/audit/AuditList.spec.ts
+++ b/src/Frontend/src/components/audit/AuditList.spec.ts
@@ -125,6 +125,7 @@ async function renderAuditList(messages: Message[] = []): Promise<RenderResult> 
     createSpy: vi.fn,
     initialState: {
       AuditStore: { messages, totalCount: messages.length },
+      ConfigurationStore: { isMassTransitConnected: false },
     },
   });
 

--- a/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
+++ b/src/Frontend/src/components/failedmessages/EditRetryDialog.vue
@@ -159,7 +159,8 @@ function togglePanel(panelNum: number) {
   panel.value = panelNum;
 }
 
-onMounted(() => {
+onMounted(async () => {
+  await messageStore.ensureEditAndRetryConfigurationLoaded();
   togglePanel(1);
   initializeMessageBodyAndHeaders();
 });

--- a/src/Frontend/src/components/failedmessages/PendingRetries.spec.ts
+++ b/src/Frontend/src/components/failedmessages/PendingRetries.spec.ts
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/vue";
 import { createTestingPinia } from "@pinia/testing";
 import { createRouter, createMemoryHistory } from "vue-router";
 import FailedMessagesView from "@/views/FailedMessagesView.vue";
+import routeLinks from "@/router/routeLinks";
 
 /**
  * DSL for the Pending Retries Tab Visibility feature.
@@ -68,37 +69,47 @@ async function renderComponent(options: RenderOptions = {}): Promise<RenderResul
     routes: [
       {
         path: "/",
-        redirect: "/failed-messages/groups",
+        redirect: routeLinks.failedMessage.failedMessagesGroups.link,
       },
       {
-        path: "/failed-messages",
+        path: routeLinks.failedMessage.root,
         name: "failed-messages",
         component: FailedMessagesView,
         children: [
           {
-            path: "groups",
+            path: routeLinks.failedMessage.failedMessagesGroups.template,
             name: "failed-messages-groups",
             component: { template: "<div>Groups</div>" },
           },
           {
-            path: "all",
+            path: routeLinks.failedMessage.failedMessages.template,
             name: "failed-messages-all",
             component: { template: "<div>All Messages</div>" },
           },
           {
-            path: "deleted-groups",
+            path: routeLinks.failedMessage.deletedMessagesGroup.template,
             name: "failed-messages-deleted-groups",
             component: { template: "<div>Deleted Groups</div>" },
           },
           {
-            path: "deleted",
+            path: routeLinks.failedMessage.deletedMessages.template,
             name: "failed-messages-deleted",
             component: { template: "<div>Deleted</div>" },
           },
           {
-            path: "pending-retries",
+            path: routeLinks.failedMessage.pendingRetries.template,
             name: "failed-messages-pending-retries",
             component: { template: "<div>Pending Retries</div>" },
+          },
+          {
+            path: routeLinks.failedMessage.group.template,
+            name: "failed-messages-group",
+            component: { template: "<div>Group</div>" },
+          },
+          {
+            path: routeLinks.failedMessage.deletedGroup.template,
+            name: "failed-messages-deleted-group",
+            component: { template: "<div>Deleted Group</div>" },
           },
         ],
       },
@@ -110,7 +121,7 @@ async function renderComponent(options: RenderOptions = {}): Promise<RenderResul
     stubActions: true,
   });
 
-  await router.push("/failed-messages/groups");
+  await router.push(routeLinks.failedMessage.failedMessagesGroups.link);
   await router.isReady();
 
   render(FailedMessagesView, {

--- a/src/Frontend/src/components/messages/EditAndRetryButton.vue
+++ b/src/Frontend/src/components/messages/EditAndRetryButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ActionButton from "@/components/ActionButton.vue";
 import { useMessageStore } from "@/stores/MessageStore";
-import { computed, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useShowToast } from "@/composables/toast";
 import { TYPE } from "vue-toastification";
 import EditRetryDialog from "@/components/failedmessages/EditRetryDialog.vue";
@@ -47,6 +47,10 @@ async function openDialog() {
   await store.downloadBody();
   isConfirmDialogVisible.value = true;
 }
+
+onMounted(() => {
+  store.ensureEditAndRetryConfigurationLoaded();
+});
 </script>
 
 <template>

--- a/src/Frontend/src/composables/useAuth.spec.ts
+++ b/src/Frontend/src/composables/useAuth.spec.ts
@@ -2,10 +2,19 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import routeLinks from "@/router/routeLinks";
 
+const logger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
 // Capture the OIDC event callbacks useAuth registers, plus a spy on signinRedirect, so the tests
 // can fire "token expired" / "silent renew error" and assert that recovery re-authenticates.
 const signinRedirect = vi.fn().mockResolvedValue(undefined);
 const captured: { expired?: () => void; renewError?: (error: unknown) => void } = {};
+
+vi.mock("@/logger", () => ({
+  default: logger,
+}));
 
 vi.mock("oidc-client-ts", () => ({
   UserManager: class {
@@ -45,6 +54,8 @@ async function initAuth() {
 
 beforeEach(() => {
   vi.resetModules();
+  logger.warn.mockReset();
+  logger.error.mockReset();
   signinRedirect.mockClear();
   captured.expired = undefined;
   captured.renewError = undefined;
@@ -69,9 +80,11 @@ describe("useAuth recovers a lost session from OIDC events", () => {
     store.setAuthenticating(false);
     signinRedirect.mockClear();
 
-    captured.renewError!(new Error("silent renew failed"));
+    const error = new Error("silent renew failed");
+    captured.renewError!(error);
 
     expect(signinRedirect).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith("Silent renew error:", error);
   });
 
   test("does not re-authenticate while an auth flow is already running", async () => {

--- a/src/Frontend/src/stores/AllowedRoutesStore.spec.ts
+++ b/src/Frontend/src/stores/AllowedRoutesStore.spec.ts
@@ -3,9 +3,17 @@ import { setActivePinia, createPinia } from "pinia";
 import { ApiRoutes } from "@/composables/apiRoutes";
 import { normalizeRouteKey } from "@/composables/routeMatching";
 
+const logger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
 const rootFetch = vi.fn();
 const scFetch = vi.fn();
 const monFetch = vi.fn();
+vi.mock("@/logger", () => ({
+  default: logger,
+}));
 vi.mock("@/components/serviceControlClient", () => ({
   default: {
     fetchTypedFromServiceControl: (s: string) => rootFetch(s),
@@ -30,6 +38,8 @@ const rootDoc = (myRoutesUrl?: string) => [{}, myRoutesUrl === undefined ? {} : 
 describe("AllowedRoutesStore", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    logger.warn.mockReset();
+    logger.error.mockReset();
     rootFetch.mockReset();
     scFetch.mockReset();
     monFetch.mockReset();
@@ -80,6 +90,9 @@ describe("AllowedRoutesStore", () => {
     await store.refresh();
     expect(store.loaded).toBe(false);
     expect(store.loadAttempted).toBe(true);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenNthCalledWith(1, "Failed to fetch allowed routes", expect.any(Error));
+    expect(logger.warn).toHaveBeenNthCalledWith(2, "Failed to fetch allowed routes", expect.any(Error));
   });
 
   it("Monitoring manifest entry at root (no /api prefix) matches the ApiRoutes registry path", async () => {
@@ -106,6 +119,7 @@ describe("AllowedRoutesStore", () => {
     expect(store.loaded).toBe(true);
     expect(store.routes.has("GET /api/errors")).toBe(true);
     expect(store.routes.size).toBe(1);
+    expect(logger.warn).toHaveBeenCalledWith("Skipping malformed allowed-route entry", { method: "POST" });
   });
 
   it("skips the primary fetch entirely when the root document omits my_routes_url", async () => {

--- a/src/Frontend/src/stores/ConfigurationStore.ts
+++ b/src/Frontend/src/stores/ConfigurationStore.ts
@@ -6,22 +6,37 @@ import logger from "@/logger";
 
 export const useConfigurationStore = defineStore("ConfigurationStore", () => {
   const configuration = ref<Configuration | null>(null);
+  let refreshPromise: Promise<void> | null = null;
 
   const isMassTransitConnected = computed(() => configuration.value?.mass_transit_connector !== undefined);
 
-  serviceControlClient
-    .fetchFromServiceControl("configuration")
-    .then(async (response) => {
-      configuration.value = await response.json();
-      return configuration.value;
-    })
-    .catch((error) => {
-      logger.error("Failed to fetch configuration:", error);
-    });
+  async function refresh() {
+    refreshPromise ??= (async () => {
+      try {
+        const response = await serviceControlClient.fetchFromServiceControl("configuration");
+        configuration.value = await response.json();
+      } catch (error) {
+        logger.error("Failed to fetch configuration:", error);
+      } finally {
+        refreshPromise = null;
+      }
+    })();
+
+    await refreshPromise;
+  }
+
+  async function ensureLoaded() {
+    if (configuration.value !== null) {
+      return;
+    }
+    await refresh();
+  }
 
   return {
     configuration,
     isMassTransitConnected,
+    ensureLoaded,
+    refresh,
   };
 });
 

--- a/src/Frontend/src/stores/MessageStore.spec.ts
+++ b/src/Frontend/src/stores/MessageStore.spec.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import { ref } from "vue";
+import { HttpError } from "@/utils/HttpError";
 
 const { fetchFromServiceControl, fetchTypedFromServiceControl } = vi.hoisted(() => ({
   fetchFromServiceControl: vi.fn(),
   fetchTypedFromServiceControl: vi.fn(),
+}));
+const logger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
 }));
 
 vi.mock("@/components/serviceControlClient", () => ({
@@ -12,6 +17,9 @@ vi.mock("@/components/serviceControlClient", () => ({
     fetchFromServiceControl,
     fetchTypedFromServiceControl,
   },
+}));
+vi.mock("@/logger", () => ({
+  default: logger,
 }));
 
 vi.mock("@/composables/useEnvironmentAndVersionsAutoRefresh", () => ({
@@ -28,6 +36,8 @@ describe("MessageStore tests", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    logger.warn.mockReset();
+    logger.error.mockReset();
 
     fetchFromServiceControl.mockResolvedValue({
       json: () => Promise.resolve({ data_retention: {} }),
@@ -41,6 +51,12 @@ describe("MessageStore tests", () => {
     });
   });
 
+  test("does not load edit/config during store creation", () => {
+    useMessageStore();
+
+    expect(fetchTypedFromServiceControl).not.toHaveBeenCalledWith("edit/config");
+  });
+
   test.each([
     ["id\\with\\backslash", "id%5Cwith%5Cbackslash"],
     ["id/with/slash", "id%2Fwith%2Fslash"],
@@ -50,5 +66,40 @@ describe("MessageStore tests", () => {
     await store.loadMessage(messageId, "message-instance-id");
 
     expect(fetchTypedFromServiceControl).toHaveBeenCalledWith(`messages/search/${encodedMessageId}`);
+  });
+
+  test("logs a warning when edit/config fails with a non-403 error", async () => {
+    fetchTypedFromServiceControl.mockImplementation((suffix: string) => {
+      if (suffix === "edit/config") {
+        return Promise.reject(new Error("boom"));
+      }
+
+      return Promise.resolve([{} as Response, []]);
+    });
+
+    const store = useMessageStore();
+    await store.ensureEditAndRetryConfigurationLoaded();
+    await vi.waitFor(() => {
+      expect(fetchTypedFromServiceControl).toHaveBeenCalledWith("edit/config");
+      expect(logger.warn).toHaveBeenCalledWith("Failed to load Edit and Retry configuration");
+    });
+  });
+
+  test("does not log a warning when edit/config returns 403", async () => {
+    fetchTypedFromServiceControl.mockImplementation((suffix: string) => {
+      if (suffix === "edit/config") {
+        return Promise.reject(new HttpError(403));
+      }
+
+      return Promise.resolve([{} as Response, []]);
+    });
+
+    const store = useMessageStore();
+    await store.ensureEditAndRetryConfigurationLoaded();
+    await vi.waitFor(() => {
+      expect(fetchTypedFromServiceControl).toHaveBeenCalledWith("edit/config");
+    });
+
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/Frontend/src/stores/MessageStore.ts
+++ b/src/Frontend/src/stores/MessageStore.ts
@@ -78,6 +78,7 @@ export const useMessageStore = defineStore("MessageStore", () => {
   let conversationLoadedId = "";
 
   const configStore = useConfigurationStore();
+  configStore.ensureLoaded();
   const { store: environmentStore } = useEnvironmentAndVersionsAutoRefresh();
   const areSimpleHeadersSupported = environmentStore.serviceControlIsGreaterThan("5.2.0");
 
@@ -155,6 +156,7 @@ export const useMessageStore = defineStore("MessageStore", () => {
       state.loading = false;
     }
 
+    await configStore.ensureLoaded();
     const countdown = dayjs(state.data.failure_metadata.last_modified).add(error_retention_period.value, "hours");
     state.data.failure_status.delete_soon = countdown < dayjs();
     state.data.failure_metadata.deleted_in = countdown.format();

--- a/src/Frontend/src/stores/MessageStore.ts
+++ b/src/Frontend/src/stores/MessageStore.ts
@@ -74,28 +74,32 @@ export const useMessageStore = defineStore("MessageStore", () => {
   const conversationData = ref<DataContainer<Message[]>>({ data: [] });
 
   const editRetryResponse = ref<EditRetryResponse | null>(null);
+  let editAndRetryConfigPromise: Promise<void> | null = null;
+  let editAndRetryConfigLoaded = false;
   let bodyLoadedId = "";
   let conversationLoadedId = "";
 
   const configStore = useConfigurationStore();
-  configStore.ensureLoaded();
   const { store: environmentStore } = useEnvironmentAndVersionsAutoRefresh();
   const areSimpleHeadersSupported = environmentStore.serviceControlIsGreaterThan("5.2.0");
 
   const { configuration } = storeToRefs(configStore);
   const error_retention_period = computed(() => timeSpanToDuration(configuration.value?.data_retention?.error_retention_period).asHours());
 
-  const { canCall } = useAllowedRoutes();
+  const { canCall, ensureManifestLoaded } = useAllowedRoutes();
   const canRetry = computed(() => canCall(ApiRoutes.retryMessage, state.data));
   const canEdit = computed(() => canCall(ApiRoutes.editMessage, state.data));
   const canDelete = computed(() => canCall(ApiRoutes.deleteMessage, state.data));
   const canRestore = computed(() => canCall(ApiRoutes.restoreMessage, state.data));
 
   async function loadEditAndRetryConfiguration() {
-    // edit/config is an edit-only endpoint (requires the edit permission). Skip it for users who
-    // cannot edit, leaving the default disabled config in place. A 403 (e.g. during the brief
-    // window before the route manifest loads) is the expected "not allowed" response, not an
-    // error, so it is swallowed silently rather than logged.
+    // edit/config is an edit-only endpoint (requires the edit permission). Wait for the route
+    // manifest before deciding, so we do not race the permission load and fail open into a
+    // request the user is not allowed to make.
+    await ensureManifestLoaded();
+    // Skip it for users who cannot edit, leaving the default disabled config in place. A 403
+    // remains an expected "not allowed" response (e.g. if permissions change server-side after
+    // the manifest was loaded), so it is swallowed silently rather than logged.
     if (!canEdit.value) return;
     try {
       const [, data] = await serviceControlClient.fetchTypedFromServiceControl<EditAndRetryConfig>("edit/config");
@@ -105,7 +109,22 @@ export const useMessageStore = defineStore("MessageStore", () => {
       logger.warn("Failed to load Edit and Retry configuration");
     }
   }
-  loadEditAndRetryConfiguration();
+
+  async function ensureEditAndRetryConfigurationLoaded() {
+    if (editAndRetryConfigLoaded) {
+      return;
+    }
+
+    editAndRetryConfigPromise ??= loadEditAndRetryConfiguration()
+      .then(() => {
+        editAndRetryConfigLoaded = true;
+      })
+      .finally(() => {
+        editAndRetryConfigPromise = null;
+      });
+
+    await editAndRetryConfigPromise;
+  }
 
   function reset() {
     state.data = { failure_metadata: {}, failure_status: {}, dialog_status: {}, invoked_saga: {} };
@@ -395,6 +414,7 @@ export const useMessageStore = defineStore("MessageStore", () => {
     loadConversation,
     downloadBody,
     exportMessage,
+    ensureEditAndRetryConfigurationLoaded,
     archiveMessage,
     restoreMessage,
     retryMessage,

--- a/src/Frontend/src/stores/RecoverabilityStore.ts
+++ b/src/Frontend/src/stores/RecoverabilityStore.ts
@@ -36,6 +36,7 @@ export const useRecoverabilityStore = defineStore("RecoverabilityStore", () => {
   const endpoints = ref<string[]>([]);
 
   const configurationStore = useConfigurationStore();
+  configurationStore.ensureLoaded();
   const { configuration } = storeToRefs(configurationStore);
 
   const cookies = useCookies();
@@ -109,6 +110,9 @@ export const useRecoverabilityStore = defineStore("RecoverabilityStore", () => {
   async function refresh() {
     try {
       if (!messageStatus) return;
+      if (messageStatus === FailedMessageStatus.Archived) {
+        await configurationStore.ensureLoaded();
+      }
 
       updateDateRangeForPeriod();
       const additionalQuery = buildAdditionalQuery();

--- a/src/Frontend/test/drivers/vitest/driver.ts
+++ b/src/Frontend/test/drivers/vitest/driver.ts
@@ -4,7 +4,7 @@ import type { Driver } from "../../driver";
 import { mount } from "@/mount";
 import makeRouter from "../../../src/router";
 import { mockEndpoint, mockEndpointDynamic } from "../../utils";
-import type { App } from "vue";
+import { h, type App } from "vue";
 import { mockServer } from "../../mock-server";
 
 function makeDriver() {
@@ -13,6 +13,17 @@ function makeDriver() {
   const driver = <Driver>{
     async goTo(path) {
       const router = makeRouter();
+      if (path === "/" && !router.getRoutes().some((route) => route.path === "/")) {
+        // In production the server can serve index.html at "/", but the hash router has no "/"
+        // route when default_route is empty or "/". Tests that open the app at root still need a
+        // valid client-side route to avoid Vue Router warnings during router.push("/").
+        router.addRoute({
+          path: "/",
+          component: {
+            render: () => h("div"),
+          },
+        });
+      }
       try {
         await router.push(path);
       } catch (error) {

--- a/src/Frontend/test/drivers/vitest/setup.ts
+++ b/src/Frontend/test/drivers/vitest/setup.ts
@@ -6,6 +6,27 @@ import monitoringClient from "@/components/monitoring/monitoringClient";
 import serviceControlClient from "@/components/serviceControlClient";
 import VueTippy from "vue-tippy";
 
+function getBoundingClientRect(): DOMRect {
+  const rect = {
+    x: 0,
+    y: 0,
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+  };
+
+  return { ...rect, toJSON: () => rect };
+}
+
+class FakeDOMRectList extends Array<DOMRect> implements DOMRectList {
+  item(index: number): DOMRect | null {
+    return this[index];
+  }
+}
+
 // Removes test warning noise failing to resolve tippy
 if (!config.global.plugins.includes(VueTippy)) {
   config.global.plugins.push(VueTippy);
@@ -32,6 +53,12 @@ beforeEach(() => {
 });
 
 beforeAll(() => {
+  document.elementFromPoint = (): null => null;
+  HTMLElement.prototype.getBoundingClientRect = getBoundingClientRect;
+  HTMLElement.prototype.getClientRects = (): DOMRectList => new FakeDOMRectList();
+  Range.prototype.getBoundingClientRect = getBoundingClientRect;
+  Range.prototype.getClientRects = (): DOMRectList => new FakeDOMRectList();
+
   mockServer.listen({
     onUnhandledRequest: (_, print) => {
       print.warning();

--- a/src/Frontend/test/preconditions/recoverability.ts
+++ b/src/Frontend/test/preconditions/recoverability.ts
@@ -177,6 +177,10 @@ export const hasFailedMessage =
       body: withBody,
     });
 
+    driver.mockEndpoint(`${serviceControlUrl}messages/${withGroupId}/body`, {
+      body: withBody,
+    });
+
     driver.mockEndpoint(`${serviceControlUrl}messages/search/${withMessageId}`, {
       body: [
         <Message>{

--- a/src/Frontend/test/specs/authentication/auth-callback-error.spec.ts
+++ b/src/Frontend/test/specs/authentication/auth-callback-error.spec.ts
@@ -1,8 +1,16 @@
-import { vi, expect, beforeEach } from "vitest";
+import { vi, expect, beforeEach, afterEach } from "vitest";
 import { createOidcMockUnauthenticated } from "../../mocks/oidc-client-mock";
 
 // Mock oidc-client-ts with unauthenticated state
 vi.mock("oidc-client-ts", () => createOidcMockUnauthenticated());
+const logger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@/logger", () => ({
+  default: logger,
+}));
 
 import { test, describe } from "../../drivers/vitest/driver";
 import * as precondition from "../../preconditions";
@@ -17,6 +25,16 @@ describe("FEATURE: OAuth Callback Error Handling (Scenario 16)", () => {
     beforeEach(() => {
       // Save original location
       originalLocation = window.location;
+      logger.warn.mockReset();
+      logger.error.mockReset();
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      });
     });
 
     test("EXAMPLE: access_denied error sets auth error state", async ({ driver }) => {
@@ -57,12 +75,7 @@ describe("FEATURE: OAuth Callback Error Handling (Scenario 16)", () => {
       // User should not be authenticated
       expect(authStore.isAuthenticated).toBe(false);
 
-      // Restore original location
-      Object.defineProperty(window, "location", {
-        value: originalLocation,
-        writable: true,
-        configurable: true,
-      });
+      expect(logger.error).toHaveBeenCalledWith("OAuth error:", "User cancelled the login");
     });
 
     test("EXAMPLE: invalid_request error sets auth error state", async ({ driver }) => {
@@ -99,12 +112,7 @@ describe("FEATURE: OAuth Callback Error Handling (Scenario 16)", () => {
       // User should not be authenticated
       expect(authStore.isAuthenticated).toBe(false);
 
-      // Restore original location
-      Object.defineProperty(window, "location", {
-        value: originalLocation,
-        writable: true,
-        configurable: true,
-      });
+      expect(logger.error).toHaveBeenCalledWith("OAuth error:", "Missing required parameter");
     });
 
     test("EXAMPLE: error without description uses error code", async ({ driver }) => {
@@ -141,12 +149,7 @@ describe("FEATURE: OAuth Callback Error Handling (Scenario 16)", () => {
       // User should not be authenticated
       expect(authStore.isAuthenticated).toBe(false);
 
-      // Restore original location
-      Object.defineProperty(window, "location", {
-        value: originalLocation,
-        writable: true,
-        configurable: true,
-      });
+      expect(logger.error).toHaveBeenCalledWith("OAuth error:", "server_error");
     });
   });
 });

--- a/src/Frontend/test/specs/authentication/auth-config-unavailable.spec.ts
+++ b/src/Frontend/test/specs/authentication/auth-config-unavailable.spec.ts
@@ -1,4 +1,4 @@
-import { vi, expect } from "vitest";
+import { vi, expect, beforeEach } from "vitest";
 import { createOidcMock } from "../../mocks/oidc-client-mock";
 
 // Mock oidc-client-ts
@@ -10,6 +10,12 @@ import { waitFor, screen } from "@testing-library/vue";
 import { useAuthStore } from "@/stores/AuthStore";
 
 describe("FEATURE: Auth Configuration Endpoint Unavailable (Scenario 15)", () => {
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleError.mockClear();
+  });
+
   describe("RULE: App should handle ServiceControl unavailability gracefully", () => {
     test("EXAMPLE: App continues to load when auth config endpoint returns error", async ({ driver }) => {
       // Set up ServiceControl endpoints but auth config returns 500 error
@@ -28,6 +34,7 @@ describe("FEATURE: Auth Configuration Endpoint Unavailable (Scenario 15)", () =>
 
       // Since auth config failed, auth should be treated as disabled
       expect(authStore.authEnabled).toBe(false);
+      expect(consoleError).toHaveBeenCalledWith("Error fetching auth configuration", expect.any(Error));
 
       // Dashboard should still be accessible (graceful degradation)
       await waitFor(() => {
@@ -50,6 +57,7 @@ describe("FEATURE: Auth Configuration Endpoint Unavailable (Scenario 15)", () =>
         // Auth should be treated as disabled when config unavailable
         expect(authStore.authEnabled).toBe(false);
       });
+      expect(consoleError).toHaveBeenCalledWith("Error fetching auth configuration", expect.any(Error));
 
       // App should not crash or show blank screen
       await waitFor(() => {
@@ -78,6 +86,7 @@ describe("FEATURE: Auth Configuration Endpoint Unavailable (Scenario 15)", () =>
 
       // Auth should be disabled (graceful fallback)
       expect(authStore.authEnabled).toBe(false);
+      expect(consoleError).toHaveBeenCalledWith("Error fetching auth configuration", expect.any(Error));
 
       // Dashboard should still render
       await waitFor(() => {

--- a/src/Frontend/test/specs/authentication/auth-enabled.spec.ts
+++ b/src/Frontend/test/specs/authentication/auth-enabled.spec.ts
@@ -1,11 +1,10 @@
-import { vi } from "vitest";
+import { vi, expect } from "vitest";
 import { createOidcMock } from "../../mocks/oidc-client-mock";
 
 // Mock oidc-client-ts so the auth-config tests don't trigger real document navigation in JSDOM.
 vi.mock("oidc-client-ts", () => createOidcMock());
 
 import { test, describe } from "../../drivers/vitest/driver";
-import { expect } from "vitest";
 import * as precondition from "../../preconditions";
 
 describe("FEATURE: Authentication Enabled (Scenario 2)", () => {

--- a/src/Frontend/test/specs/authentication/auth-enabled.spec.ts
+++ b/src/Frontend/test/specs/authentication/auth-enabled.spec.ts
@@ -6,6 +6,7 @@ describe("FEATURE: Authentication Enabled (Scenario 2)", () => {
   describe("RULE: Authentication configuration endpoint should return valid OIDC config", () => {
     test("EXAMPLE: Auth config endpoint returns enabled with all required fields", async ({ driver }) => {
       const authConfig = await driver.setUp(precondition.scenarioAuthEnabled);
+      await driver.setUp(precondition.hasOidcDiscoveryMock());
 
       // Verify all required fields are present
       expect(authConfig.enabled).toBe(true);
@@ -23,6 +24,7 @@ describe("FEATURE: Authentication Enabled (Scenario 2)", () => {
     test("EXAMPLE: Auth config endpoint is accessible without authentication", async ({ driver }) => {
       await driver.setUp(precondition.serviceControlWithMonitoring);
       await driver.setUp(precondition.hasAuthenticationEnabled());
+      await driver.setUp(precondition.hasOidcDiscoveryMock());
 
       // Navigate to trigger app mount
       await driver.goTo("/dashboard");

--- a/src/Frontend/test/specs/authentication/auth-enabled.spec.ts
+++ b/src/Frontend/test/specs/authentication/auth-enabled.spec.ts
@@ -1,3 +1,9 @@
+import { vi } from "vitest";
+import { createOidcMock } from "../../mocks/oidc-client-mock";
+
+// Mock oidc-client-ts so the auth-config tests don't trigger real document navigation in JSDOM.
+vi.mock("oidc-client-ts", () => createOidcMock());
+
 import { test, describe } from "../../drivers/vitest/driver";
 import { expect } from "vitest";
 import * as precondition from "../../preconditions";

--- a/src/Frontend/test/specs/authentication/auth-session-storage.spec.ts
+++ b/src/Frontend/test/specs/authentication/auth-session-storage.spec.ts
@@ -7,6 +7,7 @@ vi.mock("oidc-client-ts", () => createOidcMock());
 import { test, describe } from "../../drivers/vitest/driver";
 import * as precondition from "../../preconditions";
 import { waitFor, screen } from "@testing-library/vue";
+import routeLinks from "@/router/routeLinks";
 
 describe("FEATURE: Session Storage Behavior", () => {
   describe("RULE: Sessions should be isolated per browser tab", () => {
@@ -47,7 +48,7 @@ describe("FEATURE: Session Storage Behavior", () => {
       expect(initialToken).toBe(defaultMockUser.access_token);
 
       // Navigate to a different route
-      await driver.goTo("/failed-messages/all");
+      await driver.goTo(routeLinks.customChecks);
 
       // Wait for navigation to complete
       await waitFor(() => {

--- a/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
+++ b/src/Frontend/test/specs/failedmessages/edit-and-retry.spec.ts
@@ -5,32 +5,6 @@ import { getEditAndRetryEditor } from "./questions/getEditAndRetryEditor";
 import { expect } from "vitest";
 
 describe("FEATURE: Editing failed messages", () => {
-  function getBoundingClientRect(): DOMRect {
-    const rec = {
-      x: 0,
-      y: 0,
-      bottom: 0,
-      height: 0,
-      left: 0,
-      right: 0,
-      top: 0,
-      width: 0,
-    };
-    return { ...rec, toJSON: () => rec };
-  }
-
-  class FakeDOMRectList extends Array<DOMRect> implements DOMRectList {
-    item(index: number): DOMRect | null {
-      return this[index];
-    }
-  }
-
-  document.elementFromPoint = (): null => null;
-  HTMLElement.prototype.getBoundingClientRect = getBoundingClientRect;
-  HTMLElement.prototype.getClientRects = (): DOMRectList => new FakeDOMRectList();
-  Range.prototype.getBoundingClientRect = getBoundingClientRect;
-  Range.prototype.getClientRects = (): DOMRectList => new FakeDOMRectList();
-
   describe("RULE: Editing of a message should only be allowed when ServiceControl 'AllowMessageEditing' is enabled", () => {
     test.todo(
       "EXAMPLE: ServiceControl 'AllowMessageEditing' is disabled"

--- a/src/Frontend/test/specs/installation-config/app-constants.spec.ts
+++ b/src/Frontend/test/specs/installation-config/app-constants.spec.ts
@@ -38,7 +38,7 @@ describe("FEATURE: app.constants.js", () => {
       window.defaultConfig.default_route = "";
 
       //act
-      await driver.goTo("");
+      await driver.goTo("/");
 
       expect(window.location.href).toBe("http://localhost:3000/#/");
     });
@@ -49,7 +49,7 @@ describe("FEATURE: app.constants.js", () => {
       window.defaultConfig.default_route = "/";
 
       //act
-      await driver.goTo("");
+      await driver.goTo("/");
 
       expect(window.location.href).toBe("http://localhost:3000/#/");
     });

--- a/src/Frontend/test/specs/monitoring/endpoint-details.spec.ts
+++ b/src/Frontend/test/specs/monitoring/endpoint-details.spec.ts
@@ -150,6 +150,7 @@ describe("FEATURE: Endpoint details", () => {
       await driver.setUp(precondition.serviceControlWithMonitoring);
       const endpointDetails = structuredClone(monitoredEndpointDetails);
       endpointDetails.errorCount = 5;
+      endpointDetails.serviceControlId = "group-id-1";
       await driver.setUp(precondition.hasMonitoredEndpointDetails(endpointDetails));
 
       // Act

--- a/src/Frontend/test/specs/platformcapabilities/audit-capability-card.spec.ts
+++ b/src/Frontend/test/specs/platformcapabilities/audit-capability-card.spec.ts
@@ -127,6 +127,7 @@ describe("FEATURE: Audit capability card", () => {
     test("EXAMPLE: Audit instance available with successful messages shows available status", async ({ driver }) => {
       // Arrange
       // Need to set up ServiceControl with version >= 6.6.0 for "All Messages" feature support
+      await driver.setUp(precondition.hasAuthenticationDisabled());
       await driver.setUp(precondition.hasActiveLicense);
       await driver.setUp(precondition.hasLicensingSettingTest());
       await driver.setUp(precondition.hasServiceControlMainInstance(precondition.serviceControlVersionSupportingAllMessages));
@@ -261,6 +262,7 @@ describe("FEATURE: Audit capability card", () => {
     test("EXAMPLE: ServiceControl version < 6.6.0 with successful messages still shows not configured status", async ({ driver }) => {
       // Arrange
       // Set up ServiceControl with version < 6.6.0 which does NOT support "All Messages" feature
+      await driver.setUp(precondition.hasAuthenticationDisabled());
       await driver.setUp(precondition.hasActiveLicense);
       await driver.setUp(precondition.hasLicensingSettingTest());
       await driver.setUp(precondition.hasServiceControlMainInstance(precondition.serviceControlVersionNotSupportingAllMessages));

--- a/src/Frontend/test/specs/platformcapabilities/monitoring-capability-card.spec.ts
+++ b/src/Frontend/test/specs/platformcapabilities/monitoring-capability-card.spec.ts
@@ -1,5 +1,5 @@
 import { test, describe } from "../../drivers/vitest/driver";
-import { expect } from "vitest";
+import { expect, vi, beforeEach } from "vitest";
 import * as precondition from "../../preconditions";
 import { waitFor } from "@testing-library/vue";
 import {
@@ -15,6 +15,12 @@ import {
 import { disableMonitoring } from "../../drivers/vitest/setup";
 
 describe("FEATURE: Monitoring capability card", () => {
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleError.mockClear();
+  });
+
   describe("RULE: When monitoring instance is available with endpoints sending data, show 'Available' status", () => {
     test("EXAMPLE: Monitoring instance available with monitored endpoints shows available status", async ({ driver }) => {
       // Arrange
@@ -115,6 +121,7 @@ describe("FEATURE: Monitoring capability card", () => {
       await waitFor(async () => {
         expect(await isMonitoringCardUnavailable()).toBe(true);
       });
+      expect(consoleError).toHaveBeenCalled();
 
       const statusBadge = await monitoringStatusBadge();
       expect(statusBadge).toBeInTheDocument();

--- a/src/Frontend/vitest.config.ts
+++ b/src/Frontend/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     clearMocks: true,
     css: true,
     testTimeout: 30000,
-    slowTestThreshold: 20000,  
+    slowTestThreshold: 20000,
     coverage: {
       exclude: [`**/__test__/**/*`, `**/.eslintrc.js`, `**/*.spec.ts`, `test/**/*`],
       provider: `v8`,

--- a/src/Frontend/vitest.config.ts
+++ b/src/Frontend/vitest.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
     globals: true,
     clearMocks: true,
     css: true,
-    testTimeout: 15000,
+    testTimeout: 30000,
+    slowTestThreshold: 20000,  
     coverage: {
       exclude: [`**/__test__/**/*`, `**/.eslintrc.js`, `**/*.spec.ts`, `test/**/*`],
       provider: `v8`,


### PR DESCRIPTION
The frontend tests have a lot of warning noise, either from untested/unmocked console output or misconfigured route mocks.  This cleans up those warnings to make the output cleaner and less confusing for identifying legitimate errors.

## Reviewer Checklist

- [x] Components are broken down into sensible and maintainable sub-components.
- [x] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [x] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [x] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [x] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
