### PR TITLE
List recent searches under the All Messages search field

### DIFF
--- a/src/Frontend/src/components/audit/FiltersPanel.vue
+++ b/src/Frontend/src/components/audit/FiltersPanel.vue
@@ -5,6 +5,7 @@ import { useAuditStore } from "@/stores/AuditStore";
 import ListFilterSelector from "@/components/audit/ListFilterSelector.vue";
 import { computed } from "vue";
 import SuperDatePicker from "@/components/audit/SuperDatePicker.vue";
+import SearchHistory from "@/components/audit/SearchHistory.vue";
 
 const store = useAuditStore();
 const { messageFilterString, selectedEndpointName, endpoints } = storeToRefs(store);
@@ -18,7 +19,9 @@ const endpointNames = computed(() => {
     <div class="filter">
       <div class="filter-label"></div>
       <div class="filter-component text-search-container">
-        <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" />
+        <SearchHistory>
+          <FilterInput v-model="messageFilterString" placeholder="Search messages..." aria-label="Search messages" />
+        </SearchHistory>
         <div class="note">Check the <a href="https://docs.particular.net/servicepulse/all-messages#filtering-options">documentation</a> to see the available filtering options</div>
       </div>
     </div>

--- a/src/Frontend/src/components/audit/SearchHistory.spec.ts
+++ b/src/Frontend/src/components/audit/SearchHistory.spec.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/vue";
+import { createTestingPinia } from "@pinia/testing";
+import SearchHistory from "@/components/audit/SearchHistory.vue";
+import { useAuditStore } from "@/stores/AuditStore";
+
+function renderHistory(entries: { search: string; endpoint: string; from?: string; to?: string; at: string }[]) {
+  const pinia = createTestingPinia({ createSpy: vi.fn, initialState: { AuditStore: { searchHistory: entries } } });
+  // The history wraps the search field it belongs to
+  render(SearchHistory, { global: { plugins: [pinia] }, slots: { default: '<input aria-label="Search messages" />' } });
+  return useAuditStore(pinia);
+}
+
+const searchField = () => screen.getByLabelText("Search messages") as HTMLInputElement;
+const openHistory = () => fireEvent.focusIn(searchField());
+const panel = () => screen.queryByRole("listbox", { name: "Recent searches" });
+
+describe("FEATURE: Search history panel under the search field", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("EXAMPLE: Entries list the search, the endpoint and when they ran", async () => {
+    renderHistory([{ search: "orders", endpoint: "Sales.Endpoint", at: new Date().toISOString() }]);
+
+    await openHistory();
+
+    expect(screen.getByText("orders")).toBeInTheDocument();
+    expect(screen.getByText("@ Sales.Endpoint")).toBeInTheDocument();
+  });
+
+  test("EXAMPLE: Entries show the time range they ran with, worded like the picker", async () => {
+    renderHistory([
+      { search: "orders", endpoint: "", from: "now-1h", to: "now", at: new Date().toISOString() },
+      { search: "invoices", endpoint: "", from: "2026-09-01 08:00", to: "2026-09-01 12:00", at: new Date().toISOString() },
+    ]);
+
+    await openHistory();
+
+    expect(screen.getByText("now-1h")).toBeInTheDocument();
+    expect(screen.getByText("2026-09-01 08:00 to 2026-09-01 12:00")).toBeInTheDocument();
+  });
+
+  test("EXAMPLE: Clicking an entry reruns it, time range included", async () => {
+    const store = renderHistory([{ search: "orders", endpoint: "Sales.Endpoint", from: "now-1h", to: "now", at: new Date().toISOString() }]);
+
+    await openHistory();
+    await fireEvent.click(screen.getByText("orders"));
+
+    expect(store.messageFilterString).toBe("orders");
+    expect(store.selectedEndpointName).toBe("Sales.Endpoint");
+    expect(store.timeRangeFrom).toBe("now-1h");
+    expect(store.timeRangeTo).toBe("now");
+  });
+
+  test("EXAMPLE: Rerunning an entry recorded before ranges were captured leaves the current range alone", async () => {
+    const store = renderHistory([{ search: "orders", endpoint: "", at: new Date().toISOString() }]);
+    store.timeRangeFrom = "now-6h";
+    store.timeRangeTo = "now";
+
+    await openHistory();
+    await fireEvent.click(screen.getByText("orders"));
+
+    expect(store.timeRangeFrom).toBe("now-6h");
+    expect(store.timeRangeTo).toBe("now");
+  });
+
+  test("EXAMPLE: The panel opens when the search field receives focus and closes on Escape", async () => {
+    renderHistory([{ search: "orders", endpoint: "", at: new Date().toISOString() }]);
+
+    expect(panel()).not.toBeInTheDocument();
+
+    await openHistory();
+    expect(panel()).toBeInTheDocument();
+
+    await fireEvent.keyDown(searchField(), { key: "Escape" });
+    expect(panel()).not.toBeInTheDocument();
+  });
+
+  test("EXAMPLE: Clicking the search field re-opens the panel after it was dismissed", async () => {
+    renderHistory([{ search: "orders", endpoint: "", at: new Date().toISOString() }]);
+
+    await openHistory();
+    await fireEvent.keyDown(searchField(), { key: "Escape" });
+    await fireEvent.click(searchField());
+
+    expect(panel()).toBeInTheDocument();
+  });
+
+  test("EXAMPLE: Typing narrows the panel to the searches that match", async () => {
+    renderHistory([
+      { search: "orders", endpoint: "", at: new Date().toISOString() },
+      { search: "invoices", endpoint: "Billing", at: new Date().toISOString() },
+    ]);
+
+    await openHistory();
+    await fireEvent.input(searchField(), { target: { value: "inv" } });
+
+    expect(screen.queryByText("orders")).not.toBeInTheDocument();
+    expect(screen.getByText("invoices")).toBeInTheDocument();
+
+    await fireEvent.input(searchField(), { target: { value: "bill" } });
+    expect(screen.getByText("invoices")).toBeInTheDocument();
+
+    await fireEvent.input(searchField(), { target: { value: "zzz" } });
+    expect(panel()).not.toBeInTheDocument();
+  });
+
+  test("EXAMPLE: An empty history shows no panel, even on focus", async () => {
+    renderHistory([]);
+
+    await openHistory();
+
+    expect(panel()).not.toBeInTheDocument();
+  });
+
+  test("EXAMPLE: Clear history goes through the store", async () => {
+    const store = renderHistory([{ search: "orders", endpoint: "", at: new Date().toISOString() }]);
+
+    await openHistory();
+    await fireEvent.click(screen.getByText("Clear history"));
+
+    expect(store.clearSearchHistory).toHaveBeenCalled();
+  });
+});

--- a/src/Frontend/src/components/audit/SearchHistory.spec.ts
+++ b/src/Frontend/src/components/audit/SearchHistory.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/vue";
+import { nextTick } from "vue";
 import { createTestingPinia } from "@pinia/testing";
 import SearchHistory from "@/components/audit/SearchHistory.vue";
 import { useAuditStore } from "@/stores/AuditStore";
@@ -121,5 +122,108 @@ describe("FEATURE: Search history panel under the search field", () => {
     await fireEvent.click(screen.getByText("Clear history"));
 
     expect(store.clearSearchHistory).toHaveBeenCalled();
+  });
+
+  describe("RULE: The panel closes once the search is submitted, and typing brings it back", () => {
+    test("EXAMPLE: The search reaching the store closes the panel", async () => {
+      const store = renderHistory([{ search: "orders", endpoint: "", at: new Date().toISOString() }]);
+      await openHistory();
+      expect(panel()).toBeInTheDocument();
+
+      // what the debounced search field does once the user pauses
+      store.messageFilterString = "ord";
+      await nextTick();
+
+      expect(panel()).not.toBeInTheDocument();
+    });
+
+    test("EXAMPLE: Typing again after that reopens the panel", async () => {
+      const store = renderHistory([{ search: "orders", endpoint: "", at: new Date().toISOString() }]);
+      await openHistory();
+      store.messageFilterString = "ord";
+      await nextTick();
+
+      await fireEvent.input(searchField(), { target: { value: "orde" } });
+
+      expect(panel()).toBeInTheDocument();
+    });
+
+    test("EXAMPLE: Enter submits the search and closes the panel", async () => {
+      renderHistory([{ search: "orders", endpoint: "", at: new Date().toISOString() }]);
+      await openHistory();
+
+      await fireEvent.keyDown(searchField(), { key: "Enter" });
+
+      expect(panel()).not.toBeInTheDocument();
+    });
+  });
+
+  describe("RULE: The panel is a combobox: arrows move, Enter picks, Tab and blur leave", () => {
+    const entries = () => [
+      { search: "orders", endpoint: "", at: new Date().toISOString() },
+      { search: "invoices", endpoint: "Billing", at: new Date().toISOString() },
+    ];
+
+    test("EXAMPLE: Entries are not tab stops, and Tab closes the panel", async () => {
+      renderHistory(entries());
+      await openHistory();
+
+      const options = screen.getAllByRole("option");
+      expect(options.every((option) => option.getAttribute("tabindex") === "-1")).toBe(true);
+
+      await fireEvent.keyDown(searchField(), { key: "Tab" });
+      expect(panel()).not.toBeInTheDocument();
+    });
+
+    test("EXAMPLE: Arrow keys move a highlight and Enter reruns the highlighted entry", async () => {
+      const store = renderHistory(entries());
+      await openHistory();
+
+      await fireEvent.keyDown(searchField(), { key: "ArrowDown" });
+      await fireEvent.keyDown(searchField(), { key: "ArrowDown" });
+      expect(screen.getAllByRole("option")[1]).toHaveAttribute("aria-selected", "true");
+
+      await fireEvent.keyDown(searchField(), { key: "Enter" });
+
+      expect(store.messageFilterString).toBe("invoices");
+      expect(store.selectedEndpointName).toBe("Billing");
+      expect(panel()).not.toBeInTheDocument();
+    });
+
+    test("EXAMPLE: Arrow Down opens a closed panel", async () => {
+      renderHistory(entries());
+      await openHistory();
+      await fireEvent.keyDown(searchField(), { key: "Escape" });
+      expect(panel()).not.toBeInTheDocument();
+
+      await fireEvent.keyDown(searchField(), { key: "ArrowDown" });
+
+      expect(panel()).toBeInTheDocument();
+    });
+
+    test("EXAMPLE: The field announces itself as a combobox that controls the list", async () => {
+      renderHistory(entries());
+      await openHistory();
+
+      const field = searchField();
+      expect(field).toHaveAttribute("role", "combobox");
+      expect(field).toHaveAttribute("aria-expanded", "true");
+      expect(field.getAttribute("aria-controls")).toBe(panel()!.id);
+
+      await fireEvent.keyDown(field, { key: "ArrowDown" });
+      expect(field.getAttribute("aria-activedescendant")).toBe(screen.getAllByRole("option")[0].id);
+    });
+
+    test("EXAMPLE: Focus leaving the field and the panel closes it", async () => {
+      renderHistory(entries());
+      const outside = document.createElement("button");
+      document.body.appendChild(outside);
+      await openHistory();
+
+      await fireEvent.focusOut(searchField(), { relatedTarget: outside });
+
+      expect(panel()).not.toBeInTheDocument();
+      outside.remove();
+    });
   });
 });

