### PR TITLE
Actually disable the button properly when disabled

### DIFF
--- a/src/Frontend/public/mockServiceWorker.js
+++ b/src/Frontend/public/mockServiceWorker.js
@@ -12,26 +12,6 @@ const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
-function sleep(duration) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, duration)
-  })
-}
-
-async function waitForClientActivation(clientId, timeout = 500) {
-  const startedAt = Date.now()
-
-  while (Date.now() - startedAt < timeout) {
-    if (activeClientIds.has(clientId)) {
-      return true
-    }
-
-    await sleep(10)
-  }
-
-  return activeClientIds.has(clientId)
-}
-
 addEventListener('install', function () {
   self.skipWaiting()
 })
@@ -142,10 +122,6 @@ addEventListener('fetch', function (event) {
  * @param {number} requestInterceptedAt
  */
 async function handleRequest(event, requestId, requestInterceptedAt) {
-  if (event.request.mode === 'navigate' || event.request.destination === 'document') {
-    return fetch(event.request)
-  }
-
   const client = await resolveMainClient(event)
   const requestCloneForEvents = event.request.clone()
   const response = await getResponse(
@@ -268,17 +244,11 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
   }
 
   // Bypass initial page load requests (i.e. static assets).
-  // For XHR/fetch requests, wait briefly for the reloaded page to re-activate mocking
-  // so startup API calls do not leak to the real network during reload races.
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    if (event.request.destination) {
-      return passthrough()
-    }
-
-    const activated = await waitForClientActivation(client.id)
-    if (!activated) {
-      return passthrough()
-    }
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.

--- a/src/Frontend/src/components/platformhealth/PlatformHealthSupportModal.vue
+++ b/src/Frontend/src/components/platformhealth/PlatformHealthSupportModal.vue
@@ -66,7 +66,18 @@ onUnmounted(() => {
         <div class="modal-footer modal-actions">
           <ActionButton variant="primary" aria-label="Download platform health" @click="download">Download platform-health.json</ActionButton>
           <ActionButton :aria-label="showPreview ? 'Hide platform health preview' : 'Preview platform health'" @click="togglePreview">{{ showPreview ? "Hide preview" : "Preview platform-health.json" }}</ActionButton>
-          <a :href="supportCaseUrl" class="btn btn-default" :class="{ disabled: !hasDownloaded }" target="_blank" rel="noreferrer" :aria-disabled="!hasDownloaded" :tabindex="hasDownloaded ? 0 : -1">Then open the support case</a>
+          <a
+            :href="hasDownloaded ? supportCaseUrl : undefined"
+            role="link"
+            class="btn btn-default"
+            :class="{ disabled: !hasDownloaded }"
+            target="_blank"
+            rel="noreferrer"
+            :aria-disabled="!hasDownloaded"
+            :tabindex="hasDownloaded ? 0 : -1"
+            @click="!hasDownloaded && $event.preventDefault()"
+            >Then open the support case</a
+          >
           <ActionButton aria-label="Close support dialog" @click="close">Close</ActionButton>
         </div>
       </div>

--- a/src/Frontend/src/views/PlatformHealthView.spec.ts
+++ b/src/Frontend/src/views/PlatformHealthView.spec.ts
@@ -86,6 +86,9 @@ describe("PlatformHealthView", () => {
 
     const supportLink = screen.getByRole("link", { name: /Then open the support case/i });
     expect(supportLink).toHaveAttribute("aria-disabled", "true");
+    // Disabled link must not expose a navigation target (the bug was that :href
+    // was always bound, so a click still opened the support URL).
+    expect(supportLink).not.toHaveAttribute("href");
 
     await user.click(screen.getByRole("button", { name: /Preview platform health/i }));
 
@@ -98,6 +101,8 @@ describe("PlatformHealthView", () => {
     expect(downloadFileFromString).toHaveBeenCalledTimes(1);
     expect(downloadFileFromString).toHaveBeenCalledWith(expect.stringContaining('"platformHealth"'), "application/json", "platform-health.json");
     expect(supportLink).toHaveAttribute("aria-disabled", "false");
+    // Once downloaded the link becomes a real navigation target.
+    expect(supportLink).toHaveAttribute("href");
   });
 
   test("shows an inline upgrade cue for an outdated instance version", () => {


### PR DESCRIPTION
Properly disable the support case button until json file is downloaded (minor fix to #3098)

## Reviewer Checklist

- [x] Components are broken down into sensible and maintainable sub-components.
- [x] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [x] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [x] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [x] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
