### PR TITLE
Remove the unused id from the recoverability history response

### DIFF
--- a/src/Frontend/src/resources/RecoverabilityHistoryResponse.ts
+++ b/src/Frontend/src/resources/RecoverabilityHistoryResponse.ts
@@ -2,7 +2,6 @@ import type HistoricRetryOperation from "./HistoricRetryOperation";
 import type UnacknowledgedRetryOperation from "./UnacknowledgedRetryOperation";
 
 export default interface RecoverabilityHistoryResponse {
-  id: string;
   historic_operations: HistoricRetryOperation[];
   unacknowledged_operations: UnacknowledgedRetryOperation[];
 }

--- a/src/Frontend/test/preconditions/recoverability.ts
+++ b/src/Frontend/test/preconditions/recoverability.ts
@@ -65,7 +65,6 @@ export const recoverabilityHistoryDefaultHandler = ({ driver }: SetupFactoryOpti
   const serviceControlUrl = window.defaultConfig.service_control_url;
   driver.mockEndpoint(`${serviceControlUrl}recoverability/history`, {
     body: <RecoverabilityHistoryResponse>{
-      id: "RetryOperations/History",
       historic_operations: [],
       unacknowledged_operations: [],
     },


### PR DESCRIPTION
Nothing reads it. LastTenOperations uses historic_operations only. It was the id of the RavenDB document ServiceControl kept the retry history in, and ServiceControl no longer returns it.

## Reviewer Checklist

- [ ] Components are broken down into sensible and maintainable sub-components.
- [ ] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [ ] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [ ] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [ ] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