--- a/src/Frontend/src/components/audit/SearchHistory.vue
+++ b/src/Frontend/src/components/audit/SearchHistory.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from "vue";
+import { storeToRefs } from "pinia";
+import { useAuditStore } from "@/stores/AuditStore";
+import type { SearchHistoryEntry } from "@/components/audit/searchHistory";
+import TimeSince from "@/components/TimeSince.vue";
+import { describeRangeText } from "@/components/audit/timeRange";
+
+// Wraps the search field (default slot) and floats the recent searches below it while
+// the field has focus, the way a browser's address bar does. Entries carry the whole
+// query (text, endpoint, time range), so they are listed with all of it.
+
+const store = useAuditStore();
+const { searchHistory, messageFilterString, selectedEndpointName, timeRangeFrom, timeRangeTo } = storeToRefs(store);
+
+const open = ref(false);
+// What is being typed right now (the store value trails it by the input's debounce)
+const typed = ref("");
+const root = useTemplateRef<HTMLElement>("root");
+
+const matching = computed(() => {
+  const needle = typed.value.trim().toLowerCase();
+  if (needle === "") return searchHistory.value;
+  return searchHistory.value.filter((entry) => entry.search.toLowerCase().includes(needle) || entry.endpoint.toLowerCase().includes(needle));
+});
+const visible = computed(() => open.value && matching.value.length > 0);
+
+function isSearchField(target: EventTarget | null): target is HTMLInputElement {
+  return target instanceof HTMLInputElement;
+}
+
+function onFocusIn(event: FocusEvent) {
+  if (isSearchField(event.target)) {
+    typed.value = event.target.value;
+    open.value = true;
+  }
+}
+
+function onClick(event: MouseEvent) {
+  // Re-opens after Escape without having to leave and re-enter the field
+  if (isSearchField(event.target)) open.value = true;
+}
+
+function onInput(event: Event) {
+  if (isSearchField(event.target)) {
+    typed.value = event.target.value;
+    open.value = true;
+  }
+}
+
+function rerun(entry: SearchHistoryEntry) {
+  messageFilterString.value = entry.search;
+  selectedEndpointName.value = entry.endpoint;
+  // Restoring the range makes this a true "run this again"; entries recorded
+  // before ranges were captured leave the current range alone
+  if (entry.from !== undefined && entry.to !== undefined) {
+    timeRangeFrom.value = entry.from;
+    timeRangeTo.value = entry.to;
+  }
+  typed.value = entry.search;
+  open.value = false;
+}
+
+function rangeLabel(entry: SearchHistoryEntry): string | null {
+  if (entry.from === undefined || entry.to === undefined) return null;
+  if (entry.from === "" && entry.to === "") return "no time filter";
+  return describeRangeText({ from: entry.from, to: entry.to });
+}
+
+// Not the Popover API: this panel behaves like a combobox and must stay open while the
+// field it belongs to has focus or is clicked, whereas a popover's light dismiss treats a
+// click on that field as a click outside. (And, as for the date picker, a popover would
+// need anchor positioning, which Firefox ESR does not have yet.)
+function onOutsidePointer(event: PointerEvent) {
+  if (open.value && root.value && !root.value.contains(event.target as Node)) open.value = false;
+}
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") open.value = false;
+}
+onMounted(() => document.addEventListener("pointerdown", onOutsidePointer));
+onBeforeUnmount(() => document.removeEventListener("pointerdown", onOutsidePointer));
+</script>
+
+<template>
+  <div class="search-history" ref="root" @focusin="onFocusIn" @click="onClick" @input="onInput" @keydown="onKeydown">
+    <slot />
+
+    <div v-if="visible" class="pop" role="listbox" aria-label="Recent searches">
+      <div class="head">Recent searches</div>
+      <button v-for="entry in matching" :key="`${entry.search}|${entry.endpoint}|${entry.from}|${entry.to}`" type="button" role="option" class="entry" title="Run this search again" @click="rerun(entry)">
+        <span class="what">
+          <span v-if="entry.search" class="term">{{ entry.search }}</span>
+          <span v-else class="term muted">(no search text)</span>
+          <span v-if="entry.endpoint" class="endpoint">@ {{ entry.endpoint }}</span>
+          <span v-if="rangeLabel(entry)" class="range">{{ rangeLabel(entry) }}</span>
+        </span>
+        <span class="when"><TimeSince :date-utc="entry.at" /></span>
+      </button>
+      <div class="foot">
+        <button type="button" class="clear" @click="store.clearSearchHistory()">Clear history</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.search-history {
+  position: relative;
+}
+
+.pop {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 200;
+  width: 100%;
+  min-width: min(420px, 92vw);
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  padding: 0.4rem;
+}
+
+.head {
+  color: #777;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.15rem 0.5rem 0.3rem;
+}
+
+.entry {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.8rem;
+  width: 100%;
+  border: 0;
+  background: none;
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.entry:hover,
+.entry:focus-visible {
+  background: #e6f2f6;
+}
+
+.what {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.term {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  color: #333;
+}
+
+.term.muted {
+  color: #999;
+  font-style: italic;
+  font-family: inherit;
+}
+
+.endpoint {
+  color: #00729c;
+  font-size: 0.8rem;
+  margin-left: 0.4rem;
+}
+
+.range {
+  color: #999;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  margin-left: 0.4rem;
+}
+
+.when {
+  color: #999;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.foot {
+  border-top: 1px solid #e3e3e3;
+  margin-top: 0.3rem;
+  padding-top: 0.35rem;
+  text-align: right;
+}
+
+.clear {
+  border: 0;
+  background: none;
+  color: #999;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.clear:hover {
+  color: #ce4844;
+}
+</style>

--- a/src/Frontend/src/components/audit/SearchHistory.vue
+++ b/src/Frontend/src/components/audit/SearchHistory.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch, watchEffect } from "vue";
 import { storeToRefs } from "pinia";
 import { useAuditStore } from "@/stores/AuditStore";
 import type { SearchHistoryEntry } from "@/components/audit/searchHistory";
@@ -9,6 +9,12 @@ import { describeRangeText } from "@/components/audit/timeRange";
 // Wraps the search field (default slot) and floats the recent searches below it while
 // the field has focus, the way a browser's address bar does. Entries carry the whole
 // query (text, endpoint, time range), so they are listed with all of it.
+//
+// It behaves as a combobox: the entries are not tab stops; Arrow Up/Down move a
+// highlight, Enter reruns the highlighted entry, Escape and Tab close, and so does focus
+// leaving the field and the panel. Submitting a search (Enter, or the debounced text
+// reaching the store) closes it too: once results show, the history is out of the way
+// until the user types again.
 
 const store = useAuditStore();
 const { searchHistory, messageFilterString, selectedEndpointName, timeRangeFrom, timeRangeTo } = storeToRefs(store);
@@ -16,7 +22,9 @@ const { searchHistory, messageFilterString, selectedEndpointName, timeRangeFrom,
 const open = ref(false);
 // What is being typed right now (the store value trails it by the input's debounce)
 const typed = ref("");
+const highlighted = ref(-1);
 const root = useTemplateRef<HTMLElement>("root");
+const listId = useId();
 
 const matching = computed(() => {
   const needle = typed.value.trim().toLowerCase();
@@ -24,6 +32,9 @@ const matching = computed(() => {
   return searchHistory.value.filter((entry) => entry.search.toLowerCase().includes(needle) || entry.endpoint.toLowerCase().includes(needle));
 });
 const visible = computed(() => open.value && matching.value.length > 0);
+const optionId = (index: number) => `${listId}-option-${index}`;
+
+watch([matching, open], () => (highlighted.value = -1));
 
 function isSearchField(target: EventTarget | null): target is HTMLInputElement {
   return target instanceof HTMLInputElement;
@@ -34,6 +45,13 @@ function onFocusIn(event: FocusEvent) {
     typed.value = event.target.value;
     open.value = true;
   }
+}
+
+function onFocusOut(event: FocusEvent) {
+  // Focus moving anywhere outside the field and the panel closes it (Tab away, a click elsewhere)
+  const next = event.relatedTarget as Node | null;
+  if (next && root.value?.contains(next)) return;
+  open.value = false;
 }
 
 function onClick(event: MouseEvent) {
@@ -61,10 +79,46 @@ function rerun(entry: SearchHistoryEntry) {
   open.value = false;
 }
 
+// The query inputs reaching the store means the search was submitted: results are (about
+// to be) on screen and the panel has done its job. Auto-refresh does not touch these.
+watch([messageFilterString, selectedEndpointName, timeRangeFrom, timeRangeTo], () => (open.value = false));
+
 function rangeLabel(entry: SearchHistoryEntry): string | null {
   if (entry.from === undefined || entry.to === undefined) return null;
   if (entry.from === "" && entry.to === "") return "no time filter";
   return describeRangeText({ from: entry.from, to: entry.to });
+}
+
+function onKeydown(event: KeyboardEvent) {
+  switch (event.key) {
+    case "ArrowDown":
+      if (matching.value.length === 0) return;
+      event.preventDefault();
+      if (!open.value) {
+        open.value = true;
+        highlighted.value = 0;
+      } else {
+        highlighted.value = Math.min(highlighted.value + 1, matching.value.length - 1);
+      }
+      return;
+    case "ArrowUp":
+      if (!visible.value) return;
+      event.preventDefault();
+      highlighted.value = Math.max(highlighted.value - 1, -1);
+      return;
+    case "Enter":
+      if (visible.value && highlighted.value >= 0) {
+        event.preventDefault();
+        rerun(matching.value[highlighted.value]);
+      } else {
+        open.value = false; // the search itself is submitted by the field
+      }
+      return;
+    case "Escape":
+    case "Tab":
+      open.value = false;
+      return;
+  }
 }
 
 // Not the Popover API: this panel behaves like a combobox and must stay open while the
@@ -74,20 +128,46 @@ function rangeLabel(entry: SearchHistoryEntry): string | null {
 function onOutsidePointer(event: PointerEvent) {
   if (open.value && root.value && !root.value.contains(event.target as Node)) open.value = false;
 }
-function onKeydown(event: KeyboardEvent) {
-  if (event.key === "Escape") open.value = false;
-}
 onMounted(() => document.addEventListener("pointerdown", onOutsidePointer));
 onBeforeUnmount(() => document.removeEventListener("pointerdown", onOutsidePointer));
+
+// The field comes in through the slot, so its combobox semantics are set from here
+const field = ref<HTMLInputElement | null>(null);
+onMounted(() => {
+  field.value = root.value?.querySelector("input") ?? null;
+  field.value?.setAttribute("role", "combobox");
+  field.value?.setAttribute("aria-autocomplete", "list");
+  field.value?.setAttribute("aria-haspopup", "listbox");
+  field.value?.setAttribute("aria-controls", listId);
+});
+watchEffect(() => {
+  if (!field.value) return;
+  field.value.setAttribute("aria-expanded", String(visible.value));
+  if (visible.value && highlighted.value >= 0) field.value.setAttribute("aria-activedescendant", optionId(highlighted.value));
+  else field.value.removeAttribute("aria-activedescendant");
+});
 </script>
 
 <template>
-  <div class="search-history" ref="root" @focusin="onFocusIn" @click="onClick" @input="onInput" @keydown="onKeydown">
+  <div class="search-history" ref="root" @focusin="onFocusIn" @focusout="onFocusOut" @click="onClick" @input="onInput" @keydown="onKeydown">
     <slot />
 
-    <div v-if="visible" class="pop" role="listbox" aria-label="Recent searches">
+    <div v-if="visible" :id="listId" class="pop" role="listbox" aria-label="Recent searches">
       <div class="head">Recent searches</div>
-      <button v-for="entry in matching" :key="`${entry.search}|${entry.endpoint}|${entry.from}|${entry.to}`" type="button" role="option" class="entry" title="Run this search again" @click="rerun(entry)">
+      <button
+        v-for="(entry, index) in matching"
+        :id="optionId(index)"
+        :key="`${entry.search}|${entry.endpoint}|${entry.from}|${entry.to}`"
+        type="button"
+        role="option"
+        tabindex="-1"
+        class="entry"
+        :class="{ highlighted: index === highlighted }"
+        :aria-selected="index === highlighted"
+        title="Run this search again"
+        @mouseenter="highlighted = index"
+        @click="rerun(entry)"
+      >
         <span class="what">
           <span v-if="entry.search" class="term">{{ entry.search }}</span>
           <span v-else class="term muted">(no search text)</span>
@@ -97,7 +177,7 @@ onBeforeUnmount(() => document.removeEventListener("pointerdown", onOutsidePoint
         <span class="when"><TimeSince :date-utc="entry.at" /></span>
       </button>
       <div class="foot">
-        <button type="button" class="clear" @click="store.clearSearchHistory()">Clear history</button>
+        <button type="button" class="clear" tabindex="-1" @click="store.clearSearchHistory()">Clear history</button>
       </div>
     </div>
   </div>
@@ -145,7 +225,8 @@ onBeforeUnmount(() => document.removeEventListener("pointerdown", onOutsidePoint
 }
 
 .entry:hover,
-.entry:focus-visible {
+.entry:focus-visible,
+.entry.highlighted {
   background: #e6f2f6;
 }
 

--- a/src/Frontend/src/components/audit/searchHistory.ts
+++ b/src/Frontend/src/components/audit/searchHistory.ts
@@ -1,0 +1,67 @@
+// Per-browser history of audit searches (search text and/or endpoint), most
+// recently used first. Re-running or re-entering an existing search bumps it to
+// the front instead of duplicating it; the least recently used entry falls off
+// once the list is full.
+
+export interface SearchHistoryEntry {
+  search: string;
+  endpoint: string;
+  // Time-range expressions the search ran with ("" on both = no time filter).
+  // Absent on entries recorded before ranges were captured; rerunning those
+  // leaves the current range untouched.
+  from?: string;
+  to?: string;
+  at: string; // ISO timestamp of last use
+}
+
+const STORAGE_KEY = "audit.searchHistory";
+export const searchHistoryLimit = 10;
+
+export function loadSearchHistory(): SearchHistoryEntry[] {
+  try {
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "");
+    if (Array.isArray(stored)) {
+      const optionalString = (v: unknown) => v === undefined || typeof v === "string";
+      return stored.filter((e) => e && typeof e.search === "string" && typeof e.endpoint === "string" && typeof e.at === "string" && optionalString(e.from) && optionalString(e.to));
+    }
+  } catch {
+    // fall through to empty history
+  }
+  return [];
+}
+
+function save(entries: SearchHistoryEntry[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // storage unavailable: history just doesn't persist
+  }
+}
+
+// Records a use of (search, endpoint, time range) and returns the updated
+// history. The range is part of a search's identity: the same text over a
+// different window is a different query.
+export function recordSearch(search: string, endpoint: string, range: { from: string; to: string }, now: () => Date = () => new Date()): SearchHistoryEntry[] {
+  const trimmedSearch = search.trim();
+  const trimmedEndpoint = endpoint.trim();
+  if (trimmedSearch === "" && trimmedEndpoint === "") {
+    return loadSearchHistory();
+  }
+
+  const from = range.from.trim();
+  const to = range.to.trim();
+  const entries = loadSearchHistory().filter((e) => !(e.search === trimmedSearch && e.endpoint === trimmedEndpoint && e.from === from && e.to === to));
+  entries.unshift({ search: trimmedSearch, endpoint: trimmedEndpoint, from, to, at: now().toISOString() });
+  const capped = entries.slice(0, searchHistoryLimit);
+  save(capped);
+  return capped;
+}
+
+export function clearSearchHistory(): SearchHistoryEntry[] {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+  return [];
+}

--- a/src/Frontend/src/components/audit/searchHistoryStorage.spec.ts
+++ b/src/Frontend/src/components/audit/searchHistoryStorage.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { clearSearchHistory, loadSearchHistory, recordSearch, searchHistoryLimit } from "@/components/audit/searchHistory";
+
+const at = (iso: string) => () => new Date(iso);
+const last6h = { from: "now-6h", to: "now" };
+const lastHour = { from: "now-1h", to: "now" };
+
+describe("FEATURE: Audit search history", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("EXAMPLE: The most recent search is listed first", () => {
+    recordSearch("orders", "", last6h, at("2026-09-03T10:00:00Z"));
+    recordSearch("", "Sales.Endpoint", last6h, at("2026-09-03T11:00:00Z"));
+
+    const history = loadSearchHistory();
+    expect(history.map((e) => e.search)).toEqual(["", "orders"]);
+    expect(history[0].endpoint).toBe("Sales.Endpoint");
+  });
+
+  test("EXAMPLE: The time range the search ran with is captured", () => {
+    recordSearch("orders", "", lastHour, at("2026-09-03T10:00:00Z"));
+
+    expect(loadSearchHistory()[0]).toMatchObject({ search: "orders", from: "now-1h", to: "now" });
+  });
+
+  test("EXAMPLE: Re-running a search bumps it to the front instead of duplicating", () => {
+    recordSearch("orders", "", last6h, at("2026-09-03T10:00:00Z"));
+    recordSearch("invoices", "", last6h, at("2026-09-03T11:00:00Z"));
+    const history = recordSearch("orders", "", last6h, at("2026-09-03T12:00:00Z"));
+
+    expect(history).toHaveLength(2);
+    expect(history[0]).toMatchObject({ search: "orders", at: "2026-09-03T12:00:00.000Z" });
+  });
+
+  test("EXAMPLE: The same text on a different endpoint is a different search", () => {
+    recordSearch("orders", "A", last6h, at("2026-09-03T10:00:00Z"));
+    const history = recordSearch("orders", "B", last6h, at("2026-09-03T11:00:00Z"));
+
+    expect(history).toHaveLength(2);
+  });
+
+  test("EXAMPLE: The same text over a different time range is a different search", () => {
+    recordSearch("orders", "", last6h, at("2026-09-03T10:00:00Z"));
+    const history = recordSearch("orders", "", lastHour, at("2026-09-03T11:00:00Z"));
+
+    expect(history).toHaveLength(2);
+    expect(history[0].from).toBe("now-1h");
+  });
+
+  test("EXAMPLE: Entries recorded before ranges were captured still load", () => {
+    localStorage.setItem("audit.searchHistory", JSON.stringify([{ search: "orders", endpoint: "", at: "2026-09-03T10:00:00.000Z" }]));
+
+    const history = loadSearchHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].from).toBeUndefined();
+  });
+
+  test("EXAMPLE: The least recently used entry falls off when the list is full", () => {
+    for (let i = 0; i < searchHistoryLimit + 1; i++) {
+      recordSearch(`term-${i}`, "", last6h, at(`2026-09-03T10:${String(i).padStart(2, "0")}:00Z`));
+    }
+
+    const history = loadSearchHistory();
+    expect(history).toHaveLength(searchHistoryLimit);
+    expect(history.some((e) => e.search === "term-0")).toBe(false);
+    expect(history[0].search).toBe(`term-${searchHistoryLimit}`);
+  });
+
+  test("EXAMPLE: Queries without search text or endpoint are not recorded", () => {
+    recordSearch("  ", "", last6h, at("2026-09-03T10:00:00Z"));
+
+    expect(loadSearchHistory()).toHaveLength(0);
+  });
+
+  test("EXAMPLE: Corrupt storage yields an empty history", () => {
+    localStorage.setItem("audit.searchHistory", "{nonsense");
+
+    expect(loadSearchHistory()).toEqual([]);
+  });
+
+  test("EXAMPLE: Clearing empties the history", () => {
+    recordSearch("orders", "", last6h, at("2026-09-03T10:00:00Z"));
+
+    expect(clearSearchHistory()).toEqual([]);
+    expect(loadSearchHistory()).toEqual([]);
+  });
+});

--- a/src/Frontend/src/stores/AuditStore.spec.ts
+++ b/src/Frontend/src/stores/AuditStore.spec.ts
@@ -118,6 +118,21 @@ describe("AuditStore refresh", () => {
     expect(store.queryDurationMs).toBeGreaterThanOrEqual(0);
   });
 
+  test("a query with search text or endpoint is recorded in the search history", async () => {
+    fetchTypedFromServiceControl.mockResolvedValue([responseWithTotalCount(0), []]);
+    const store = useAuditStore();
+
+    await store.refresh(); // no search, no endpoint: nothing recorded
+    expect(store.searchHistory).toHaveLength(0);
+
+    store.messageFilterString = "orders";
+    await store.refresh();
+    await store.refresh(); // repeat does not duplicate
+
+    expect(store.searchHistory).toHaveLength(1);
+    expect(store.searchHistory[0]).toMatchObject({ search: "orders", endpoint: "" });
+  });
+
   test("cancelQuery aborts the query in flight without reporting a failure", async () => {
     const store = useAuditStore();
 

--- a/src/Frontend/src/stores/AuditStore.ts
+++ b/src/Frontend/src/stores/AuditStore.ts
@@ -7,6 +7,7 @@ import type { DateRange } from "@/types/date";
 import serviceControlClient from "@/components/serviceControlClient";
 import auditClient from "@/components/audit/auditClient";
 import { loadDefaultRange, resolveTimeRange } from "@/components/audit/timeRange";
+import { clearSearchHistory, loadSearchHistory, recordSearch } from "@/components/audit/searchHistory";
 
 export enum FieldNames {
   TimeSent = "time_sent",
@@ -37,6 +38,7 @@ export const useAuditStore = defineStore("AuditStore", () => {
   // of the query that produced the current results
   const queryStartedAt = ref<number | null>(null);
   const queryDurationMs = ref<number | null>(null);
+  const searchHistory = ref(loadSearchHistory());
   let activeQuery: AbortController | null = null;
 
   async function loadEndpoints() {
@@ -62,6 +64,10 @@ export const useAuditStore = defineStore("AuditStore", () => {
 
     const started = performance.now();
     queryStartedAt.value = Date.now();
+
+    if (messageFilterString.value.trim() !== "" || selectedEndpointName.value.trim() !== "") {
+      searchHistory.value = recordSearch(messageFilterString.value, selectedEndpointName.value, { from: timeRangeFrom.value, to: timeRangeTo.value });
+    }
 
     try {
       const [response, data] = await auditClient.getMessages(
@@ -107,6 +113,10 @@ export const useAuditStore = defineStore("AuditStore", () => {
   // Stops the in-flight query, e.g. when the view showing the results is left.
   // The abort propagates through the ServiceControl API and terminates the
   // database query, so a backgrounded view does not keep load on the server.
+  function clearHistory() {
+    searchHistory.value = clearSearchHistory();
+  }
+
   function cancelQuery() {
     activeQuery?.abort();
     activeQuery = null;
@@ -140,6 +150,8 @@ export const useAuditStore = defineStore("AuditStore", () => {
     queryFailed,
     queryStartedAt,
     queryDurationMs,
+    searchHistory,
+    clearSearchHistory: clearHistory,
   };
 });
 


### PR DESCRIPTION
Stacked on:

- #3105
- #3106
- #3109
- #3110

Per-browser history of audit searches with one-click rerun.

- Any query that used search text or an endpoint is remembered in this browser (most recent first, capped at 10, no duplicates), together with the time-range expressions it ran with. The range is part of a search's identity, and rerunning restores it, so an entry is a true "run this exact query again"
- Review feedback applied: instead of a separate "History" dropdown, the recent searches float **under the search field while it has focus**, the way a browser address bar does. Typing narrows the list to entries whose search text or endpoint match; Escape dismisses it; a click in the field brings it back. An empty history shows nothing
