### PR TITLE
Expand one Platform Health row at a time when instances share a name

### DIFF
--- a/src/Frontend/src/resources/PlatformHealth.ts
+++ b/src/Frontend/src/resources/PlatformHealth.ts
@@ -5,6 +5,8 @@ export type PlatformHealthSeverity = "danger" | "warning" | "none";
 export type PlatformHealthResponse = PlatformModel;
 
 export interface PlatformHealthRow {
+  // The instance's own id. Names are not unique: scaled-out audit instances commonly share one
+  id: string;
   type: string;
   name: string;
   version: string;

--- a/src/Frontend/src/stores/PlatformHealthStore.ts
+++ b/src/Frontend/src/stores/PlatformHealthStore.ts
@@ -209,6 +209,7 @@ function toRow(instance: PlatformInstance, latestVersion: string, upgradeLink: s
   }
 
   return {
+    id: instance.id,
     type: formatRowType(instance),
     name: instance.name,
     version: instance.version,
@@ -224,6 +225,7 @@ function toRow(instance: PlatformInstance, latestVersion: string, upgradeLink: s
 
 function toServicePulseRow(servicePulse: ServicePulse, latestVersion: string, upgradeLink: string): PlatformHealthRow {
   return {
+    id: "servicepulse",
     type: "ServicePulse",
     name: servicePulse.name,
     version: servicePulse.version,

--- a/src/Frontend/src/views/PlatformHealthView.spec.ts
+++ b/src/Frontend/src/views/PlatformHealthView.spec.ts
@@ -172,7 +172,10 @@ describe("PlatformHealthView", () => {
 
     const rows = vi.spyOn(store, "rows", "get").mockReturnValue([
       {
+        id: "row-1",
+
         type: "Error instance",
+
         name: "Particular.ServiceControl",
         version: "6.19.3",
         health: "healthy",
@@ -184,7 +187,10 @@ describe("PlatformHealthView", () => {
         healthDetails: [],
       },
       {
+        id: "row-2",
+
         type: "Audit instance",
+
         name: "Particular.ServiceControl.Audit",
         version: "6.18.0",
         health: "healthy",
@@ -325,7 +331,10 @@ describe("PlatformHealthView", () => {
 
     const rows = vi.spyOn(store, "rows", "get").mockReturnValue([
       {
+        id: "row-3",
+
         type: "Error instance",
+
         name: "Particular.ServiceControl",
         version: "6.19.3",
         health: "healthy",
@@ -337,7 +346,10 @@ describe("PlatformHealthView", () => {
         healthDetails: [],
       },
       {
+        id: "row-4",
+
         type: "Audit instance",
+
         name: "Particular.ServiceControl.Audit",
         version: "6.19.3",
         health: "degraded",
@@ -389,7 +401,10 @@ describe("PlatformHealthView", () => {
 
     const rows = vi.spyOn(store, "rows", "get").mockReturnValue([
       {
+        id: "row-5",
+
         type: "Error instance",
+
         name: "Particular.ServiceControl",
         version: "6.19.3",
         health: "healthy",
@@ -414,6 +429,47 @@ describe("PlatformHealthView", () => {
     expect(screen.getByText("http://localhost:33333/api/")).toBeInTheDocument();
 
     rows.mockRestore();
+  });
+
+  test("expands only the clicked row when several audit instances share a name", async () => {
+    const platformModelStore = usePlatformModelStore();
+    const audit = (id: string, port: number, health: "healthy" | "degraded") => ({
+      id,
+      name: "Particular.ServiceControl.Audit",
+      kind: "audit" as const,
+      role: "remote-audit" as const,
+      version: "6.19.3",
+      health,
+      apiUrl: `http://localhost:${port}/api/`,
+    });
+    platformModelStore.model = {
+      primary: {
+        id: "primary",
+        name: "Particular.ServiceControl",
+        kind: "error",
+        role: "primary-error",
+        version: "6.19.3",
+        health: "healthy",
+        apiUrl: "http://localhost:33333/api/",
+      },
+      remotes: [audit("remote-0", 44444, "degraded"), audit("remote-1", 44445, "degraded")],
+      monitoring: null,
+      servicePulse: { name: "ServicePulse", version: "2.8.0", health: "healthy" },
+    } satisfies PlatformModel;
+
+    render(PlatformHealthView, {
+      global: {
+        plugins: [],
+      },
+    });
+
+    const user = userEvent.setup();
+    const [first] = screen.getAllByRole("button", { name: /Degraded/i });
+    await user.click(first);
+
+    expect(document.querySelectorAll('[aria-expanded="true"]')).toHaveLength(1);
+    expect(screen.getAllByText("http://localhost:44444/api/")).toHaveLength(1);
+    expect(screen.queryByText("http://localhost:44445/api/")).not.toBeInTheDocument();
   });
 
   test("renders the Name header and a ServicePulse version nudge", () => {
@@ -448,7 +504,10 @@ describe("PlatformHealthView", () => {
     const store = usePlatformHealthStore();
     const rows = vi.spyOn(store, "rows", "get").mockReturnValue([
       {
+        id: "row-6",
+
         type: "Error instance",
+
         name: "Particular.ServiceControl",
         version: "6.19.3",
         health: "healthy",
@@ -460,7 +519,10 @@ describe("PlatformHealthView", () => {
         healthDetails: [],
       },
       {
+        id: "row-7",
+
         type: "Audit instance",
+
         name: "Particular.ServiceControl.Audit",
         version: "6.19.3",
         health: "degraded",
@@ -513,7 +575,7 @@ describe("PlatformHealthView", () => {
 
     const user = userEvent.setup();
     const buttons = screen.getAllByRole("button", { name: /Healthy/i });
-    const servicePulseButton = buttons.find((button) => button.getAttribute("aria-controls") === "ServicePulse-ServicePulse-details");
+    const servicePulseButton = buttons.find((button) => button.getAttribute("aria-controls") === "servicepulse-details");
     expect(servicePulseButton).toBeDefined();
     await user.click(servicePulseButton!);
 

--- a/src/Frontend/src/views/PlatformHealthView.spec.ts
+++ b/src/Frontend/src/views/PlatformHealthView.spec.ts
@@ -173,9 +173,7 @@ describe("PlatformHealthView", () => {
     const rows = vi.spyOn(store, "rows", "get").mockReturnValue([
       {
         id: "row-1",
-
         type: "Error instance",
-
         name: "Particular.ServiceControl",
         version: "6.19.3",
         health: "healthy",
@@ -188,9 +186,7 @@ describe("PlatformHealthView", () => {
       },
       {
         id: "row-2",
-
         type: "Audit instance",
-
         name: "Particular.ServiceControl.Audit",
         version: "6.18.0",
         health: "healthy",
@@ -332,9 +328,7 @@ describe("PlatformHealthView", () => {
     const rows = vi.spyOn(store, "rows", "get").mockReturnValue([
       {
         id: "row-3",
-
         type: "Error instance",
-
         name: "Particular.ServiceControl",
         version: "6.19.3",
         health: "healthy",
@@ -347,9 +341,7 @@ describe("PlatformHealthView", () => {
       },
       {
         id: "row-4",
-
         type: "Audit instance",
-
         name: "Particular.ServiceControl.Audit",
         version: "6.19.3",
         health: "degraded",
@@ -402,9 +394,7 @@ describe("PlatformHealthView", () => {
     const rows = vi.spyOn(store, "rows", "get").mockReturnValue([
       {
         id: "row-5",
-
         type: "Error instance",
-
         name: "Particular.ServiceControl",
         version: "6.19.3",
         health: "healthy",

--- a/src/Frontend/src/views/PlatformHealthView.vue
+++ b/src/Frontend/src/views/PlatformHealthView.vue
@@ -35,8 +35,10 @@ function shouldShowUpgradeCue(row: (typeof store.rows)[number]) {
   return row.upgradeAvailable && !!getUpgradeTargetVersion(row);
 }
 
+// Keyed by the instance id, not by type and name: several audit instances can carry the
+// same name, and a shared key would expand (and re-render) all of them together
 function rowKey(row: (typeof store.rows)[number]) {
-  return `${row.type}-${row.name}`;
+  return row.id;
 }
 
 function isExpanded(row: (typeof store.rows)[number]) {


### PR DESCRIPTION
### Symptoms

On Platform Health, with several audit instances that report the same instance name, expanding the health badge of one instance expands all of them at once. The browser console also shows Vue's duplicate-key warning for the rows.

### Who's affected

Anyone running scaled-out audit instances that share an instance name, which default installs commonly do.

### Root cause

The view keyed the expanded row, the `v-for` and the details row `id` on `type-name`. Same-named instances shared one key, so "is this row expanded" was true for all of them.

### Fix

A row now carries the instance's own `id` from the platform model and the view keys on that. A view test with two same-named degraded audit instances expands one and asserts the other stays collapsed.

## Reviewer Checklist

- [x] Components are broken down into sensible and maintainable sub-components.
- [x] Styles are scoped to the component using it. If multiple components need to share CSS, then a .css file is created containing the shared CSS and imported into component scoped style sections.
- [x] Naming is consistent with existing code, and adequately describes the component or function being introduced
- [x] Only functions utilizing Vue state or lifecycle hooks are named as composables (i.e. starting with 'use');
- [x] No module-level state is being introduced. If so, request the PR author to move the state to the corresponding Pinia store.
