### PR TITLE
Serve the embedded frontend regardless of the OS the host was built on

### DIFF
--- a/src/ServicePulse.Host/Owin/EmbeddedFileFinder.cs
+++ b/src/ServicePulse.Host/Owin/EmbeddedFileFinder.cs
@@ -14,14 +14,22 @@
         {
             var lastModified = new FileInfo(Assembly.Location).LastWriteTime;
 
-            var resource = Assembly.GetManifestResourceStream(filePath);
-            if (resource != null)
+            // The embedded resource names are derived from file paths at build time, so their
+            // directory separator is that of the OS the build ran on. Look the file up under
+            // both separators so the frontend is served regardless of where it was built.
+            var candidates = new[] { filePath, filePath.Replace('\\', '/') };
+
+            foreach (var candidate in candidates)
             {
-                return new EmbeddedResourceFileInfo(Assembly, filePath, string.Empty, lastModified);
+                var resource = Assembly.GetManifestResourceStream(candidate);
+                if (resource != null)
+                {
+                    return new EmbeddedResourceFileInfo(Assembly, candidate, string.Empty, lastModified);
+                }
             }
 
             var matchingKey = Assembly.GetManifestResourceNames()
-                .FirstOrDefault(name => string.Compare(filePath, name, StringComparison.OrdinalIgnoreCase) == 0);
+                .FirstOrDefault(name => candidates.Any(candidate => string.Compare(candidate, name, StringComparison.OrdinalIgnoreCase) == 0));
             if (matchingKey != null)
             {
                 return new EmbeddedResourceFileInfo(Assembly, matchingKey, string.Empty, lastModified);


### PR DESCRIPTION
The frontend is embedded into `ServicePulse.Host.exe` with resource names derived from file paths at build time, so their directory separator matches the OS the build ran on. `StaticFileMiddleware` looks resources up with backslash-separated names only, which makes a host built on a non-Windows machine serve nothing: the listener runs, every request 404s, the browser shows a blank page.

The embedded file finder now tries the requested name under both separators. A Windows-built release is unaffected.