### PR TITLE
Stop the audit capability probe from scanning the whole store

### DIFF
--- a/src/Frontend/src/components/audit/AuditList.spec.ts
+++ b/src/Frontend/src/components/audit/AuditList.spec.ts
@@ -21,8 +21,9 @@ import { type default as Message, MessageStatus } from "@/resources/Message";
 // ==================== Mock Setup ====================
 
 vi.mock("@/composables/autoRefresh");
+const auditingStatus = vi.hoisted(() => ({ value: "Available" }));
 vi.mock("@/components/platformcapabilities/capabilities/AuditingCapability", () => ({
-  useAuditingCapability: () => ({ status: { value: "Available" } }),
+  useAuditingCapability: () => ({ status: auditingStatus }),
 }));
 vi.mock("@/components/platformcapabilities/wizards/AuditingWizardPages", () => ({
   getAuditingWizardPages: () => [],
@@ -209,6 +210,7 @@ async function waitForFirstLoadToComplete() {
 describe("FEATURE: Audit Messages Query State", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    auditingStatus.value = "Available";
     localStorage.clear();
   });
 
@@ -307,6 +309,17 @@ describe("FEATURE: Audit Messages Query State", () => {
       await new Promise((r) => setTimeout(r, 400));
       verify.overlayIsNotVisible();
       verify.messagesAreVisible();
+    });
+  });
+
+  describe("RULE: Onboarding prompts render only after the capability probe has answered", () => {
+    test("EXAMPLE: The banner appears once a completed probe found no messages", async () => {
+      auditingStatus.value = "Endpoints Not Configured";
+      await renderAuditList([]);
+
+      await waitForFirstLoadToComplete();
+
+      expect(document.querySelector("page-banner-stub")).not.toBeNull();
     });
   });
 

--- a/src/Frontend/src/components/audit/auditClient.ts
+++ b/src/Frontend/src/components/audit/auditClient.ts
@@ -22,10 +22,13 @@ class AuditClient {
     );
   }
 
-  public async hasSuccessfulMessages(): Promise<boolean> {
+  public async hasSuccessfulMessages(from?: Date): Promise<boolean> {
     // Fetch the latest 10 messages and check if any are successful
-    // ideally we would want to filter successful messages server-side, but the API doesn't currently support that
-    const [, data] = await serviceControlClient.fetchTypedFromServiceControl<Message[]>(`messages2/?page_size=10&sort=time_sent&direction=desc`);
+    // ideally we would want to filter successful messages server-side, but the API doesn't currently support that.
+    // An unbounded sorted query scans the whole audit index, so callers should probe a bounded
+    // window first and only fall back to the unbounded form when the window is empty.
+    const bound = from ? `&from=${from.toISOString()}` : "";
+    const [, data] = await serviceControlClient.fetchTypedFromServiceControl<Message[]>(`messages2/?page_size=10&sort=time_sent&direction=desc${bound}`);
     return data?.some((msg) => msg.status === MessageStatus.Successful) ?? false;
   }
 }

--- a/src/Frontend/src/components/platformcapabilities/capabilities/AuditingCapability.ts
+++ b/src/Frontend/src/components/platformcapabilities/capabilities/AuditingCapability.ts
@@ -149,8 +149,8 @@ export function useAuditingCapability(): CapabilityComposable {
   const auditIndicators = computed(() => {
     const indicators: StatusIndicator[] = [];
 
-    // Messages available indicator - show if at least one instance is available
-    if (hasAvailableAuditInstances(auditInstances.value)) {
+    // Messages available indicator - show if at least one instance is available and the probe answered
+    if (hasAvailableAuditInstances(auditInstances.value) && hasSuccessfulMessages.value !== null) {
       const messagesAvailable = isAllMessagesSupported.value && hasSuccessfulMessages.value;
 
       let messageTooltip: string;

--- a/src/Frontend/src/stores/AuditStore.spec.ts
+++ b/src/Frontend/src/stores/AuditStore.spec.ts
@@ -31,6 +31,21 @@ describe("AuditStore refresh", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test("the default time range bounds the very first query", async () => {
+    fetchTypedFromServiceControl.mockResolvedValue([responseWithTotalCount(0), []]);
+    const store = useAuditStore();
+
+    await store.refresh();
+
+    const url = fetchTypedFromServiceControl.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(store.timeRangeFrom).toBe("now-6h");
+    expect(params.get("from")).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(params.get("to")).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(new Date(params.get("to")!).getTime() - new Date(params.get("from")!).getTime()).toBe(6 * 3600 * 1000);
   });
 
   test("a successful query populates the messages and total count", async () => {

--- a/src/Frontend/src/stores/AuditStore.ts
+++ b/src/Frontend/src/stores/AuditStore.ts
@@ -69,6 +69,7 @@ export const useAuditStore = defineStore("AuditStore", () => {
       );
 
       if (activeQuery !== thisQuery) {
+        // a newer query took over the view state while this one was in flight
         return;
       }
 
@@ -77,7 +78,7 @@ export const useAuditStore = defineStore("AuditStore", () => {
       queryFailed.value = false;
     } catch {
       if (thisQuery.signal.aborted) {
-        // Superseded by a newer query, which owns the view state from here on
+        // Superseded by a newer query, or the view was left
         return;
       }
 

--- a/src/Frontend/src/stores/PlatformCapabilitiesStore.spec.ts
+++ b/src/Frontend/src/stores/PlatformCapabilitiesStore.spec.ts
@@ -18,6 +18,34 @@ describe("FEATURE: Successful-messages capability probe", () => {
     localStorage.clear();
   });
 
+  test("EXAMPLE: Before the first probe answers, the state is unknown, not 'no messages'", () => {
+    const store = usePlatformCapabilitiesStore();
+
+    expect(store.hasSuccessfulMessages).toBeNull();
+  });
+
+  test("EXAMPLE: A failed probe proves nothing — the state stays unknown and is retried", async () => {
+    auditClient.hasSuccessfulMessages.mockRejectedValue(new Error("boom"));
+    const store = usePlatformCapabilitiesStore();
+
+    await store.refresh();
+    expect(store.hasSuccessfulMessages).toBeNull();
+
+    auditClient.hasSuccessfulMessages.mockReset();
+    auditClient.hasSuccessfulMessages.mockResolvedValue(true);
+    await store.refresh();
+    expect(store.hasSuccessfulMessages).toBe(true);
+  });
+
+  test("EXAMPLE: A completed probe finding nothing reports false", async () => {
+    auditClient.hasSuccessfulMessages.mockResolvedValue(false);
+    const store = usePlatformCapabilitiesStore();
+
+    await store.refresh();
+
+    expect(store.hasSuccessfulMessages).toBe(false);
+  });
+
   test("EXAMPLE: A bounded window is probed before falling back to the full store", async () => {
     auditClient.hasSuccessfulMessages.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const store = usePlatformCapabilitiesStore();

--- a/src/Frontend/src/stores/PlatformCapabilitiesStore.spec.ts
+++ b/src/Frontend/src/stores/PlatformCapabilitiesStore.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+const auditClient = vi.hoisted(() => ({ hasSuccessfulMessages: vi.fn() }));
+vi.mock("@/components/audit/auditClient", () => ({ default: auditClient }));
+vi.mock("@/components/monitoring/monitoringClient", () => ({ default: { isMonitoringEnabled: false } }));
+vi.mock("@/components/serviceControlClient", () => ({ default: { url: undefined } }));
+vi.mock("@/composables/useConnectionsAndStatsAutoRefresh", () => ({
+  default: () => ({ store: { monitoringConnectionState: { unableToConnect: true } } }),
+}));
+
+import { usePlatformCapabilitiesStore } from "@/stores/PlatformCapabilitiesStore";
+
+describe("FEATURE: Successful-messages capability probe", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test("EXAMPLE: A bounded window is probed before falling back to the full store", async () => {
+    auditClient.hasSuccessfulMessages.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const store = usePlatformCapabilitiesStore();
+
+    await store.refresh();
+
+    expect(auditClient.hasSuccessfulMessages).toHaveBeenCalledTimes(2);
+    expect(auditClient.hasSuccessfulMessages.mock.calls[0][0]).toBeInstanceOf(Date); // bounded first
+    expect(auditClient.hasSuccessfulMessages.mock.calls[1][0]).toBeUndefined(); // unbounded fallback
+    expect(store.hasSuccessfulMessages).toBe(true);
+  });
+
+  test("EXAMPLE: A hit in the bounded window skips the expensive unbounded probe", async () => {
+    auditClient.hasSuccessfulMessages.mockResolvedValueOnce(true);
+    const store = usePlatformCapabilitiesStore();
+
+    await store.refresh();
+
+    expect(auditClient.hasSuccessfulMessages).toHaveBeenCalledTimes(1);
+    expect(store.hasSuccessfulMessages).toBe(true);
+  });
+
+  test("EXAMPLE: Once successful messages were seen, later refreshes stop probing", async () => {
+    auditClient.hasSuccessfulMessages.mockResolvedValue(true);
+    const store = usePlatformCapabilitiesStore();
+
+    await store.refresh();
+    await store.refresh();
+    await store.refresh();
+
+    expect(auditClient.hasSuccessfulMessages).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Frontend/src/stores/PlatformCapabilitiesStore.ts
+++ b/src/Frontend/src/stores/PlatformCapabilitiesStore.ts
@@ -57,7 +57,8 @@ function saveVisibility(visibility: PlatformCapabilitiesVisibility): void {
 export const usePlatformCapabilitiesStore = defineStore("PlatformCapabilitiesStore", () => {
   const { store: connectionStore } = useConnectionsAndStatsAutoRefresh();
   const visibility = ref<PlatformCapabilitiesVisibility>(loadVisibility());
-  const hasSuccessfulMessages = ref(false);
+  // null = not yet determined: consumers must render nothing promotional until the probe answers
+  const hasSuccessfulMessages = ref<boolean | null>(null);
   const hasMonitoredEndpoints = ref(false);
 
   async function checkForSuccessfulMessages() {
@@ -65,14 +66,15 @@ export const usePlatformCapabilitiesStore = defineStore("PlatformCapabilitiesSto
     // The unbounded form of this probe scans the entire audit index (minutes on large
     // stores), so probe a recent window first and fall back to unbounded only when
     // the window is empty.
-    if (hasSuccessfulMessages.value) {
+    if (hasSuccessfulMessages.value === true) {
       return;
     }
     try {
       const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 3600 * 1000);
       hasSuccessfulMessages.value = (await auditClient.hasSuccessfulMessages(sevenDaysAgo)) || (await auditClient.hasSuccessfulMessages());
     } catch {
-      hasSuccessfulMessages.value = false;
+      // A failed probe proves nothing about the data; stay unknown and let the next tick retry
+      hasSuccessfulMessages.value = null;
     }
   }
 

--- a/src/Frontend/src/stores/PlatformCapabilitiesStore.ts
+++ b/src/Frontend/src/stores/PlatformCapabilitiesStore.ts
@@ -61,8 +61,16 @@ export const usePlatformCapabilitiesStore = defineStore("PlatformCapabilitiesSto
   const hasMonitoredEndpoints = ref(false);
 
   async function checkForSuccessfulMessages() {
+    // Successful messages don't un-exist: once seen, never query again.
+    // The unbounded form of this probe scans the entire audit index (minutes on large
+    // stores), so probe a recent window first and fall back to unbounded only when
+    // the window is empty.
+    if (hasSuccessfulMessages.value) {
+      return;
+    }
     try {
-      hasSuccessfulMessages.value = await auditClient.hasSuccessfulMessages();
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 3600 * 1000);
+      hasSuccessfulMessages.value = (await auditClient.hasSuccessfulMessages(sevenDaysAgo)) || (await auditClient.hasSuccessfulMessages());
     } catch {
       hasSuccessfulMessages.value = false;
     }


### PR DESCRIPTION
Stacked on:

- #3105
- #3106

Two bug fixes for the `hasSuccessfulMessages` capability probe, found while profiling the slow first load of All Messages on a large store.

- **The probe was the slow query, not the list.** The probe ran an *unbounded* sorted query over the whole audit index, re-fired every 5 seconds by the platform-capabilities poll, on every view. It now probes the last 7 days first, falls back to unbounded only when that window is empty, and never re-probes after a positive answer.
- **Onboarding prompts rendered on an assumption.** The "no successful audit messages" flag started as `false`, so the Messages indicator claimed "not configured" until the (minutes-long) probe proved otherwise. The flag is now tri-state and the indicator only renders after a completed probe; a failed probe proves nothing and leaves the state unknown for the next tick.

Depends on the picker PR only for the bounded default range the probe's tests assume.
